### PR TITLE
understory_responder: add deterministic router, hover, box-tree adapter, and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_MIN_VER: "1.88"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree"
+  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree -p understory_responder"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default"
 
@@ -103,6 +103,9 @@ jobs:
 
       - name: check understory_box_tree README
         run: cargo rdme --workspace-project=understory_box_tree --heading-base-level=0 --check
+
+      - name: check understory_responder README
+        run: cargo rdme --workspace-project=understory_responder --heading-base-level=0 --check
 
   clippy-stable:
     name: cargo clippy

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+# This is the list of Understory's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Bruce Mitchener, Jr.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,8 +505,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "understory_examples"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+ "understory_box_tree",
+ "understory_responder",
+]
+
+[[package]]
 name = "understory_index"
 version = "0.0.1"
+
+[[package]]
+name = "understory_responder"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+ "understory_box_tree",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "2"
-members = ["understory_index", "understory_box_tree", "benches"]
+members = [
+  "understory_index",
+  "understory_box_tree",
+  "understory_responder",
+  "benches",
+  "examples",
+]
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Not a layout engine.
   - Upstream code (your layout system) decides sizes and positions and then updates this tree.
 
+- `understory_responder`
+  - A deterministic event router that builds the responder chain sequence: capture → target → bubble.
+  - Consumes pre‑resolved hits (from a picker or the box tree) and emits an ordered dispatch sequence.
+  - Supports pointer capture with path reconstruction via a `ParentLookup` provider and bypasses scope filters.
+
 Both crates are `#![no_std]` and use `alloc`.
 Examples and tests use `std`.
 
@@ -64,10 +69,14 @@ For example, a canvas or DWG or DXF viewer can reuse the box and index layers wi
 - Read the crate READMEs.
   - `understory_index/README.md` has the API and a “Choosing a backend” guide.
   - `understory_box_tree/README.md` has usage, hit‑testing, and visible‑set examples.
+  - `understory_responder/README.md` explains routing, capture, and how to integrate with a picker.
 - Run examples.
   - `cargo run -p understory_index --example basic_index`
   - `cargo run -p understory_box_tree --example basic_box_tree`
   - `cargo run -p understory_box_tree --example visible_list`
+  - `cargo run -p understory_examples --example responder_basics`
+  - `cargo run -p understory_examples --example responder_hover`
+  - `cargo run -p understory_examples --example responder_box_tree`
 
 ## MSRV & License
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "understory_examples"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+understory_responder = { path = "../understory_responder", features = [
+  "box_tree_adapter",
+  "std",
+] }
+understory_box_tree = { path = "../understory_box_tree" }
+kurbo = { workspace = true, default-features = true }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# Understory Examples
+
+These examples form a short, progressive walkthrough from routing basics to integrating the box tree adapter.
+
+- responder_basics
+  - Rank hits by depth, reconstruct a path via parents, and emit the capture → target → bubble sequence.
+  - Run: `cargo run -p understory_examples --example responder_basics`
+
+- responder_hover
+  - Derive hover enter/leave by comparing successive dispatch paths using the least common ancestor (LCA).
+  - Run: `cargo run -p understory_examples --example responder_hover`
+
+- responder_box_tree
+  - Resolve hits from `understory_box_tree`, route them, and compute hover transitions. Includes a tiny ASCII tree and prints box rects and query coordinates.
+  - Run: `cargo run -p understory_examples --example responder_box_tree`
+
+Notes
+- Examples live in a separate crate (`understory_examples`) so that published crates stay free of example-only dependencies.
+- Output is formatted with section headers to make sequences easy to follow.

--- a/examples/examples/responder_basics.rs
+++ b/examples/examples/responder_basics.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Router basics.
+//!
+//! This minimal example ranks hits by depth, reconstructs a path via parents
+//! when needed, and emits the capture → target → bubble dispatch sequence.
+//!
+//! Run:
+//! - `cargo run -p understory_examples --example responder_basics`
+
+use understory_responder::router::Router;
+use understory_responder::types::{DepthKey, Localizer, ParentLookup, ResolvedHit, WidgetLookup};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+struct Node(u32);
+
+struct Lookup;
+impl WidgetLookup<Node> for Lookup {
+    type WidgetId = u32;
+    fn widget_of(&self, node: &Node) -> Option<Self::WidgetId> {
+        Some(node.0)
+    }
+}
+
+struct Parents;
+impl ParentLookup<Node> for Parents {
+    fn parent_of(&self, node: &Node) -> Option<Node> {
+        match node.0 {
+            3 => Some(Node(2)),
+            2 => Some(Node(1)),
+            _ => None,
+        }
+    }
+}
+
+fn main() {
+    let router: Router<Node, Lookup, Parents> = Router::with_parent(Lookup, Parents);
+
+    // Two hits: Node(3) has higher Z and wins over Node(9).
+    let hits = vec![
+        ResolvedHit {
+            node: Node(9),
+            path: Some(vec![Node(9)]),
+            depth_key: DepthKey::Z(5),
+            localizer: Localizer::default(),
+            meta: (),
+        },
+        ResolvedHit {
+            node: Node(3),
+            path: None,
+            depth_key: DepthKey::Z(10),
+            localizer: Localizer::default(),
+            meta: (),
+        },
+    ];
+
+    let out = router.handle_with_hits::<()>(&hits);
+    println!("== Dispatch (capture → target → bubble) ==");
+    for d in out {
+        println!("  {:?}  node={:?}  widget={:?}", d.phase, d.node, d.widget);
+    }
+}

--- a/examples/examples/responder_box_tree.rs
+++ b/examples/examples/responder_box_tree.rs
@@ -1,0 +1,181 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Box tree → responder adapter with a simple ASCII tree.
+//!
+//! This example shows how a box tree can feed the responder by resolving
+//! hits, building a dispatch sequence, and deriving hover transitions.
+//!
+//! Run:
+//! - `cargo run -p understory_examples --example responder_box_tree`
+
+use std::collections::HashMap;
+
+use kurbo::{Affine, Point, Rect};
+use understory_box_tree::{LocalNode, NodeFlags, NodeId, QueryFilter, Tree};
+use understory_responder::adapters::box_tree::{hits_for_rect, top_hit_for_point};
+use understory_responder::hover::{HoverState, path_from_dispatch};
+use understory_responder::router::Router;
+use understory_responder::types::{ResolvedHit, WidgetLookup};
+
+fn main() {
+    // Build a small scene with two overlapping siblings.
+    let mut bt = Tree::new();
+
+    let root_local = LocalNode {
+        local_bounds: Rect::new(0.0, 0.0, 400.0, 400.0),
+        local_transform: Affine::IDENTITY,
+        local_clip: None,
+        z_index: 0,
+        flags: NodeFlags::VISIBLE | NodeFlags::PICKABLE,
+    };
+    let root = bt.insert(None, root_local);
+
+    // Track a simple adjacency for printing (NodeId → children), and attach
+    // human-friendly labels + geometry for clarity when printing.
+    let mut edges: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+    let mut info: HashMap<NodeId, (String, Rect, i32)> = HashMap::new();
+    info.insert(root, ("root".into(), Rect::new(0.0, 0.0, 400.0, 400.0), 0));
+
+    // Child A: behind (z=0), at (50,50)-(150,150)
+    let child_a = bt.insert(
+        Some(root),
+        LocalNode {
+            local_bounds: Rect::new(50.0, 50.0, 150.0, 150.0),
+            z_index: 0,
+            ..Default::default()
+        },
+    );
+    edges.entry(root).or_default().push(child_a);
+    info.insert(
+        child_a,
+        ("A".into(), Rect::new(50.0, 50.0, 150.0, 150.0), 0),
+    );
+
+    // Child B: on top (z=5), overlapping A: (100,100)-(200,200)
+    let child_b = bt.insert(
+        Some(root),
+        LocalNode {
+            local_bounds: Rect::new(100.0, 100.0, 200.0, 200.0),
+            z_index: 5,
+            ..Default::default()
+        },
+    );
+    edges.entry(root).or_default().push(child_b);
+    info.insert(
+        child_b,
+        ("B".into(), Rect::new(100.0, 100.0, 200.0, 200.0), 5),
+    );
+
+    // Commit to compute world transforms/AABBs and update the spatial index.
+    let _dmg = bt.commit();
+
+    // Draw a tiny ASCII tree of what we built, with labels and rectangles.
+    print_ascii_tree(root, &edges, &info);
+
+    // Minimal lookup mapping nodes to "widget ids" (echo NodeId for demo).
+    struct Lookup;
+    impl WidgetLookup<NodeId> for Lookup {
+        type WidgetId = NodeId;
+        fn widget_of(&self, node: &NodeId) -> Option<Self::WidgetId> {
+            Some(*node)
+        }
+    }
+
+    let router: Router<NodeId, Lookup> = Router::new(Lookup);
+
+    // Point inside the overlap region; top_hit should be child_b (higher z).
+    let pt = Point::new(120.0, 120.0);
+    let filter = QueryFilter {
+        visible_only: true,
+        pickable_only: true,
+    };
+    let hit: ResolvedHit<NodeId, ()> = top_hit_for_point(&bt, pt, filter).expect("expected a hit");
+    println!("\nQuery point #1: ({:.1}, {:.1})", pt.x, pt.y);
+    let dispatch = router.handle_with_hits(&[hit]);
+    println!("\n== Dispatch (overlap @ 120,120) ==");
+    for d in &dispatch {
+        println!("  {:?}  node={:?}  widget={:?}", d.phase, d.node, d.widget);
+    }
+
+    // Derive a hover path and compute transitions using HoverState.
+    let mut hover = HoverState::new();
+    let path = path_from_dispatch(&dispatch);
+    let first = hover.update_path(&path);
+    println!("\n== Hover transitions (first) ==\n  {:?}", first);
+
+    // Move point into only-child A region (e.g., 60,60) and re-route.
+    let pt2 = Point::new(60.0, 60.0);
+    let hit2 = top_hit_for_point(&bt, pt2, filter).expect("expected hit in A");
+    println!("\nQuery point #2: ({:.1}, {:.1})", pt2.x, pt2.y);
+    let dispatch2 = router.handle_with_hits(&[hit2]);
+    println!("\n== Dispatch (point #2 @ {:.1},{:.1}) ==", pt2.x, pt2.y);
+    for d in &dispatch2 {
+        println!("  {:?}  node={:?}  widget={:?}", d.phase, d.node, d.widget);
+    }
+    let path2 = path_from_dispatch(&dispatch2);
+    let second = hover.update_path(&path2);
+    println!("\n== Hover transitions (second) ==\n  {:?}", second);
+
+    // Visible set example: query a viewport.
+    let viewport = Rect::new(0.0, 0.0, 300.0, 300.0);
+    let visible_hits = hits_for_rect(
+        &bt,
+        viewport,
+        QueryFilter {
+            visible_only: true,
+            pickable_only: false,
+        },
+    );
+    println!(
+        "\n== Visible nodes in viewport ==\n  viewport: ({:.1},{:.1})–({:.1},{:.1})\n  count: {}",
+        viewport.x0,
+        viewport.y0,
+        viewport.x1,
+        viewport.y1,
+        visible_hits.len()
+    );
+}
+
+fn print_ascii_tree(
+    root: NodeId,
+    edges: &HashMap<NodeId, Vec<NodeId>>,
+    info: &HashMap<NodeId, (String, Rect, i32)>,
+) {
+    println!("Scene:");
+    // Print root, then recurse into children.
+    print_node("", root, info);
+    fn go(
+        node: NodeId,
+        edges: &HashMap<NodeId, Vec<NodeId>>,
+        info: &HashMap<NodeId, (String, Rect, i32)>,
+        prefix: &str,
+    ) {
+        if let Some(kids) = edges.get(&node) {
+            let len = kids.len();
+            for (i, &k) in kids.iter().enumerate() {
+                let last = i + 1 == len;
+                let branch = if last { "└── " } else { "├── " };
+                print_node(&format!("{}{}", prefix, branch), k, info);
+                let next_prefix = if last {
+                    format!("{}    ", prefix)
+                } else {
+                    format!("{}│   ", prefix)
+                };
+                go(k, edges, info, &next_prefix);
+            }
+        }
+    }
+    go(root, edges, info, "");
+}
+
+fn print_node(prefix: &str, id: NodeId, info: &HashMap<NodeId, (String, Rect, i32)>) {
+    if let Some((name, rect, z)) = info.get(&id) {
+        println!(
+            "{}{} {:?}  rect=({:.0},{:.0})–({:.0},{:.0})  z={}",
+            prefix, name, id, rect.x0, rect.y0, rect.x1, rect.y1, z
+        );
+    } else {
+        println!("{}{:?}", prefix, id);
+    }
+}

