### PR TITLE
 Rename `BVH` => `Bvh`

### DIFF
--- a/understory_box_tree/README.md
+++ b/understory_box_tree/README.md
@@ -54,7 +54,7 @@ fit your workload (flat vector, R-tree or BVH). Float inputs are
 assumed to be finite (no NaNs). AABBs are conservative for non-axis transforms and rounded clips.
 
 See [`understory_index::Index`], [`understory_index::RTreeF32`]/[`understory_index::RTreeF64`]/[`understory_index::RTreeI64`], and
-[`understory_index::BVHF32`]/[`understory_index::BVHF64`]/[`understory_index::BVHI64`] for details.
+[`understory_index::BvhF32`]/[`understory_index::BvhF64`]/[`understory_index::BvhI64`] for details.
 
 ## API overview
 

--- a/understory_box_tree/src/lib.rs
+++ b/understory_box_tree/src/lib.rs
@@ -37,7 +37,7 @@
 //! assumed to be finite (no NaNs). AABBs are conservative for non-axis transforms and rounded clips.
 //!
 //! See [`understory_index::Index`], [`understory_index::RTreeF32`]/[`understory_index::RTreeF64`]/[`understory_index::RTreeI64`], and
-//! [`understory_index::BVHF32`]/[`understory_index::BVHF64`]/[`understory_index::BVHI64`] for details.
+//! [`understory_index::BvhF32`]/[`understory_index::BvhF64`]/[`understory_index::BvhI64`] for details.
 //!
 //! ## API overview
 //!

--- a/understory_index/README.md
+++ b/understory_index/README.md
@@ -78,7 +78,7 @@ assert_eq!(hits.len(), 1);
 - `RTreeF32`/`RTreeF64`/`RTreeI64`: R-tree with SAH-like splits and widened metrics; good
   general-purpose index when distribution is irregular and updates are frequent.
   See the [`backends`] docs for a brief SAH overview.
-- `BVHF32`/`BVHF64`/`BVHI64`: binary hierarchy with SAH-like splits; excels when bulk-build
+- `BvhF32`/`BvhF64`/`BvhI64`: binary hierarchy with SAH-like splits; excels when bulk-build
   and query performance matter; updates are supported but may be costlier than R-tree.
 
 ### Float semantics

--- a/understory_index/src/backends/bvh.rs
+++ b/understory_index/src/backends/bvh.rs
@@ -11,7 +11,7 @@ use crate::backend::Backend;
 use crate::types::{Aabb2D, Scalar, area, union_aabb};
 
 /// A simple BVH backend using SAH-like splits.
