### PR TITLE
box-tree: Add parent_of method that respects node liveness

### DIFF
--- a/understory_box_tree/README.md
+++ b/understory_box_tree/README.md
@@ -72,6 +72,7 @@ Key operations:
 - [`Tree::commit`](Tree::commit) → damage summary; updates world data and the spatial index.
 - [`Tree::hit_test_point`](Tree::hit_test_point) and [`Tree::intersect_rect`](Tree::intersect_rect).
 - [`Tree::z_index`](Tree::z_index) exposes the stacking order of a live [`NodeId`].
+- [`Tree::parent_of`](Tree::parent_of) returns the parent of a live [`NodeId`].
 
 ## Damage and debugging notes
 

--- a/understory_box_tree/src/lib.rs
+++ b/understory_box_tree/src/lib.rs
@@ -55,6 +55,7 @@
 //! - [`Tree::commit`](Tree::commit) → damage summary; updates world data and the spatial index.
 //! - [`Tree::hit_test_point`](Tree::hit_test_point) and [`Tree::intersect_rect`](Tree::intersect_rect).
 //! - [`Tree::z_index`](Tree::z_index) exposes the stacking order of a live [`NodeId`].
+//! - [`Tree::parent_of`](Tree::parent_of) returns the parent of a live [`NodeId`].
 //!
 //! ## Damage and debugging notes
 //!


### PR DESCRIPTION
Add Tree::parent_of method that returns the parent of a live node or None  for roots or stale node IDs. 

Also updates crate documentation to include parent_of in the list of key operations alongside z_index and other accessor methods.