### PR TITLE
understory_responder: add focus routing + `FocusState`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,10 @@ These examples form a short, progressive walkthrough from routing basics to inte
   - Resolve hits from `understory_box_tree`, route them, and compute hover transitions. Includes a tiny ASCII tree and prints box rects and query coordinates.
   - Run: `cargo run -p understory_examples --example responder_box_tree`
 
+- responder_focus
+  - Dispatch to focused target via `dispatch_for` and compute focus transitions with `FocusState`.
+  - Run: `cargo run -p understory_examples --example responder_focus`
+
 - index_basics
   - Insert, update, commit damage, and query using `understory_index`.
   - Run: `cargo run -p understory_examples --example index_basics`

--- a/examples/examples/responder_focus.rs
+++ b/examples/examples/responder_focus.rs
@@ -1,0 +1,79 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Focus routing and transitions.
+//!
+//! Demonstrate dispatching to focus via `dispatch_for` and computing focus
+//! enter/leave transitions via `FocusState`.
+//!
+//! Run:
+//! - `cargo run -p understory_examples --example responder_focus`
+
+use understory_responder::focus::{FocusEvent, FocusState};
+use understory_responder::router::Router;
+use understory_responder::types::{ParentLookup, WidgetLookup};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+struct Node(u32);
+
+struct Lookup;
+impl WidgetLookup<Node> for Lookup {
+    type WidgetId = u32;
+    fn widget_of(&self, n: &Node) -> Option<u32> {
+        Some(n.0)
+    }
+}
+
+struct Parents;
+impl ParentLookup<Node> for Parents {
+    fn parent_of(&self, node: &Node) -> Option<Node> {
+        match node.0 {
+            3 => Some(Node(2)),
+            2 => Some(Node(1)),
+            4 => Some(Node(1)),
+            _ => None,
+        }
+    }
+}
+
+fn main() {
+    let router: Router<Node, Lookup, Parents> = Router::with_parent(Lookup, Parents);
+
+    // Focus path: 1→2→3
+    let dispatch1 = router.dispatch_for::<()>(Node(3));
+    println!("== Focus dispatch (to 3) ==");
+    for d in &dispatch1 {
+        println!("  {:?}  node={:?}  widget={:?}", d.phase, d.node, d.widget);
+    }
+
+    // Compute FocusState transitions between focus paths.
+    let mut focus: FocusState<Node> = FocusState::new();
+    let ev1 = focus.update_path(&[Node(1), Node(2), Node(3)]);
+    println!("== Focus transitions (first) ==\n  {:?}", ev1);
+
+    // Move focus to sibling branch: 1→4
+    let dispatch2 = router.dispatch_for::<()>(Node(4));
+    println!("== Focus dispatch (to 4) ==");
+    for d in &dispatch2 {
+        println!("  {:?}  node={:?}  widget={:?}", d.phase, d.node, d.widget);
+    }
+    let ev2 = focus.update_path(&[Node(1), Node(4)]);
+    println!("== Focus transitions (second) ==\n  {:?}", ev2);
+
+    assert_eq!(
+        ev1,
+        vec![
+            FocusEvent::Enter(Node(1)),
+            FocusEvent::Enter(Node(2)),
+            FocusEvent::Enter(Node(3))
+        ]
+    );
+    assert_eq!(
+        ev2,
+        vec![
+            FocusEvent::Leave(Node(3)),
+            FocusEvent::Leave(Node(2)),
+            FocusEvent::Enter(Node(4))
+        ]
+    );
+}