--- a/examples/examples/responder_hover.rs
+++ b/examples/examples/responder_hover.rs
@@ -1,0 +1,84 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Hover transitions from a dispatch sequence.
+//!
+//! This example derives enter/leave events from two successive routes by
+//! computing the least common ancestor (LCA) between paths.
+//!
+//! Run:
+//! - `cargo run -p understory_examples --example responder_hover`
+
+use understory_responder::hover::{HoverEvent, HoverState, path_from_dispatch};
+use understory_responder::router::Router;
+use understory_responder::types::{DepthKey, Localizer, ParentLookup, ResolvedHit, WidgetLookup};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+struct Node(u32);
+
+struct Lookup;
+impl WidgetLookup<Node> for Lookup {
+    type WidgetId = u32;
+    fn widget_of(&self, n: &Node) -> Option<u32> {
+        Some(n.0)
+    }
+}
+
+struct Parents;
+impl ParentLookup<Node> for Parents {
+    fn parent_of(&self, node: &Node) -> Option<Node> {
+        match node.0 {
+            3 => Some(Node(2)),
+            2 => Some(Node(1)),
+            4 => Some(Node(1)),
+            _ => None,
+        }
+    }
+}
+
+fn main() {
+    let router: Router<Node, Lookup, Parents> = Router::with_parent(Lookup, Parents);
+
+    // First hover at path 1→2→3
+    let hits1 = vec![ResolvedHit {
+        node: Node(3),
+        path: None,
+        depth_key: DepthKey::Z(10),
+        localizer: Localizer::default(),
+        meta: (),
+    }];
+    let path1 = path_from_dispatch(&router.handle_with_hits::<()>(&hits1));
+
+    // Second hover moves to sibling branch: 1→4
+    let hits2 = vec![ResolvedHit {
+        node: Node(4),
+        path: None,
+        depth_key: DepthKey::Z(12),
+        localizer: Localizer::default(),
+        meta: (),
+    }];
+    let path2 = path_from_dispatch(&router.handle_with_hits::<()>(&hits2));
+
+    let mut hover: HoverState<Node> = HoverState::new();
+    let ev1 = hover.update_path(&path1);
+    println!("== Hover (first) ==\n  {:?}", ev1);
+    let ev2 = hover.update_path(&path2);
+    println!("== Hover (second) ==\n  {:?}", ev2);
+
+    assert_eq!(
+        ev1,
+        vec![
+            HoverEvent::Enter(Node(1)),
+            HoverEvent::Enter(Node(2)),
+            HoverEvent::Enter(Node(3))
+        ]
+    );
+    assert_eq!(
+        ev2,
+        vec![
+            HoverEvent::Leave(Node(3)),
+            HoverEvent::Leave(Node(2)),
+            HoverEvent::Enter(Node(4))
+        ]
+    );
+}

--- a/understory_responder/Cargo.toml
+++ b/understory_responder/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "understory_responder"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Deterministic, no_std event responder chain for UI: capture → target → bubble"
+keywords = ["ui", "events", "router", "responder", "no_std", "understory"]
+categories = ["gui", "data-structures"]
+
+[features]
+default = []
+# Enable std mode for deps that support it.
+std = ["kurbo/std", "understory_box_tree/std"]
+# Enable no_std numeric support via libm for deps that support it.
+libm = ["kurbo/libm", "understory_box_tree/libm"]
+# Adapter depends on box tree + kurbo; default to libm for no_std builds.
+box_tree_adapter = ["dep:understory_box_tree", "dep:kurbo", "libm"]
+
+[dependencies]
+understory_box_tree = { path = "../understory_box_tree", default-features = false, optional = true }
+kurbo = { workspace = true, default-features = false, optional = true }
+
+[lints]
+workspace = true