-pub struct BVH<T: Scalar> {
+pub struct Bvh<T: Scalar> {
     max_leaf: usize,
     root: Option<NodeIdx>,
     arena: Vec<Node<T>>,
@@ -41,7 +41,7 @@ impl NodeIdx {
     }
 }
 
-impl<T: Scalar> Default for BVH<T> {
+impl<T: Scalar> Default for Bvh<T> {
     fn default() -> Self {
         Self {
             max_leaf: 8,
@@ -57,7 +57,7 @@ type BvhItem<TS> = (usize, Aabb2D<TS>);
 type BvhItems<TS> = Vec<BvhItem<TS>>;
 type BvhBestSplit<TS> = Option<(crate::types::ScalarAcc<TS>, BvhItems<TS>, BvhItems<TS>)>;
 
-impl<T: Scalar> BVH<T> {
+impl<T: Scalar> Bvh<T> {
     fn ensure_slot(&mut self, slot: usize, bbox: Aabb2D<T>) {
         if self.slots.len() <= slot {
             self.slots.resize_with(slot + 1, || None);
@@ -244,7 +244,7 @@ impl<T: Scalar> BVH<T> {
     }
 }
 
-impl<T: Scalar> Backend<T> for BVH<T> {
+impl<T: Scalar> Backend<T> for Bvh<T> {
     fn insert(&mut self, slot: usize, aabb: Aabb2D<T>) {
         self.ensure_slot(slot, aabb);
         match self.root {
@@ -342,12 +342,12 @@ impl<T: Scalar> Backend<T> for BVH<T> {
     }
 }
 
-impl<T: Scalar> Debug for BVH<T> {
+impl<T: Scalar> Debug for Bvh<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let total = self.slots.len();
         let alive = self.slots.iter().filter(|e| e.is_some()).count();
         let has_root = self.root.is_some();
-        f.debug_struct("BVH")
+        f.debug_struct("Bvh")
             .field("max_leaf", &self.max_leaf)
             .field("arena_nodes", &self.arena.len())
             .field("total_slots", &total)
@@ -359,13 +359,13 @@ impl<T: Scalar> Debug for BVH<T> {
 
 /// Convenience type aliases for common scalar choices.
 /// BVH with f32 coordinates and f64 metrics.
-pub type BVHF32 = BVH<f32>;
+pub type BvhF32 = Bvh<f32>;
 
 /// BVH with f64 coordinates and f64 metrics.
-pub type BVHF64 = BVH<f64>;
+pub type BvhF64 = Bvh<f64>;
 
 /// BVH with i64 coordinates and i128 metrics.
-pub type BVHI64 = BVH<i64>;
+pub type BvhI64 = Bvh<i64>;
 
 #[cfg(test)]
 mod tests {
@@ -389,7 +389,7 @@ mod tests {
     #[test]
     fn bvh_f64_update_move_correctness() {
         // Use backend directly to inspect structure behavior on updates.
-        let mut b: BVH<f64> = BVH::default();
+        let mut b: Bvh<f64> = Bvh::default();
         b.insert(0, Aabb2D::new(0.0, 0.0, 10.0, 10.0));
         b.insert(1, Aabb2D::new(12.0, 0.0, 22.0, 10.0));
 
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn bvh_i64_update_churn_small() {
-        let mut b: BVH<i64> = BVH::default();
+        let mut b: Bvh<i64> = Bvh::default();
         b.insert(0, Aabb2D::new(0, 0, 10, 10));
         b.insert(1, Aabb2D::new(12, 0, 22, 10));
         let baseline_nodes = b.arena.len();
@@ -448,7 +448,7 @@ mod tests {
     fn bvh_f64_split_then_updates_on_internal() {
         // Force a split by exceeding max_leaf (8), then update several items and
         // verify the internal-node tree remains correct.
-        let mut b: BVH<f64> = BVH::default();
+        let mut b: Bvh<f64> = Bvh::default();
 
         // Build 12 non-overlapping AABBs along the x-axis
         let n = 12_usize;

--- a/understory_index/src/backends/mod.rs
+++ b/understory_index/src/backends/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! - `flatvec`: flat vector with linear scans (small, simple).
 //! - `rtree`: generic R-tree (`T: Scalar`) with SAH-like split (aliases: `RTreeI64`, `RTreeF32`, `RTreeF64`).
-//! - `bvh`: generic BVH (`T: Scalar`) with SAH-like split (aliases: `BVHF32`, `BVHF64`, `BVHI64`).
+//! - `bvh`: generic BVH (`T: Scalar`) with SAH-like split (aliases: `BvhF32`, `BvhF64`, `BvhI64`).
 //!
 //! SAH note
 //! --------

--- a/understory_index/src/index.rs
+++ b/understory_index/src/index.rs
@@ -234,11 +234,11 @@ impl<T: Copy + PartialOrd + Debug, P: Copy + Debug> Default for Index<T, P> {
 
 impl<P: Copy + Debug> Index<f64, P> {
     /// Create a BVH-backed index using SAH-like splits.
-    pub fn with_bvh() -> IndexGeneric<f64, P, crate::backends::bvh::BVHF64> {
+    pub fn with_bvh() -> IndexGeneric<f64, P, crate::backends::bvh::BvhF64> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
-            backend: crate::backends::bvh::BVHF64::default(),
+            backend: crate::backends::bvh::BvhF64::default(),
         }
     }
 
@@ -313,11 +313,11 @@ impl<P: Copy + Debug> Index<i64, P> {
 
 impl<P: Copy + Debug> Index<f32, P> {
     /// Create a BVH-backed index (f32 coordinates).
-    pub fn with_bvh() -> IndexGeneric<f32, P, crate::backends::bvh::BVHF32> {
+    pub fn with_bvh() -> IndexGeneric<f32, P, crate::backends::bvh::BvhF32> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
-            backend: crate::backends::bvh::BVHF32::default(),
+            backend: crate::backends::bvh::BvhF32::default(),
         }
     }
 

--- a/understory_index/src/lib.rs
+++ b/understory_index/src/lib.rs
@@ -63,7 +63,7 @@
 //! - `RTreeF32`/`RTreeF64`/`RTreeI64`: R-tree with SAH-like splits and widened metrics; good
 //!   general-purpose index when distribution is irregular and updates are frequent.
 //!   See the [`backends`] docs for a brief SAH overview.
-//! - `BVHF32`/`BVHF64`/`BVHI64`: binary hierarchy with SAH-like splits; excels when bulk-build
+//! - `BvhF32`/`BvhF64`/`BvhI64`: binary hierarchy with SAH-like splits; excels when bulk-build
 //!   and query performance matter; updates are supported but may be costlier than R-tree.
 //!
 //! ### Float semantics
@@ -82,7 +82,7 @@ pub mod index;
 pub mod types;
 
 pub use backend::Backend;
-pub use backends::bvh::{BVHF32, BVHF64, BVHI64};
+pub use backends::bvh::{BvhF32, BvhF64, BvhI64};
 pub use backends::flatvec::FlatVec;
 pub use backends::rtree::{RTreeF32, RTreeF64, RTreeI64};
 pub use damage::Damage;


### PR DESCRIPTION
This is in line with naming acronyms (like `Aabb`) as if they were single words.