### PR TITLE
responder: Fix path_from_dispatch to include Target phase 

### DIFF
--- a/understory_responder/src/hover.rs
+++ b/understory_responder/src/hover.rs
@@ -161,8 +161,8 @@ pub fn path_from_dispatch<K: Copy, W, M>(seq: &[Dispatch<K, W, M>]) -> Vec<K> {
     let mut path = Vec::new();
     for d in seq {
         match d.phase {
-            Phase::Capture => path.push(d.node),
-            Phase::Target | Phase::Bubble => break,
+            Phase::Capture | Phase::Target => path.push(d.node),
+            Phase::Bubble => break,
         }
     }
     path
@@ -264,5 +264,24 @@ mod tests {
         let second = h.update_path(&[7, 8]);
         assert!(second.is_empty());
         assert_eq!(h.current_path(), &[7, 8]);
+    }
+
+    // Test that path_from_dispatch includes Target phase in the path
+    #[test]
+    fn path_from_dispatch_includes_target_phase() {
+        use crate::types::{Dispatch, Phase, Localizer};
+        
+        let seq = vec![
+            Dispatch { phase: Phase::Capture, node: 1u32, widget: Some(10), localizer: Localizer::default(), meta: Some(()) },
+            Dispatch { phase: Phase::Capture, node: 2u32, widget: Some(20), localizer: Localizer::default(), meta: Some(()) },
+            Dispatch { phase: Phase::Target, node: 3u32, widget: Some(30), localizer: Localizer::default(), meta: Some(()) },
+            Dispatch { phase: Phase::Bubble, node: 3u32, widget: Some(30), localizer: Localizer::default(), meta: Some(()) },
+            Dispatch { phase: Phase::Bubble, node: 2u32, widget: Some(20), localizer: Localizer::default(), meta: Some(()) },
+            Dispatch { phase: Phase::Bubble, node: 1u32, widget: Some(10), localizer: Localizer::default(), meta: Some(()) },
+        ];
+
+        let path = path_from_dispatch(&seq);
+        // Should include all Capture phases plus the Target phase
+        assert_eq!(path, vec![1, 2, 3]);
     }
 }


### PR DESCRIPTION

The path_from_dispatch function was incorrectly stopping at the Target phase  instead of including it in the returned root→target path. This meant hover  transitions would not properly recognize the target node as part of the hover  path, potentially causing incorrect enter/leave events.

Fixed by changing the match pattern to only break on Bubble phase, allowing Target phase events to be included in the path alongside Capture events.

Added test coverage for the Target phase inclusion behavior.