--- a/understory_responder/LICENSE-APACHE
+++ b/understory_responder/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/understory_responder/LICENSE-MIT
+++ b/understory_responder/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/understory_responder/README.md
+++ b/understory_responder/README.md
@@ -1,0 +1,153 @@
+<div align="center">
+
+# Understory Responder
+
+**Deterministic responder chain for UI: capture → target → bubble**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_responder.svg)](https://crates.io/crates/understory_responder)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_responder.svg)](https://docs.rs/understory_responder)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/endoli/understory/ci.yml?logo=github&label=CI)](https://github.com/endoli/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_responder
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Understory Responder: a deterministic, `no_std` router for UI events.
+
+## Overview
+
+This crate builds the responder chain sequence — capture → target → bubble — from pre‑resolved hits.
+It does not perform hit testing.
+Instead, feed it [`ResolvedHit`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.ResolvedHit.html) items (for example from a box tree or a 3D ray cast), and it emits a deterministic propagation sequence you can dispatch.
+
+## Inputs
+
+Provide one or more [`ResolvedHit`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.ResolvedHit.html) values for candidate targets.
+A [`ResolvedHit`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.ResolvedHit.html) contains the node key, an optional root→target `path`, a [`DepthKey`](https://docs.rs/understory_responder/latest/understory_responder/types/enum.DepthKey.html) used for ordering,
+a [`Localizer`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.Localizer.html) for coordinate conversion, and an optional `meta` payload (e.g., text or ray‑hit details).
+You may also provide a [`ParentLookup`](https://docs.rs/understory_responder/latest/understory_responder/types/trait.ParentLookup.html) source to reconstruct a path when `path` is absent.
+
+## Ordering
+
+Candidates are ranked by [`DepthKey`](https://docs.rs/understory_responder/latest/understory_responder/types/enum.DepthKey.html).
+For `Z`, higher is nearer. For `Distance`, lower is nearer. When kinds differ, `Z` ranks above `Distance` by default.
+Equal‑depth ties are stable and the router selects the last.
+
+## Pointer capture
+
+If capture is set, the router routes to the captured node regardless of fresh hits.
+It uses the matching hit’s path and `meta` if present, otherwise reconstructs a path with [`ParentLookup`](https://docs.rs/understory_responder/latest/understory_responder/types/trait.ParentLookup.html) or falls back to a singleton path.
+Capture bypasses scope filtering.
+
+## Layering
+
+The router only computes the traversal order. A higher‑level dispatcher can execute handlers, honor cancelation, and apply toolkit policies.
+
+## Workflow
+
+1) Pick candidates — e.g., from a 2D box tree or a 3D ray cast — and build
+   one or more [`ResolvedHit`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.ResolvedHit.html) values (with optional root→target paths).
+2) Route — [`Router`](https://docs.rs/understory_responder/latest/understory_responder/router/struct.Router.html) ranks candidates by [`DepthKey`](https://docs.rs/understory_responder/latest/understory_responder/types/enum.DepthKey.html) and selects
+   exactly one target. It emits a capture→target→bubble sequence for that target’s path.
+   - Overlapping siblings: only the topmost/nearest candidate is selected; siblings do not receive the target.
+   - Equal‑depth ties: deterministic and stable; the last candidate wins unless you pre‑order your hits or set a policy.
+   - Pointer capture: overrides selection until released.
+3) Hover — derive the path from the dispatch via [`path_from_dispatch`](https://docs.rs/understory_responder/latest/understory_responder/hover/fn.path_from_dispatch.html)
+   and feed it to [`HoverState`](https://docs.rs/understory_responder/latest/understory_responder/hover/struct.HoverState.html). `HoverState` emits leave (inner→outer)
+   and enter (outer→inner) events for the minimal transition between old and new paths.
+
+## Dispatcher sketch
+
+The snippet below shows how a higher‑level layer could walk the router’s sequence and honor stop/cancel rules.
+It groups contiguous entries by phase and allows a handler to stop within a phase or stop‑and‑consume the event entirely.
+
+```rust
+use understory_responder::types::{Dispatch, Outcome, Phase};
+
+/// Deliver a single dispatch item to your toolkit and return
+/// whether to continue propagation or stop.
+fn deliver<K, W, M>(_d: &Dispatch<K, W, M>) -> Outcome {
+    Outcome::Continue
+}
+
+/// Walk the dispatch sequence produced by the router.
+/// Returns true if the event was consumed (e.g., default prevented).
+fn run_dispatch<K, W, M>(seq: &[Dispatch<K, W, M>]) -> bool {
+    let mut consumed = false;
+    let mut i = 0;
+    while i < seq.len() {
+        let phase = seq[i].phase;
+        // Process contiguous entries for the same phase.
+        while i < seq.len() && seq[i].phase == phase {
+            match deliver(&seq[i]) {
+                Outcome::Continue => {}
+                Outcome::Stop => {
+                    // Skip remaining entries in this phase.
+                    while i + 1 < seq.len() && seq[i + 1].phase == phase {
+                        i += 1;
+                    }
+                }
+                Outcome::StopAndConsume => {
+                    consumed = true;
+                    // Abort remaining phases.
+                    return consumed;
+                }
+            }
+            i += 1;
+        }
+    }
+    consumed
+}
+
+```
+
+This crate is `no_std` and uses `alloc`.
+
+
+<!-- cargo-rdme end -->
+
+## Examples
+
+- Router basics.
+  - `cargo run -p understory_examples --example responder_basics`
+- Hover transitions.
+  - `cargo run -p understory_examples --example responder_hover`
+- Box tree integration.
+  - `cargo run -p understory_examples --example responder_box_tree`
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>), or
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>),
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ../AUTHORS
+[LICENSE-APACHE]: LICENSE-APACHE
+[LICENSE-MIT]: LICENSE-MIT

--- a/understory_responder/src/adapters/box_tree.rs
+++ b/understory_responder/src/adapters/box_tree.rs
@@ -1,0 +1,71 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Adapter helpers for Understory Box Tree.
+//!
+//! ## Feature
+//!
+//! Enable with `box_tree_adapter`.
+//!
+//! ## Notes
+//!
+//! These helpers convert box-tree query results into responder hits.
+//! They do not perform ordering; when only a single candidate exists (e.g., top hit), the depth key value is irrelevant.
+//! For lists (e.g., viewport queries), consumers can apply their own ordering if needed.
+
+use alloc::vec::Vec;
+
+use kurbo::{Point, Rect};
+use understory_box_tree::{QueryFilter, Tree};
+
+use crate::types::{DepthKey, Localizer, ResolvedHit};
+
+/// Build a single resolved hit for the topmost node under a point.
+///
+/// Returns `None` if no node matches the filter.
+///
+/// Notes
+/// - Path is populated from the box tree's hit test result so the router does
+///   not need a parent lookup.
+/// - `DepthKey` is set to `Z(0)` since only a single candidate is returned.
+///   TODO: populate with the node's actual z-index once a public getter exists.
+pub fn top_hit_for_point(
+    tree: &Tree,
+    pt: Point,
+    filter: QueryFilter,
+) -> Option<ResolvedHit<understory_box_tree::NodeId, ()>> {
+    let hit = tree.hit_test_point(pt, filter)?;
+    Some(ResolvedHit {
+        node: hit.node,
+        path: Some(hit.path),
+        // TODO: use the node's z-index for DepthKey when available; for a
+        // single candidate this value is not consulted.
+        depth_key: DepthKey::Z(0),
+        localizer: Localizer::default(),
+        meta: (),
+    })
+}
+
+/// Build resolved hits for nodes intersecting a world-space rectangle.
+///
+/// Path is not populated; the router can reconstruct a singleton path (or a
+/// parent-aware path if constructed with a parent lookup). Depth keys are set
+/// to `Z(0)`; consumers may apply their own ordering if desired.
+/// TODO: populate `DepthKey::Z(actual_z)` when the box tree exposes a z getter
+/// or provide a convenience helper that returns a z-sorted hit list.
+pub fn hits_for_rect(
+    tree: &Tree,
+    rect: Rect,
+    filter: QueryFilter,
+) -> Vec<ResolvedHit<understory_box_tree::NodeId, ()>> {
+    tree.intersect_rect(rect, filter)
+        .map(|id| ResolvedHit {
+            node: id,
+            path: None,
+            // TODO: set to actual z-index when available
+            depth_key: DepthKey::Z(0),
+            localizer: Localizer::default(),
+            meta: (),
+        })
+        .collect()
+}

--- a/understory_responder/src/adapters/mod.rs
+++ b/understory_responder/src/adapters/mod.rs
@@ -1,0 +1,9 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Adapters to integrate with other Understory crates.
+//!
+//! Enabled via feature flags to keep the core small and `no_std` by default.
+
+#[cfg(feature = "box_tree_adapter")]
+pub mod box_tree;

--- a/understory_responder/src/hover.rs
+++ b/understory_responder/src/hover.rs
@@ -1,0 +1,268 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Hover state helper: compute enter/leave transitions from path changes.
+//!
+//! ## Usage
+//!
+//! 1) Run the router to produce a dispatch sequence for a pointer move or similar.
+//! 2) Extract the root→target path from the dispatch with [`path_from_dispatch`].
+//! 3) Call [`HoverState::update_path`] with that path to get `Enter(..)` / `Leave(..)` transitions.
+//!
+//! ## Minimal example
+//!
+//! ```
+//! use understory_responder::hover::{HoverState, HoverEvent};
+//! let mut h: HoverState<u32> = HoverState::new();
+//! assert_eq!(h.update_path(&[1, 2]), vec![HoverEvent::Enter(1), HoverEvent::Enter(2)]);
+//! assert_eq!(h.update_path(&[1, 3]), vec![HoverEvent::Leave(2), HoverEvent::Enter(3)]);
+//! ```
+//!
+//! ## Example (sketch):
+//!
+//! ```no_run
+//! use understory_responder::hover::{HoverState, path_from_dispatch};
+//! use understory_responder::types::{ResolvedHit, DepthKey, Localizer};
+//! # use understory_responder::router::Router;
+//! # use understory_responder::types::{ParentLookup, WidgetLookup};
+//! #
+//! # // Minimal types for demonstration
+//! # #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+//! # struct Node(u32);
+//! #
+//! # struct Lookup;
+//! # impl WidgetLookup<Node> for Lookup {
+//! #     type WidgetId = u32;
+//! #     fn widget_of(&self, n: &Node) -> Option<u32> { Some(n.0) }
+//! # }
+//! #
+//! # struct Parents;
+//! # impl ParentLookup<Node> for Parents {
+//! #     fn parent_of(&self, _n: &Node) -> Option<Node> { None }
+//! # }
+//! #
+//! # let router: Router<Node, Lookup, Parents> = Router::with_parent(Lookup, Parents);
+//! # let hits = vec![ResolvedHit {
+//! #     node: Node(1),
+//! #     path: None,
+//! #     depth_key: DepthKey::Z(10),
+//! #     localizer: Localizer::default(),
+//! #     meta: (),
+//! # }];
+//! # let seq = router.handle_with_hits::<()>(&hits);
+//! #
+//! // Derive the root→target path from the dispatch sequence.
+//! let path = path_from_dispatch(&seq);
+//!
+//! // Compute hover transitions from the previous path to the new path.
+//! let mut hover = HoverState::new();
+//! let transitions = hover.update_path(&path);
+//! # let _ = transitions;
+//! ```
+
+use alloc::vec::Vec;
+
+use crate::types::{Dispatch, Phase};
+
+/// A simple hover state machine over root→target paths.
+///
+/// Tracks the current hovered path (root→target) and, when updated with a new
+/// path, computes the minimal sequence of leave and enter transitions to move
+/// from the old state to the new state.
+///
+/// Ordering semantics:
+/// - Leave events are emitted from inner-most to outer-most.
+/// - Enter events are emitted from outer-most to inner-most.
+///
+/// This mirrors common UI expectations for hover transitions as the pointer
+/// moves across siblings and their ancestors.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HoverState<K: Copy + Eq> {
+    current: Vec<K>,
+}
+
+/// A hover transition event.
+///
+/// Returned by [`HoverState::update_path`]. Use
+/// [`path_from_dispatch`] to derive a root→target path from a router
+/// dispatch sequence, then pass that path into [`HoverState::update_path`]
+/// to obtain `Enter(..)` / `Leave(..)` transitions.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HoverEvent<K> {
+    /// Pointer enters the given node (in order from outer→inner).
+    Enter(K),
+    /// Pointer leaves the given node (in order from inner→outer).
+    Leave(K),
+}
+
+impl<K: Copy + Eq> HoverState<K> {
+    /// Create an empty hover state.
+    pub fn new() -> Self {
+        Self {
+            current: Vec::new(),
+        }
+    }
+
+    /// Return the current root→target path (if any).
+    pub fn current_path(&self) -> &[K] {
+        &self.current
+    }
+
+    /// Clear the current hover path, returning the corresponding leave events
+    /// from inner-most to outer-most.
+    pub fn clear(&mut self) -> Vec<HoverEvent<K>> {
+        let mut out = Vec::new();
+        for &k in self.current.iter().rev() {
+            out.push(HoverEvent::Leave(k));
+        }
+        self.current.clear();
+        out
+    }
+
+    /// Update the hover path and return the enter/leave events required to
+    /// transition from the previous path to `new_path`.
+    ///
+    /// Leaves are emitted from inner-most to outer-most, then enters from
+    /// outer-most to inner-most (matching common UI expectations).
+    pub fn update_path(&mut self, new_path: &[K]) -> Vec<HoverEvent<K>> {
+        // Compute the length of the common prefix (the shared ancestry)
+        // which corresponds to the lowest common ancestor (LCA) depth.
+        let mut lca = 0;
+        while lca < self.current.len() && lca < new_path.len() && self.current[lca] == new_path[lca]
+        {
+            lca += 1;
+        }
+
+        let mut out = Vec::new();
+        // Leaves: from old tail back to the LCA (exclusive), inner→outer.
+        for &k in self.current[lca..].iter().rev() {
+            out.push(HoverEvent::Leave(k));
+        }
+
+        // Enters: from LCA down to new tail, outer→inner.
+        for &k in &new_path[lca..] {
+            out.push(HoverEvent::Enter(k));
+        }
+
+        self.current.clear();
+        self.current.extend_from_slice(new_path);
+        out
+    }
+}
+
+/// Extract a root→target path from a router dispatch sequence.
+///
+/// Assumes the sequence begins with all [`Capture`](crate::types::Phase::Capture)
+/// events for the path, followed by the [`Target`](crate::types::Phase::Target)
+/// and [`Bubble`](crate::types::Phase::Bubble) phases (as produced by the
+/// router in this crate). Pass the returned path to
+/// [`HoverState::update_path`] to compute hover transitions.
+pub fn path_from_dispatch<K: Copy, W, M>(seq: &[Dispatch<K, W, M>]) -> Vec<K> {
+    let mut path = Vec::new();
+    for d in seq {
+        match d.phase {
+            Phase::Capture => path.push(d.node),
+            Phase::Target | Phase::Bubble => break,
+        }
+    }
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    // Fresh path: expect outer→inner enters.
+    #[test]
+    fn hover_enter_on_fresh_path() {
+        let mut h: HoverState<u32> = HoverState::new();
+        let ev = h.update_path(&[1, 2, 3]);
+        assert_eq!(
+            ev,
+            vec![
+                HoverEvent::Enter(1),
+                HoverEvent::Enter(2),
+                HoverEvent::Enter(3)
+            ]
+        );
+        assert_eq!(h.current_path(), &[1, 2, 3]);
+    }
+
+    // Clearing path: expect inner→outer leaves.
+    #[test]
+    fn hover_leave_to_empty() {
+        let mut h: HoverState<u32> = HoverState::new();
+        let _ = h.update_path(&[1, 2]);
+        let ev = h.clear();
+        assert_eq!(ev, vec![HoverEvent::Leave(2), HoverEvent::Leave(1)]);
+        assert!(h.current_path().is_empty());
+    }
+
+    // Branch change with shallow LCA (depth 1): leave inner tail, then enter new branch.
+    #[test]
+    fn hover_branch_change() {
+        let mut h: HoverState<u32> = HoverState::new();
+        let _ = h.update_path(&[1, 2, 3]);
+        let ev = h.update_path(&[1, 4]);
+        assert_eq!(
+            ev,
+            vec![
+                HoverEvent::Leave(3),
+                HoverEvent::Leave(2),
+                HoverEvent::Enter(4)
+            ]
+        );
+        assert_eq!(h.current_path(), &[1, 4]);
+    }
+
+    // Disjoint paths: no common prefix — leave entire old path, enter entire new path.
+    #[test]
+    fn hover_disjoint_paths() {
+        let mut h: HoverState<u32> = HoverState::new();
+        let _ = h.update_path(&[1, 2, 3]);
+        // No common prefix between old and new.
+        let ev = h.update_path(&[4, 5]);
+        assert_eq!(
+            ev,
+            vec![
+                HoverEvent::Leave(3),
+                HoverEvent::Leave(2),
+                HoverEvent::Leave(1),
+                HoverEvent::Enter(4),
+                HoverEvent::Enter(5),
+            ]
+        );
+        assert_eq!(h.current_path(), &[4, 5]);
+    }
+
+    // Deep LCA: shared prefix [1,2,3], tails [4,5] → [9,10].
+    // Expect leaves 5,4 (inner→outer), then enters 9,10 (outer→inner).
+    #[test]
+    fn hover_deep_lca() {
+        let mut h: HoverState<u32> = HoverState::new();
+        let _ = h.update_path(&[1, 2, 3, 4, 5]);
+        let ev = h.update_path(&[1, 2, 3, 9, 10]);
+        assert_eq!(
+            ev,
+            vec![
+                HoverEvent::Leave(5),
+                HoverEvent::Leave(4),
+                HoverEvent::Enter(9),
+                HoverEvent::Enter(10),
+            ]
+        );
+        assert_eq!(h.current_path(), &[1, 2, 3, 9, 10]);
+    }
+
+    // Same path repeated: no transitions.
+    #[test]
+    fn hover_same_path_no_events() {
+        let mut h: HoverState<u32> = HoverState::new();
+        let first = h.update_path(&[7, 8]);
+        assert_eq!(first, vec![HoverEvent::Enter(7), HoverEvent::Enter(8)]);
+        let second = h.update_path(&[7, 8]);
+        assert!(second.is_empty());
+        assert_eq!(h.current_path(), &[7, 8]);
+    }
+}

--- a/understory_responder/src/lib.rs
+++ b/understory_responder/src/lib.rs
@@ -1,0 +1,109 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=understory_responder --heading-base-level=0
+
+//! Understory Responder: a deterministic, `no_std` router for UI events.
+//!
+//! ## Overview
+//!
+//! This crate builds the responder chain sequence — capture → target → bubble — from pre‑resolved hits.
+//! It does not perform hit testing.
+//! Instead, feed it [`ResolvedHit`](crate::types::ResolvedHit) items (for example from a box tree or a 3D ray cast), and it emits a deterministic propagation sequence you can dispatch.
+//!
+//! ## Inputs
+//!
+//! Provide one or more [`ResolvedHit`](crate::types::ResolvedHit) values for candidate targets.
+//! A [`ResolvedHit`](crate::types::ResolvedHit) contains the node key, an optional root→target `path`, a [`DepthKey`](crate::types::DepthKey) used for ordering,
+//! a [`Localizer`](crate::types::Localizer) for coordinate conversion, and an optional `meta` payload (e.g., text or ray‑hit details).
+//! You may also provide a [`ParentLookup`](crate::types::ParentLookup) source to reconstruct a path when `path` is absent.
+//!
+//! ## Ordering
+//!
+//! Candidates are ranked by [`DepthKey`](crate::types::DepthKey).
+//! For `Z`, higher is nearer. For `Distance`, lower is nearer. When kinds differ, `Z` ranks above `Distance` by default.
+//! Equal‑depth ties are stable and the router selects the last.
+//!
+//! ## Pointer capture
+//!
+//! If capture is set, the router routes to the captured node regardless of fresh hits.
+//! It uses the matching hit’s path and `meta` if present, otherwise reconstructs a path with [`ParentLookup`](crate::types::ParentLookup) or falls back to a singleton path.
+//! Capture bypasses scope filtering.
+//!
+//! ## Layering
+//!
+//! The router only computes the traversal order. A higher‑level dispatcher can execute handlers, honor cancelation, and apply toolkit policies.
+//!
+//! ## Workflow
+//!
+//! 1) Pick candidates — e.g., from a 2D box tree or a 3D ray cast — and build
+//!    one or more [`ResolvedHit`](crate::types::ResolvedHit) values (with optional root→target paths).
+//! 2) Route — [`Router`](crate::router::Router) ranks candidates by [`DepthKey`](crate::types::DepthKey) and selects
+//!    exactly one target. It emits a capture→target→bubble sequence for that target’s path.
+//!    - Overlapping siblings: only the topmost/nearest candidate is selected; siblings do not receive the target.
+//!    - Equal‑depth ties: deterministic and stable; the last candidate wins unless you pre‑order your hits or set a policy.
+//!    - Pointer capture: overrides selection until released.
+//! 3) Hover — derive the path from the dispatch via [`path_from_dispatch`](crate::hover::path_from_dispatch)
+//!    and feed it to [`HoverState`](crate::hover::HoverState). `HoverState` emits leave (inner→outer)
+//!    and enter (outer→inner) events for the minimal transition between old and new paths.
+//!
+//! ## Dispatcher sketch
+//!
+//! The snippet below shows how a higher‑level layer could walk the router’s sequence and honor stop/cancel rules.
+//! It groups contiguous entries by phase and allows a handler to stop within a phase or stop‑and‑consume the event entirely.
+//!
+//! ```no_run
+//! use understory_responder::types::{Dispatch, Outcome, Phase};
+//!
+//! /// Deliver a single dispatch item to your toolkit and return
+//! /// whether to continue propagation or stop.
+//! fn deliver<K, W, M>(_d: &Dispatch<K, W, M>) -> Outcome {
+//!     Outcome::Continue
+//! }
+//!
+//! /// Walk the dispatch sequence produced by the router.
+//! /// Returns true if the event was consumed (e.g., default prevented).
+//! fn run_dispatch<K, W, M>(seq: &[Dispatch<K, W, M>]) -> bool {
+//!     let mut consumed = false;
+//!     let mut i = 0;
+//!     while i < seq.len() {
+//!         let phase = seq[i].phase;
+//!         // Process contiguous entries for the same phase.
+//!         while i < seq.len() && seq[i].phase == phase {
+//!             match deliver(&seq[i]) {
+//!                 Outcome::Continue => {}
+//!                 Outcome::Stop => {
+//!                     // Skip remaining entries in this phase.
+//!                     while i + 1 < seq.len() && seq[i + 1].phase == phase {
+//!                         i += 1;
+//!                     }
+//!                 }
+//!                 Outcome::StopAndConsume => {
+//!                     consumed = true;
+//!                     // Abort remaining phases.
+//!                     return consumed;
+//!                 }
+//!             }
+//!             i += 1;
+//!         }
+//!     }
+//!     consumed
+//! }
+//!
+//! # // Example: invoking with a dummy sequence
+//! # fn _example<K, W, M>(seq: &[Dispatch<K, W, M>]) { let _ = run_dispatch(seq); }
+//! ```
+//!
+//! This crate is `no_std` and uses `alloc`.
+//!
+//!
+
+#![no_std]
+
+extern crate alloc;
+
+pub mod adapters;
+pub mod hover;
+pub mod router;
+pub mod types;

--- a/understory_responder/src/router.rs
+++ b/understory_responder/src/router.rs
@@ -1,0 +1,767 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Router implementation.
+//!
+//! ## Overview
+//!
+//! Orders hits, reconstructs paths, and emits dispatch steps.
+//! Produces a capture → target → bubble sequence for the selected target.
+//!
+//! ## Target Selection
+//!
+//! - Ranks candidates by [`DepthKey`](crate::types::DepthKey).
+//! - In 2D, `Z` higher is nearer.
+//! - In 3D, `Distance` lower is nearer.
+//! - When kinds differ, `Z` outranks `Distance`.
+//! - Picks exactly one winning candidate, the last after ordering.
+//!
+//! ## Ties and Policies
+//!
+//! - Equal‑depth ties are stable and the last wins.
+//! - Use [`TieBreakPolicy`] to document intent or pre‑order your input when you have a stronger ordering.
+//! - `set_scope` filters candidates before ranking.
+//! - `capture` overrides selection entirely until released.
+//!
+//! ## See Also
+//!
+//! [`hover`](crate::hover) for hover transitions derived from the dispatch sequence.
+
+use alloc::vec::Vec;
+
+use crate::types::{
+    Dispatch, Localizer, NoParent, ParentLookup, Phase, ResolvedHit, TieBreakPolicy, WidgetLookup,
+};
+
+/// Deterministic responder chain router.
+///
+/// ## Usage
+///
+/// - Construct with [`Router::new`] when callers always provide a full path in
+///   [`crate::types::ResolvedHit`], or with [`Router::with_parent`] to enable
+///   path reconstruction via a [`crate::types::ParentLookup`].
+/// - Optionally configure policies:
+///   - [`Router::set_default_tie_break`] to document equal‑depth intent.
+///   - [`Router::set_scope`] to filter candidates (e.g., visibility/pickability).
+///   - [`Router::capture`] to override target selection until released.
+/// - Call [`Router::handle_with_hits`] each input event to select the winning
+///   candidate and produce a capture → target → bubble dispatch sequence.
+///
+/// ## See Also
+///
+/// [`crate::hover`] for deriving hover enter/leave transitions from
+/// the returned dispatch sequence.
+pub struct Router<K, L: WidgetLookup<K>, P: ParentLookup<K> = NoParent> {
+    pub(crate) lookup: L,
+    pub(crate) parent: P,
+    pub(crate) default_tie_break: TieBreakPolicy,
+    pub(crate) scope: Option<fn(&K) -> bool>,
+    pub(crate) focus: Option<K>,
+    // Minimal capture for skeleton; production would be per-pointer id.
+    pub(crate) capture: Option<K>,
+    pub(crate) _phantom: core::marker::PhantomData<fn() -> K>,
+}
+
+impl<K: Copy + Eq, L: WidgetLookup<K>, P: ParentLookup<K>> core::fmt::Debug for Router<K, L, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Router")
+            .field("default_tie_break", &self.default_tie_break)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<K: Copy + Eq, L: WidgetLookup<K>, P: ParentLookup<K> + Default> Router<K, L, P> {
+    /// Create a router with default policies and a default parent lookup.
+    pub fn new(lookup: L) -> Self {
+        Self {
+            lookup,
+            parent: P::default(),
+            default_tie_break: TieBreakPolicy::Newer,
+            scope: None,
+            focus: None,
+            capture: None,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<K: Copy + Eq, L: WidgetLookup<K>, P: ParentLookup<K>> Router<K, L, P> {
+    /// Create a router with an explicit parent lookup provider.
+    pub fn with_parent(lookup: L, parent: P) -> Self {
+        Self {
+            lookup,
+            parent,
+            default_tie_break: TieBreakPolicy::Newer,
+            scope: None,
+            focus: None,
+            capture: None,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Set the default tie-break policy when multiple hits share the same primary depth.
+    pub fn set_default_tie_break(&mut self, p: TieBreakPolicy) {
+        self.default_tie_break = p;
+    }
+
+    /// Set an optional scope filter; only nodes that satisfy the predicate are considered.
+    pub fn set_scope(&mut self, scope: Option<fn(&K) -> bool>) {
+        self.scope = scope;
+    }
+
+    /// Set the focused node (reserved for higher-level policies; currently not used in routing).
+    pub fn set_focus(&mut self, node: Option<K>) {
+        self.focus = node;
+    }
+
+    /// Set the captured node for pointer events (reserved; currently not used in routing).
+    pub fn capture(&mut self, node: Option<K>) {
+        self.capture = node;
+    }
+
+    /// Handle a pre-resolved sequence of hits and produce a propagation sequence.
+    pub fn handle_with_hits<M>(
+        &self,
+        hits: &[ResolvedHit<K, M>],
+    ) -> Vec<Dispatch<K, L::WidgetId, M>>
+    where
+        M: Clone,
+    {
+        // Capture override: when set, route to the captured node regardless of
+        // current hit ranking. Use the hit's path if available, otherwise try to
+        // reconstruct via parent lookup, and finally fall back to a singleton path.
+        if let Some(cap) = self.capture {
+            // Find any hit for the captured node (prefer the last if multiple exist).
+            let cap_hit = hits.iter().rev().find(|h| h.node == cap);
+            let (path, localizer, meta) = match cap_hit {
+                Some(h) if h.path.is_some() => (
+                    h.path.clone().unwrap(),
+                    h.localizer.clone(),
+                    Some(h.meta.clone()),
+                ),
+                Some(h) => (
+                    Self::reconstruct_path(cap, &self.parent),
+                    h.localizer.clone(),
+                    Some(h.meta.clone()),
+                ),
+                None => (
+                    Self::reconstruct_path(cap, &self.parent),
+                    Localizer::default(),
+                    None,
+                ),
+            };
+            return self.emit_path(path, localizer, meta);
+        }
+
+        // Single-pass selection without allocation/sort. Equal-depth ties are
+        // resolved by the tie-break policy, and if still equal we prefer the
+        // last candidate (stable last-wins behavior).
+        let mut best_idx: Option<usize> = None;
+        for (i, h) in hits.iter().enumerate() {
+            if let Some(f) = self.scope
+                && !f(&h.node)
+            {
+                continue;
+            }
+            match best_idx {
+                None => best_idx = Some(i),
+                Some(j) => {
+                    let a = &hits[j];
+                    use core::cmp::Ordering::*;
+                    let better = match a.depth_key.cmp(&h.depth_key) {
+                        Less => true,     // h nearer than a
+                        Greater => false, // a nearer than h
+                        Equal => match self.tiebreak(&a.node, &h.node) {
+                            Less => true,     // h preferred by policy
+                            Greater => false, // a preferred by policy
+                            Equal => true,    // stable last wins
+                        },
+                    };
+                    if better {
+                        best_idx = Some(i);
+                    }
+                }
+            }
+        }
+
+        let Some(i) = best_idx else {
+            return Vec::new();
+        };
+        let best = &hits[i];
+
+        // Derive path if not provided.
+        let path: Vec<K> = if let Some(p) = &best.path {
+            p.clone()
+        } else {
+            Self::reconstruct_path(best.node, &self.parent)
+        };
+
+        self.emit_path(path, best.localizer.clone(), Some(best.meta.clone()))
+    }
+
+    fn make_dispatch<M: Clone>(
+        &self,
+        phase: Phase,
+        node: K,
+        localizer: Localizer,
+        meta: Option<M>,
+    ) -> Dispatch<K, L::WidgetId, M> {
+        let widget = self.lookup.widget_of(&node);
+        Dispatch {
+            phase,
+            node,
+            widget,
+            localizer,
+            meta,
+        }
+    }
+
+    fn reconstruct_path(target: K, parent_lookup: &impl ParentLookup<K>) -> Vec<K> {
+        let mut out = Vec::new();
+        let mut cur = target;
+        // Collect to root; caller ensures acyclic ancestry.
+        loop {
+            out.push(cur);
+            match parent_lookup.parent_of(&cur) {
+                Some(p) => cur = p,
+                None => break,
+            }
+        }
+        out.reverse();
+        out
+    }
+
+    fn emit_path<M: Clone>(
+        &self,
+        path: Vec<K>,
+        localizer: Localizer,
+        meta: Option<M>,
+    ) -> Vec<Dispatch<K, L::WidgetId, M>> {
+        let mut out = Vec::new();
+        // Capture: root→target
+        for &n in &path {
+            out.push(self.make_dispatch(Phase::Capture, n, localizer.clone(), meta.clone()));
+        }
+        // Target
+        let target = *path.last().unwrap();
+        out.push(self.make_dispatch(Phase::Target, target, localizer.clone(), meta.clone()));
+        // Bubble: target→root
+        for &n in path.iter().rev() {
+            out.push(self.make_dispatch(Phase::Bubble, n, localizer.clone(), meta.clone()));
+        }
+        out
+    }
+
+    fn tiebreak(&self, a: &K, b: &K) -> core::cmp::Ordering {
+        use core::cmp::Ordering::*;
+        match self.default_tie_break {
+            TieBreakPolicy::Newer => {
+                if Self::id_is_newer(a, b) {
+                    Greater
+                } else if Self::id_is_newer(b, a) {
+                    Less
+                } else {
+                    Equal
+                }
+            }
+            TieBreakPolicy::Older => {
+                if Self::id_is_newer(b, a) {
+                    Greater
+                } else if Self::id_is_newer(a, b) {
+                    Less
+                } else {
+                    Equal
+                }
+            }
+            // Fallbacks when no inherent ordering is known for K.
+            TieBreakPolicy::MinId => Self::id_cmp(a, b).reverse(),
+            TieBreakPolicy::MaxId => Self::id_cmp(a, b),
+        }
+    }
+
+    // Default id comparisons assume K is comparable by address or value if desired; we provide fallbacks.
+    // TODO: Implement meaningful tie-breaking by allowing injected comparators or a trait.
+    // Consider:
+    // - `set_is_newer(fn: fn(&K, &K) -> bool)` and `set_id_cmp(fn: fn(&K, &K) -> Ordering)`;
+    // - Or a generic `IdOrder<K>` trait with a default stable-last-wins implementation;
+    // - Provide a NodeId-specific comparator in the box-tree adapter (generation, then slot).
+    fn id_is_newer(_a: &K, _b: &K) -> bool {
+        // Without generational ids in K, default to false (stable).
+        false
+    }
+
+    // TODO: As above, use an injected comparator or trait to define ordering for K.
+    // Until then, return Equal so stable last-wins applies after Equal depth.
+    fn id_cmp(_a: &K, _b: &K) -> core::cmp::Ordering {
+        core::cmp::Ordering::Equal
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::*;
+    use alloc::vec;
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+    struct Node(u32);
+
+    struct Lookup;
+    impl WidgetLookup<Node> for Lookup {
+        type WidgetId = u32;
+        fn widget_of(&self, node: &Node) -> Option<Self::WidgetId> {
+            Some(node.0)
+        }
+    }
+
+    // The rest of the tests mirror the ones in the prior lib.rs, ensuring
+    // behavior parity after the module split.
+
+    #[test]
+    fn capture_overrides_selection_and_reconstructs_path() {
+        struct Parents;
+        impl ParentLookup<Node> for Parents {
+            fn parent_of(&self, node: &Node) -> Option<Node> {
+                match node.0 {
+                    3 => Some(Node(2)),
+                    2 => Some(Node(1)),
+                    _ => None,
+                }
+            }
+        }
+
+        let lookup = Lookup;
+        let mut router: Router<Node, Lookup, Parents> = Router::with_parent(lookup, Parents);
+        router.capture(Some(Node(3)));
+        // Competing hit with higher Z for a different node.
+        let hits = vec![ResolvedHit {
+            node: Node(9),
+            path: Some(vec![Node(9)]),
+            depth_key: DepthKey::Z(999),
+            localizer: Localizer::default(),
+            meta: (),
+        }];
+        let out = router.handle_with_hits::<()>(&hits);
+        let phases: Vec<(Phase, u32)> = out.iter().map(|d| (d.phase, d.node.0)).collect();
+        assert_eq!(
+            phases,
+            vec![
+                (Phase::Capture, 1),
+                (Phase::Capture, 2),
+                (Phase::Capture, 3),
+                (Phase::Target, 3),
+                (Phase::Bubble, 3),
+                (Phase::Bubble, 2),
+                (Phase::Bubble, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn capture_prefers_hit_metadata_when_available() {
+        let lookup = Lookup;
+        let mut router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        router.capture(Some(Node(7)));
+        #[derive(Clone, Debug, PartialEq)]
+        struct Meta(&'static str);
+        let hits = vec![ResolvedHit {
+            node: Node(7),
+            path: Some(vec![Node(1), Node(7)]),
+            depth_key: DepthKey::Z(0),
+            localizer: Localizer::default(),
+            meta: Meta("captured"),
+        }];
+        let out = router.handle_with_hits::<Meta>(&hits);
+        let phases: Vec<(Phase, u32)> = out.iter().map(|d| (d.phase, d.node.0)).collect();
+        assert_eq!(
+            phases,
+            vec![
+                (Phase::Capture, 1),
+                (Phase::Capture, 7),
+                (Phase::Target, 7),
+                (Phase::Bubble, 7),
+                (Phase::Bubble, 1),
+            ]
+        );
+        assert!(
+            out.iter()
+                .all(|d| matches!(d.meta.as_ref(), Some(Meta("captured"))))
+        );
+    }
+
+    #[test]
+    fn capture_bypasses_scope_filter() {
+        let lookup = Lookup;
+        let mut router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        router.capture(Some(Node(3))); // odd
+        router.set_scope(Some(|n: &Node| (n.0 & 1) == 0)); // even only
+        let hits = vec![ResolvedHit {
+            node: Node(2),
+            path: Some(vec![Node(2)]),
+            depth_key: DepthKey::Z(100),
+            localizer: Localizer::default(),
+            meta: (),
+        }];
+        let out = router.handle_with_hits::<()>(&hits);
+        let tgt = out
+            .iter()
+            .find(|d| matches!(d.phase, Phase::Target))
+            .unwrap();
+        assert_eq!(tgt.node.0, 3);
+    }
+
+    #[test]
+    fn simple_path_dispatch() {
+        let lookup = Lookup;
+        let router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        let hits = vec![ResolvedHit {
+            node: Node(3),
+            path: Some(vec![Node(1), Node(2), Node(3)]),
+            depth_key: DepthKey::Z(10),
+            localizer: Localizer::default(),
+            meta: (),
+        }];
+        let out = router.handle_with_hits::<()>(&hits);
+        assert_eq!(out.len(), 7);
+        assert!(matches!(out[0].phase, Phase::Capture));
+        assert_eq!(out[0].node.0, 1);
+        assert!(matches!(out[3].phase, Phase::Target));
+        assert_eq!(out[3].node.0, 3);
+        assert!(matches!(out[6].phase, Phase::Bubble));
+        assert_eq!(out[6].node.0, 1);
+    }
+
+    #[test]
+    fn scope_filter_selects_allowed_hit() {
+        let lookup = Lookup;
+        let mut router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        router.set_scope(Some(|n: &Node| (n.0 & 1) == 0));
+        let hits = vec![
+            ResolvedHit {
+                node: Node(1),
+                path: Some(vec![Node(1)]),
+                depth_key: DepthKey::Z(100),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+            ResolvedHit {
+                node: Node(2),
+                path: Some(vec![Node(2)]),
+                depth_key: DepthKey::Z(50),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+        ];
+        let out = router.handle_with_hits::<()>(&hits);
+        assert_eq!(
+            out.iter()
+                .filter(|d| matches!(d.phase, Phase::Target))
+                .count(),
+            1
+        );
+        let tgt = out
+            .iter()
+            .find(|d| matches!(d.phase, Phase::Target))
+            .unwrap();
+        assert_eq!(tgt.node.0, 2);
+    }
+
+    #[test]
+    fn parent_of_reconstructs_path() {
+        struct Parents;
+        impl ParentLookup<Node> for Parents {
+            fn parent_of(&self, node: &Node) -> Option<Node> {
+                match node.0 {
+                    3 => Some(Node(2)),
+                    2 => Some(Node(1)),
+                    _ => None,
+                }
+            }
+        }
+
+        let lookup = Lookup;
+        let router: Router<Node, Lookup, Parents> = Router::with_parent(lookup, Parents);
+        let hits = vec![ResolvedHit {
+            node: Node(3),
+            path: None,
+            depth_key: DepthKey::Z(10),
+            localizer: Localizer::default(),
+            meta: (),
+        }];
+        let out = router.handle_with_hits::<()>(&hits);
+        let phases: Vec<(Phase, u32)> = out.iter().map(|d| (d.phase, d.node.0)).collect();
+        assert_eq!(
+            phases,
+            vec![
+                (Phase::Capture, 1),
+                (Phase::Capture, 2),
+                (Phase::Capture, 3),
+                (Phase::Target, 3),
+                (Phase::Bubble, 3),
+                (Phase::Bubble, 2),
+                (Phase::Bubble, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn mixed_depthkey_z_beats_distance() {
+        let lookup = Lookup;
+        let router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        let hits = vec![
+            ResolvedHit {
+                node: Node(10),
+                path: Some(vec![Node(10)]),
+                depth_key: DepthKey::Distance(0.1),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+            ResolvedHit {
+                node: Node(20),
+                path: Some(vec![Node(20)]),
+                depth_key: DepthKey::Z(0),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+        ];
+        let out = router.handle_with_hits::<()>(&hits);
+        let tgt = out
+            .iter()
+            .find(|d| matches!(d.phase, Phase::Target))
+            .unwrap();
+        assert_eq!(tgt.node.0, 20);
+    }
+
+    #[test]
+    fn tie_break_is_stable_last_wins_on_equal_depth() {
+        let lookup = Lookup;
+        let router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        let hits = vec![
+            ResolvedHit {
+                node: Node(1),
+                path: Some(vec![Node(1)]),
+                depth_key: DepthKey::Z(5),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+            ResolvedHit {
+                node: Node(2),
+                path: Some(vec![Node(2)]),
+                depth_key: DepthKey::Z(5),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+        ];
+        let out = router.handle_with_hits::<()>(&hits);
+        let tgt = out
+            .iter()
+            .find(|d| matches!(d.phase, Phase::Target))
+            .unwrap();
+        assert_eq!(tgt.node.0, 2);
+    }
+
+    #[test]
+    fn meta_and_localizer_passthrough() {
+        #[derive(Clone, Debug, PartialEq)]
+        struct Meta(&'static str);
+        let lookup = Lookup;
+        let router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        let hits = vec![ResolvedHit {
+            node: Node(7),
+            path: Some(vec![Node(7)]),
+            depth_key: DepthKey::Z(1),
+            localizer: Localizer::default(),
+            meta: Meta("hello"),
+        }];
+        let out = router.handle_with_hits::<Meta>(&hits);
+        assert!(out.iter().all(|d| d.meta.as_ref().is_some()));
+        assert!(out.iter().all(|d| d.localizer == Localizer::default()));
+        assert!(
+            out.iter()
+                .all(|d| matches!(d.meta.as_ref(), Some(Meta("hello"))))
+        );
+    }
+
+    #[test]
+    fn widget_id_is_mapped_for_each_dispatch() {
+        let lookup = Lookup;
+        let router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        let hits = vec![ResolvedHit {
+            node: Node(42),
+            path: Some(vec![Node(1), Node(42)]),
+            depth_key: DepthKey::Z(10),
+            localizer: Localizer::default(),
+            meta: (),
+        }];
+        let out = router.handle_with_hits::<()>(&hits);
+        assert!(!out.is_empty());
+        for d in &out {
+            assert_eq!(d.widget, Some(d.node.0));
+        }
+    }
+
+    #[test]
+    fn same_node_higher_z_wins() {
+        let lookup = Lookup;
+        let router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        let hits = vec![
+            ResolvedHit {
+                node: Node(5),
+                path: Some(vec![Node(5)]),
+                depth_key: DepthKey::Z(1),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+            ResolvedHit {
+                node: Node(5),
+                path: Some(vec![Node(5)]),
+                depth_key: DepthKey::Z(10),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+        ];
+        let out = router.handle_with_hits::<()>(&hits);
+        let tgt = out
+            .iter()
+            .find(|d| matches!(d.phase, Phase::Target))
+            .unwrap();
+        assert_eq!(tgt.node.0, 5);
+        assert_eq!(
+            out.iter()
+                .filter(|d| matches!(d.phase, Phase::Target))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn capture_can_be_released() {
+        let lookup = Lookup;
+        let mut router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        router.capture(Some(Node(1)));
+        router.capture(None);
+        let hits = vec![
+            ResolvedHit {
+                node: Node(2),
+                path: Some(vec![Node(2)]),
+                depth_key: DepthKey::Z(1),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+            ResolvedHit {
+                node: Node(3),
+                path: Some(vec![Node(3)]),
+                depth_key: DepthKey::Z(10),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+        ];
+        let out = router.handle_with_hits::<()>(&hits);
+        let tgt = out
+            .iter()
+            .find(|d| matches!(d.phase, Phase::Target))
+            .unwrap();
+        assert_eq!(tgt.node.0, 3);
+    }
+
+    #[test]
+    fn capture_prefers_last_matching_hit() {
+        let lookup = Lookup;
+        let mut router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        router.capture(Some(Node(7)));
+        #[derive(Clone, Debug, PartialEq)]
+        struct Meta(&'static str);
+        let hits = vec![
+            ResolvedHit {
+                node: Node(7),
+                path: Some(vec![Node(7)]),
+                depth_key: DepthKey::Z(1),
+                localizer: Localizer::default(),
+                meta: Meta("first"),
+            },
+            ResolvedHit {
+                node: Node(7),
+                path: Some(vec![Node(1), Node(7)]),
+                depth_key: DepthKey::Z(2),
+                localizer: Localizer::default(),
+                meta: Meta("second"),
+            },
+        ];
+        let out = router.handle_with_hits::<Meta>(&hits);
+        let phases: Vec<(Phase, u32)> = out.iter().map(|d| (d.phase, d.node.0)).collect();
+        assert_eq!(
+            phases,
+            vec![
+                (Phase::Capture, 1),
+                (Phase::Capture, 7),
+                (Phase::Target, 7),
+                (Phase::Bubble, 7),
+                (Phase::Bubble, 1),
+            ]
+        );
+        assert!(
+            out.iter()
+                .all(|d| matches!(d.meta.as_ref(), Some(Meta("second"))))
+        );
+    }
+
+    #[test]
+    fn distance_ordering_and_tie_break() {
+        let lookup = Lookup;
+        let router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        let hits = vec![
+            ResolvedHit {
+                node: Node(1),
+                path: Some(vec![Node(1)]),
+                depth_key: DepthKey::Distance(0.25),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+            ResolvedHit {
+                node: Node(2),
+                path: Some(vec![Node(2)]),
+                depth_key: DepthKey::Distance(0.25),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+            ResolvedHit {
+                node: Node(3),
+                path: Some(vec![Node(3)]),
+                depth_key: DepthKey::Distance(0.10),
+                localizer: Localizer::default(),
+                meta: (),
+            },
+        ];
+        let out = router.handle_with_hits::<()>(&hits);
+        let tgt = out
+            .iter()
+            .find(|d| matches!(d.phase, Phase::Target))
+            .unwrap();
+        assert_eq!(tgt.node.0, 3);
+        let out2 = router.handle_with_hits::<()>(&hits[..2]);
+        let tgt2 = out2
+            .iter()
+            .find(|d| matches!(d.phase, Phase::Target))
+            .unwrap();
+        assert_eq!(tgt2.node.0, 2);
+    }
+
+    #[test]
+    fn fallback_singleton_path_without_parent_or_path() {
+        let lookup = Lookup;
+        let router: Router<Node, Lookup, NoParent> = Router::new(lookup);
+        let hits = vec![ResolvedHit {
+            node: Node(9),
+            path: None,
+            depth_key: DepthKey::Z(0),
+            localizer: Localizer::default(),
+            meta: (),
+        }];
+        let out = router.handle_with_hits::<()>(&hits);
+        let phases: Vec<(Phase, u32)> = out.iter().map(|d| (d.phase, d.node.0)).collect();
+        assert_eq!(
+            phases,
+            vec![(Phase::Capture, 9), (Phase::Target, 9), (Phase::Bubble, 9),]
+        );
+    }
+}

--- a/understory_responder/src/types.rs
+++ b/understory_responder/src/types.rs
@@ -1,0 +1,239 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Core types for the responder: phases, outcomes, keys, hits, lookups, and dispatch.
+//!
+//! ## Overview
+//!
+//! These types describe the responder protocol and its inputs/outputs.
+//! They are referenced by the [`router`](crate::router) and used by downstream toolkits.
+
+use alloc::vec::Vec;
+
+/// Phases of event propagation.
+///
+/// Appears on each [`Dispatch`] item produced by
+/// [`Router::handle_with_hits`](crate::router::Router::handle_with_hits).
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Phase {
+    /// Parent-to-target traversal.
+    Capture,
+    /// Target node.
+    Target,
+    /// Target-to-parent traversal.
+    Bubble,
+}
+
+/// Handler outcome controlling propagation.
+///
+/// A higher‑level dispatcher (see crate docs) can use this as the return
+/// value from per‑node handlers to decide whether to continue within a phase
+/// or abort remaining phases.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Outcome {
+    /// Continue within the current phase.
+    Continue,
+    /// Stop propagation within the current phase.
+    Stop,
+    /// Stop and mark consumed (for higher-level policies).
+    StopAndConsume,
+}
+
+/// Policy for breaking ties after equal primary depth.
+///
+/// Note: The [router](crate::router::Router) does not know how to compare arbitrary node keys `K`.
+/// Implementations can supply a custom tie-break outside the router by pre-sorting hits,
+/// or future versions may accept an ordering callback.
+/// For now, ties are stable with respect to input order, and the router selects the last.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TieBreakPolicy {
+    /// Prefer the more recently created identifier when available.
+    Newer,
+    /// Prefer the less recently created identifier when available.
+    Older,
+    /// Prefer the smaller identifier when available.
+    MinId,
+    /// Prefer the larger identifier when available.
+    MaxId,
+}
+
+/// Primary depth ordering across heterogeneous hits.
+///
+/// This is carried by [`ResolvedHit`] and used by
+/// [`Router::handle_with_hits`](crate::router::Router::handle_with_hits) to rank candidates.
+///
+/// Precondition: `Distance` should be finite (no NaN) for meaningful ordering.
+/// If NaN is encountered, tie-breaking falls back to stable order.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum DepthKey {
+    /// 2D z-index; higher is nearer to the user.
+    Z(i32),
+    /// 3D ray distance; lower is nearer to the user.
+    Distance(f32),
+}
+
+impl Eq for DepthKey {}
+
+impl Ord for DepthKey {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        use core::cmp::Ordering::*;
+        match (*self, *other) {
+            (Self::Z(a), Self::Z(b)) => a.cmp(&b),
+            (Self::Distance(a), Self::Distance(b)) => b.partial_cmp(&a).unwrap_or(Equal),
+            // Cross-kind ordering is undefined globally; treat Z as above Distance by default.
+            (Self::Z(_), Self::Distance(_)) => Greater,
+            (Self::Distance(_), Self::Z(_)) => Less,
+        }
+    }
+}
+
+impl PartialOrd for DepthKey {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(Ord::cmp(self, other))
+    }
+}
+
+/// Placeholder for world→local transformation and any per-target conversion info.
+///
+/// Carried by [`ResolvedHit`] and propagated to every [`Dispatch`] entry in the
+/// resulting sequence from
+/// [`Router::handle_with_hits`](crate::router::Router::handle_with_hits).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Localizer {
+    // Future: carry inverse transforms or scroll offsets as needed.
+}
+
+/// A resolved hit to be routed.
+///
+/// Typically obtained from your picker (for example a 2D box tree hit test or a
+/// 3D ray cast). It is the input to
+/// [`Router::handle_with_hits`](crate::router::Router::handle_with_hits).
+#[derive(Clone, Debug)]
+pub struct ResolvedHit<K, M = ()> {
+    /// Node key associated with the hit.
+    pub node: K,
+    /// Optional root→target path; if absent, the router may consult [`ParentLookup`] to derive one.
+    pub path: Option<Vec<K>>,
+    /// Primary depth ordering key used to pick the winning target from candidates.
+    pub depth_key: DepthKey,
+    /// Transformation context from world space to the target's local coordinates.
+    pub localizer: Localizer,
+    /// Optional metadata carried alongside the hit (e.g., text or ray-hit details).
+    pub meta: M,
+}
+
+/// Map nodes to toolkit widget identifiers.
+///
+/// Implement this trait and supply it to the router so that each [`Dispatch`]
+/// can include an optional widget identifier alongside the node key.
+pub trait WidgetLookup<K> {
+    /// Toolkit widget identifier type associated with a node.
+    type WidgetId: Copy + core::fmt::Debug;
+    /// Returns a widget identifier for the given node, if any.
+    fn widget_of(&self, node: &K) -> Option<Self::WidgetId>;
+}
+
+/// Look up the parent of a node to reconstruct a root→target path for propagation.
+///
+/// The [router](crate::router::Router) consults this when a [`ResolvedHit::path`] is absent, if you
+/// construct it via [`Router::with_parent`](crate::router::Router::with_parent).
+pub trait ParentLookup<K> {
+    /// Returns the parent of `node`, or `None` if `node` is a root.
+    fn parent_of(&self, node: &K) -> Option<K>;
+}
+
+/// A no‑op parent provider used by default when no parent lookup is needed.
+///
+/// Used by [`Router::new`](crate::router::Router::new). All calls to
+/// [`ParentLookup::parent_of`] return `None`.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct NoParent;
+
+impl<K> ParentLookup<K> for NoParent {
+    #[inline]
+    fn parent_of(&self, _node: &K) -> Option<K> {
+        None
+    }
+}
+
+/// A single dispatch item.
+///
+/// Produced by [`Router::handle_with_hits`](crate::router::Router::handle_with_hits), and typically fed
+/// into a higher‑level dispatcher that invokes handlers in [`Capture`](Phase::Capture), then
+/// [`Target`](Phase::Target), then [`Bubble`](Phase::Bubble) phases.
+#[derive(Clone, Debug)]
+pub struct Dispatch<K, W, M = ()> {
+    /// Propagation phase for this step (capture, target, or bubble).
+    pub phase: Phase,
+    /// Node associated with this dispatch step.
+    pub node: K,
+    /// Optional widget id corresponding to the node.
+    pub widget: Option<W>,
+    /// Transformation context for local event coordinates.
+    pub localizer: Localizer,
+    /// Optional metadata (cloned from the winning hit).
+    pub meta: Option<M>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn depthkey_z_ordering() {
+        assert!(DepthKey::Z(10) > DepthKey::Z(5));
+        assert!(DepthKey::Z(-1) < DepthKey::Z(0));
+        assert_eq!(
+            DepthKey::Z(7).cmp(&DepthKey::Z(7)),
+            core::cmp::Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn depthkey_distance_ordering() {
+        // Smaller distance is considered nearer and thus greater in ordering.
+        assert!(DepthKey::Distance(0.1) > DepthKey::Distance(0.2));
+        assert!(DepthKey::Distance(1.0) < DepthKey::Distance(0.5));
+        assert_eq!(
+            DepthKey::Distance(0.25).cmp(&DepthKey::Distance(0.25)),
+            core::cmp::Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn depthkey_mixed_ordering() {
+        // Z is always considered greater than Distance when kinds differ.
+        assert!(DepthKey::Z(0) > DepthKey::Distance(0.0));
+        assert!(DepthKey::Z(-100) > DepthKey::Distance(1000.0));
+        assert_eq!(
+            DepthKey::Z(1).cmp(&DepthKey::Distance(1.0)),
+            core::cmp::Ordering::Greater
+        );
+        assert_eq!(
+            DepthKey::Distance(1.0).cmp(&DepthKey::Z(1)),
+            core::cmp::Ordering::Less
+        );
+    }
+
+    #[test]
+    fn depthkey_partialord_matches_ord() {
+        let a = DepthKey::Z(3);
+        let b = DepthKey::Z(7);
+        assert_eq!(a.partial_cmp(&b), Some(a.cmp(&b)));
+
+        let c = DepthKey::Distance(0.5);
+        let d = DepthKey::Distance(0.25);
+        assert_eq!(c.partial_cmp(&d), Some(c.cmp(&d)));
+    }
+
+    #[test]
+    fn depthkey_distance_nan_is_equal() {
+        // NaN comparisons fall back to Equal by design to keep sort stable.
+        let nan = f32::NAN;
+        let a = DepthKey::Distance(nan);
+        let b = DepthKey::Distance(0.0);
+        assert_eq!(a.cmp(&b), core::cmp::Ordering::Equal);
+        assert_eq!(b.cmp(&a), core::cmp::Ordering::Equal);
+        assert_eq!(a.partial_cmp(&b), Some(core::cmp::Ordering::Equal));
+    }
+}


### PR DESCRIPTION
- New crate: `understory_responder` (`no_std` + `alloc`)
  - Core docs and module split: types, router, hover, adapters
    - src/lib.rs
    - src/types.rs
    - src/router.rs
    - src/hover.rs
    - src/adapters/box_tree.rs
- Router
  - Builds capture → target → bubble sequence from `ResolvedHit` candidates
  - Orders by `DepthKey` (Z higher is nearer; Distance lower is nearer; Z outranks Distance; equal-depth is stable)
  - Supports pointer capture and scope filtering; reconstructs paths via `ParentLookup` when needed
- Hover
  - `HoverState` computes enter/leave via least common ancestor between old/new paths
  - Helper `path_from_dispatch` derives target path from the router’s output
- Box tree adapter (feature: `box_tree_adapter`)
  - `top_hit_for_point(tree, pt, filter)` → `ResolvedHit<NodeId, ()>` with path (via box tree hit)
  - `hits_for_rect(tree, rect, filter)` → `Vec<ResolvedHit<NodeId, ()>>` without path (router can reconstruct)
  - Note: `DepthKey` uses Z(0) in adapter for rect hits; sorting by z can be added once tree exposes z getters
- Examples (top-level examples crate)
  - examples/examples/responder_basics.rs — rank hits, reconstruct path, emit dispatch
  - examples/examples/responder_hover.rs — derive enter/leave transitions across two routes
  - examples/examples/responder_box_tree.rs — integrate box tree → adapter → router → hover; prints node rects/z and query coordinates
  - examples/README.md — short walkthrough with run commands

This commit introduces responder routing, hover, and a conservative box-tree adapter with clear examples and docs.