--- a/understory_responder/README.md
+++ b/understory_responder/README.md
@@ -65,6 +65,15 @@ The router only computes the traversal order. A higher‑level dispatcher can ex
    and feed it to [`HoverState`](https://docs.rs/understory_responder/latest/understory_responder/hover/struct.HoverState.html). `HoverState` emits leave (inner→outer)
    and enter (outer→inner) events for the minimal transition between old and new paths.
 
+## Focus
+
+Focus routing is separate from pointer routing.
+Use [`Router::dispatch_for`](router::Router::dispatch_for) to emit a capture → target → bubble sequence for the focused node.
+The router reconstructs the root→target path via [`ParentLookup`](https://docs.rs/understory_responder/latest/understory_responder/types/trait.ParentLookup.html) or falls back to a singleton path.
+Use [`FocusState`](https://docs.rs/understory_responder/latest/understory_responder/focus/struct.FocusState.html) to compute `Enter(..)` and `Leave(..)` transitions between old and new focus paths.
+Keyboard and IME events typically route to focus and may bypass scope filters by policy at a higher layer.
+Click‑to‑focus can be implemented by setting focus after a pointer route and then routing subsequent key input via `dispatch_for`.
+
 ## Dispatcher sketch
 
 The snippet below shows how a higher‑level layer could walk the router’s sequence and honor stop/cancel rules.

--- a/understory_responder/src/focus.rs
+++ b/understory_responder/src/focus.rs
@@ -1,0 +1,185 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Focus state helper: compute enter/leave transitions from focus path changes.
+//!
+//! ## Usage
+//! 1) Decide when focus changes (e.g., after a routed pointer-up).
+//! 2) Build a root→target path for the new focus (via a router, parent lookup, or stored path).
+//! 3) Call [`FocusState::update_path`] with that path to get `Enter(..)` / `Leave(..)` transitions.
+//!
+//! ## Minimal example
+//! ```
+//! use understory_responder::focus::{FocusState, FocusEvent};
+//! let mut f: FocusState<u32> = FocusState::new();
+//! assert_eq!(f.update_path(&[1, 2]), vec![FocusEvent::Enter(1), FocusEvent::Enter(2)]);
+//! assert_eq!(f.update_path(&[1, 3]), vec![FocusEvent::Leave(2), FocusEvent::Enter(3)]);
+//! ```
+
+use alloc::vec::Vec;
+
+/// A simple focus state machine over root→target paths.
+///
+/// Tracks the current focused path and, when updated, computes the minimal
+/// sequence of leave and enter transitions to move from the old focus to the new.
+///
+/// Ordering semantics:
+/// - Leave events are emitted from inner-most to outer-most.
+/// - Enter events are emitted from outer-most to inner-most.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FocusState<K: Copy + Eq> {
+    current: Vec<K>,
+}
+
+/// A focus transition event.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum FocusEvent<K> {
+    /// Focus enters the given node (outer→inner).
+    Enter(K),
+    /// Focus leaves the given node (inner→outer).
+    Leave(K),
+}
+
+impl<K: Copy + Eq> FocusState<K> {
+    /// Create an empty focus state.
+    pub fn new() -> Self {
+        Self {
+            current: Vec::new(),
+        }
+    }
+
+    /// Return the current root→target focus path (if any).
+    pub fn current_path(&self) -> &[K] {
+        &self.current
+    }
+
+    /// Clear the current focus path, returning leave events (inner→outer).
+    pub fn clear(&mut self) -> Vec<FocusEvent<K>> {
+        let mut out = Vec::new();
+        for &k in self.current.iter().rev() {
+            out.push(FocusEvent::Leave(k));
+        }
+        self.current.clear();
+        out
+    }
+
+    /// Update focus to a new path and return enter/leave transitions.
+    pub fn update_path(&mut self, new_path: &[K]) -> Vec<FocusEvent<K>> {
+        // Compute shared prefix length (LCA depth).
+        let mut lca = 0;
+        while lca < self.current.len() && lca < new_path.len() && self.current[lca] == new_path[lca]
+        {
+            lca += 1;
+        }
+
+        let mut out = Vec::new();
+        // Leaves: old tail back to LCA (exclusive), inner→outer.
+        for &k in self.current[lca..].iter().rev() {
+            out.push(FocusEvent::Leave(k));
+        }
+        // Enters: LCA down to new tail, outer→inner.
+        for &k in &new_path[lca..] {
+            out.push(FocusEvent::Enter(k));
+        }
+        self.current.clear();
+        self.current.extend_from_slice(new_path);
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    // Fresh focus: expect outer→inner enters.
+    #[test]
+    fn focus_enter_on_fresh_path() {
+        let mut f: FocusState<u32> = FocusState::new();
+        let ev = f.update_path(&[1, 2, 3]);
+        assert_eq!(
+            ev,
+            vec![
+                FocusEvent::Enter(1),
+                FocusEvent::Enter(2),
+                FocusEvent::Enter(3)
+            ]
+        );
+        assert_eq!(f.current_path(), &[1, 2, 3]);
+    }
+
+    // Clearing focus: inner→outer leaves.
+    #[test]
+    fn focus_leave_to_empty() {
+        let mut f: FocusState<u32> = FocusState::new();
+        let _ = f.update_path(&[1, 2]);
+        let ev = f.clear();
+        assert_eq!(ev, vec![FocusEvent::Leave(2), FocusEvent::Leave(1)]);
+        assert!(f.current_path().is_empty());
+    }
+
+    // Branch change with shallow LCA.
+    #[test]
+    fn focus_branch_change() {
+        let mut f: FocusState<u32> = FocusState::new();
+        let _ = f.update_path(&[1, 2, 3]);
+        let ev = f.update_path(&[1, 4]);
+        assert_eq!(
+            ev,
+            vec![
+                FocusEvent::Leave(3),
+                FocusEvent::Leave(2),
+                FocusEvent::Enter(4)
+            ]
+        );
+        assert_eq!(f.current_path(), &[1, 4]);
+    }
+
+    // Disjoint paths: leave entire old, enter entire new.
+    #[test]
+    fn focus_disjoint_paths() {
+        let mut f: FocusState<u32> = FocusState::new();
+        let _ = f.update_path(&[1, 2, 3]);
+        let ev = f.update_path(&[4, 5]);
+        assert_eq!(
+            ev,
+            vec![
+                FocusEvent::Leave(3),
+                FocusEvent::Leave(2),
+                FocusEvent::Leave(1),
+                FocusEvent::Enter(4),
+                FocusEvent::Enter(5),
+            ]
+        );
+        assert_eq!(f.current_path(), &[4, 5]);
+    }
+
+    // Deep LCA: shared prefix [1,2,3].
+    #[test]
+    fn focus_deep_lca() {
+        let mut f: FocusState<u32> = FocusState::new();
+        let _ = f.update_path(&[1, 2, 3, 4, 5]);
+        let ev = f.update_path(&[1, 2, 3, 9, 10]);
+        assert_eq!(
+            ev,
+            vec![
+                FocusEvent::Leave(5),
+                FocusEvent::Leave(4),
+                FocusEvent::Enter(9),
+                FocusEvent::Enter(10),
+            ]
+        );
+        assert_eq!(f.current_path(), &[1, 2, 3, 9, 10]);
+    }
+
+    // Same path repeated: no transitions.
+    #[test]
+    fn focus_same_path_no_events() {
+        let mut f: FocusState<u32> = FocusState::new();
+        let first = f.update_path(&[7, 8]);
+        assert_eq!(first, vec![FocusEvent::Enter(7), FocusEvent::Enter(8)]);
+        let second = f.update_path(&[7, 8]);
+        assert!(second.is_empty());
+        assert_eq!(f.current_path(), &[7, 8]);
+    }
+}

--- a/understory_responder/src/lib.rs
+++ b/understory_responder/src/lib.rs
@@ -48,6 +48,15 @@
 //!    and feed it to [`HoverState`](crate::hover::HoverState). `HoverState` emits leave (inner→outer)
 //!    and enter (outer→inner) events for the minimal transition between old and new paths.
 //!
+//! ## Focus
+//!
+//! Focus routing is separate from pointer routing.
+//! Use [`Router::dispatch_for`](router::Router::dispatch_for) to emit a capture → target → bubble sequence for the focused node.
+//! The router reconstructs the root→target path via [`ParentLookup`](crate::types::ParentLookup) or falls back to a singleton path.
+//! Use [`FocusState`](crate::focus::FocusState) to compute `Enter(..)` and `Leave(..)` transitions between old and new focus paths.
+//! Keyboard and IME events typically route to focus and may bypass scope filters by policy at a higher layer.
+//! Click‑to‑focus can be implemented by setting focus after a pointer route and then routing subsequent key input via `dispatch_for`.
+//!
 //! ## Dispatcher sketch
 //!
 //! The snippet below shows how a higher‑level layer could walk the router’s sequence and honor stop/cancel rules.
@@ -104,6 +113,7 @@
 extern crate alloc;
 
 pub mod adapters;
+pub mod focus;
 pub mod hover;
 pub mod router;
 pub mod types;


### PR DESCRIPTION
- New module: focus (`no_std` + `alloc`)
  - `FocusState<K>` with `update_path` / `clear` / `current_path`
  - `FocusEvent::{Enter, Leave}`
  - LCA-based transitions; comprehensive tests and a minimal doctest
- Router: add `dispatch_for` / `dispatch_for_with`
  - Reconstructs root→target path via `ParentLookup` (or singleton)
  - Emits capture → target → bubble for keyboard/IME-style routing
  - Does not consult scope/capture (by design)
- Examples: add `responder_focus` demonstrating `dispatch_for` + `FocusState`