### PR TITLE
Refine dispatcher outcomes and add semantic result helper

### DIFF
--- a/examples/examples/responder_basics.rs
+++ b/examples/examples/responder_basics.rs
@@ -60,7 +60,7 @@ fn main() {
 
     let dispatch = router.handle_with_hits::<()>(&hits);
     println!("== Dispatch (capture → target → bubble) ==");
-    let _consumed = dispatcher::run(&dispatch, &mut (), |d, _| {
+    let _ = dispatcher::run(&dispatch, &mut (), |d, _| {
         println!("  {:?}  node={:?}  widget={:?}", d.phase, d.node, d.widget);
         Outcome::Continue
     });

--- a/examples/examples/responder_box_tree.rs
+++ b/examples/examples/responder_box_tree.rs
@@ -92,7 +92,7 @@ fn main() {
     println!("\nQuery point #1: ({:.1}, {:.1})", pt.x, pt.y);
     let dispatch = router.handle_with_hits(&[hit]);
     println!("\n== Dispatch (overlap @ 120,120) ==");
-    let _consumed = dispatcher::run(&dispatch, &mut (), |d, _| {
+    let _ = dispatcher::run(&dispatch, &mut (), |d, _| {
         println!("  {:?}  node={:?}  widget={:?}", d.phase, d.node, d.widget);
         Outcome::Continue
     });
@@ -109,7 +109,7 @@ fn main() {
     println!("\nQuery point #2: ({:.1}, {:.1})", pt2.x, pt2.y);
     let dispatch2 = router.handle_with_hits(&[hit2]);
     println!("\n== Dispatch (point #2 @ {:.1},{:.1}) ==", pt2.x, pt2.y);
-    let _consumed = dispatcher::run(&dispatch2, &mut (), |d, _| {
+    let _ = dispatcher::run(&dispatch2, &mut (), |d, _| {
         println!("  {:?}  node={:?}  widget={:?}", d.phase, d.node, d.widget);
         Outcome::Continue
     });

--- a/understory_responder/README.md
+++ b/understory_responder/README.md
@@ -82,13 +82,13 @@ Execute handlers over the responder sequence and honor stop/cancelation with [`d
 use understory_responder::dispatcher;
 use understory_responder::types::{Dispatch, Outcome, Phase};
 let mut default_prevented = false;
-let consumed = dispatcher::run(&seq, &mut default_prevented, |d, flag| {
+let stop_at = dispatcher::run(&seq, &mut default_prevented, |d, flag| {
     if matches!(d.phase, Phase::Target) {
         *flag = true;
     }
     Outcome::Continue
 });
-assert!(!consumed);
+assert!(stop_at.is_none());
 assert!(default_prevented);
 ```
 

--- a/understory_responder/src/dispatcher.rs
+++ b/understory_responder/src/dispatcher.rs
@@ -1,16 +1,25 @@
 // Copyright 2025 the Understory Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Dispatcher helper: walk a dispatch sequence and honor stop/consume outcomes.
+//! Dispatcher helper: walk a dispatch sequence and honor stop outcomes.
 //!
 //! The dispatcher executes handlers for each step in a responder sequence and
-//! applies simple propagation rules:
+//! applies simple propagation rules. It is deliberately minimal:
+//!
+//! - [`Outcome`] only controls propagation (`Continue` vs `Stop`).
+//! - The return value from [`run`] reports where propagation stopped (if at all).
+//! - Higher‑level semantics such as “consumed” or “default prevented” live on
+//!   the event payload you pass to [`run`], not in [`Outcome`].
+//!
+//! ## Semantics
+//!
+//! The dispatcher:
 //!
 //! - Process entries in order.
 //! - Rely on the router to group phases into capture → target → bubble.
 //! - [`Outcome::Stop`] aborts propagation immediately (no target/bubble if raised in capture).
-//! - [`Outcome::StopAndConsume`] aborts propagation and returns `true`.
-//! - Returns `true` if consumed; otherwise `false` (for both `Continue` and `Stop`).
+//! - Returns the last visited dispatch entry if propagation stopped early, or
+//!   `None` if the sequence completed.
 //!
 //! Dispatch sequences are typically produced by
 //! [`Router::handle_with_hits`](crate::router::Router::handle_with_hits)
@@ -38,23 +47,66 @@
 //!
 //! // Run the dispatcher and record the order of phases.
 //! let mut handled: Vec<(Phase, u32)> = Vec::new();
-//! let consumed = dispatcher::run(&seq, &mut (), |d, _| {
+//! let stop_at = dispatcher::run(&seq, &mut (), |d, _| {
 //!     handled.push((d.phase, d.node.0));
 //!     Outcome::Continue
 //! });
 //!
-//! // It should visit all entries and not be consumed.
-//! assert!(!consumed);
+//! // It should visit all entries and not stop early.
+//! assert!(stop_at.is_none());
 //! assert_eq!(handled, vec![
 //!     (Phase::Capture, 1), (Phase::Capture, 2),
 //!     (Phase::Target, 2),
 //!     (Phase::Bubble, 2), (Phase::Bubble, 1),
 //! ]);
 //! ```
+//!
+//! ### Tracking "consumed" / "default prevented" in your event
+//!
+//! Higher‑level semantics such as “consumed” or “default prevented” live on
+//! your event payload. Handlers mutate those fields; after [`run`] you can
+//! inspect them to decide which defaults or fallbacks to execute:
+//!
+//! ```
+//! use understory_responder::dispatcher;
+//! use understory_responder::types::{Dispatch, Outcome, Phase, Localizer};
+//! #[derive(Copy, Clone, Debug)] struct Node(u32);
+//!
+//! #[derive(Default)]
+//! struct Ev {
+//!     handled: bool,
+//!     default_prevented: bool,
+//! }
+//!
+//! let seq: Vec<Dispatch<Node, (), ()>> = vec![
+//!     Dispatch::capture(Node(1)),
+//!     Dispatch::capture(Node(2)),
+//!     Dispatch::target(Node(2)).with_localizer(Localizer::default()),
+//!     Dispatch::bubble(Node(2)),
+//!     Dispatch::bubble(Node(1)),
+//! ];
+//!
+//! let mut ev = Ev::default();
+//! let stopped = dispatcher::run(&seq, &mut ev, |d, e| {
+//!     if matches!(d.phase, Phase::Target) {
+//!         e.handled = true;
+//!         e.default_prevented = true;
+//!         // Optionally stop bubbling if your framework treats
+//!         // “handled” as “don’t notify ancestors”.
+//!         Outcome::Stop
+//!     } else {
+//!         Outcome::Continue
+//!     }
+//! });
+//!
+//! assert!(stopped.is_some());            // we chose to stop at target
+//! assert!(ev.handled);                   // event was consumed
+//! assert!(ev.default_prevented);         // skip default action
+//! ```
 
 use crate::types::{Dispatch, Outcome};
 
-/// Run a handler over a dispatch sequence and honor stop/consume outcomes.
+/// Run a handler over a dispatch sequence and honor stop outcomes.
 ///
 /// ## Usage
 ///
@@ -63,15 +115,16 @@ use crate::types::{Dispatch, Outcome};
 ///     [`Router::handle_with_hits`](crate::router::Router::handle_with_hits) (pointer routing)
 ///     or [`Router::dispatch_for`](crate::router::Router::dispatch_for) (focus/keyboard).
 ///     If you build a sequence by hand, it should follow the same capture → target → bubble
-///     ordering that the router emits; `run` assumes this when applying `Stop`/`StopAndConsume`.
+///     ordering that the router emits; `run` assumes this when applying [`Outcome::Stop`].
 ///   - `event`: a mutable event payload carried across handler calls; you own its shape.
 ///   - `handler`: your per‑entry callback; return an [`Outcome`] to control propagation.
 /// - Semantics:
 ///   - [`Outcome::Continue`]: keep going.
 ///   - [`Outcome::Stop`]: abort propagation immediately (no later phases).
-///   - [`Outcome::StopAndConsume`]: abort propagation and return `true`.
 /// - Return:
-///   - `true` if consumed (via `StopAndConsume`), otherwise `false`.
+///   - `None` if the full sequence was visited.
+///   - `Some(d)` with the last visited [`Dispatch`] entry if propagation was
+///     stopped early by a handler returning [`Outcome::Stop`].
 ///
 /// ## Tips
 ///
@@ -99,14 +152,14 @@ use crate::types::{Dispatch, Outcome};
 /// ];
 ///
 /// let mut ev = Ev::default();
-/// let consumed = run(&seq, &mut ev, |d, e| {
+/// let stopped = run(&seq, &mut ev, |d, e| {
 ///     e.seen.push((d.phase, d.node.0));
 ///     if matches!(d.phase, Phase::Target) { e.default_prevented = true; }
 ///     Outcome::Continue
 /// });
 ///
-/// // Dispatcher is not consumed; default prevention is recorded on the event.
-/// assert!(!consumed);
+/// // Dispatcher runs to completion; default prevention is recorded on the event.
+/// assert!(stopped.is_none());
 /// assert!(ev.default_prevented);
 /// assert_eq!(ev.seen, vec![
 ///   (Phase::Capture, 1), (Phase::Capture, 2),
@@ -129,20 +182,20 @@ use crate::types::{Dispatch, Outcome};
 /// ];
 ///
 /// let mut seen: Vec<(Phase, u32)> = Vec::new();
-/// let consumed = run(&seq, &mut (), |d, _| {
+/// let stopped = run(&seq, &mut (), |d, _| {
 ///     seen.push((d.phase, d.node.0));
 ///     if d.phase == Phase::Capture && d.node.0 == 1 { Outcome::Stop } else { Outcome::Continue }
 /// });
 ///
-/// // Not consumed; propagation aborted after the first capture.
-/// assert!(!consumed);
+/// // Propagation aborted after the first capture; we stopped at that entry.
+/// assert!(stopped.is_some());
 /// assert_eq!(seen, vec![(Phase::Capture, 1)]);
 /// ```
-pub fn run<K, W, M, E>(
-    seq: &[Dispatch<K, W, M>],
+pub fn run<'a, K, W, M, E>(
+    seq: &'a [Dispatch<K, W, M>],
     event: &mut E,
     mut handler: impl FnMut(&Dispatch<K, W, M>, &mut E) -> Outcome,
-) -> bool {
+) -> Option<&'a Dispatch<K, W, M>> {
     // The router already emits dispatch entries in capture → target → bubble
     // order, grouped by phase. We simply walk them in sequence and apply the
     // outcome rules.
@@ -150,11 +203,10 @@ pub fn run<K, W, M, E>(
         match handler(d, event) {
             Outcome::Continue => {}
             // Abort propagation immediately (spec-aligned: no target/bubble if raised in capture).
-            Outcome::Stop => return false,
-            Outcome::StopAndConsume => return true,
+            Outcome::Stop => return Some(d),
         }
     }
-    false
+    None
 }
 
 #[cfg(test)]
@@ -181,11 +233,11 @@ mod tests {
     fn continue_through_all() {
         let seq = mk_seq();
         let mut seen: Vec<(Phase, u32)> = Vec::new();
-        let consumed = run(&seq, &mut (), |d, _| {
+        let stopped = run(&seq, &mut (), |d, _| {
             seen.push((d.phase, d.node.0));
             Outcome::Continue
         });
-        assert!(!consumed);
+        assert!(stopped.is_none());
         assert_eq!(seen.len(), seq.len());
     }
 
@@ -199,7 +251,7 @@ mod tests {
 
         let seq = mk_seq();
         let mut ev = Ev::default();
-        let consumed = run(&seq, &mut ev, |d, e| {
+        let stopped = run(&seq, &mut ev, |d, e| {
             e.seen.push((d.phase, d.node.0));
             if matches!(d.phase, Phase::Target) {
                 e.default_prevented = true;
@@ -207,7 +259,7 @@ mod tests {
             Outcome::Continue
         });
 
-        assert!(!consumed);
+        assert!(stopped.is_none());
         assert!(ev.default_prevented);
         assert_eq!(
             ev.seen,
@@ -225,7 +277,7 @@ mod tests {
     fn stop_aborts_propagation() {
         let seq = mk_seq();
         let mut seen: Vec<(Phase, u32)> = Vec::new();
-        let consumed = run(&seq, &mut (), |d, _| {
+        let stopped = run(&seq, &mut (), |d, _| {
             seen.push((d.phase, d.node.0));
             if d.phase == Phase::Capture && d.node.0 == 1 {
                 Outcome::Stop
@@ -233,7 +285,10 @@ mod tests {
                 Outcome::Continue
             }
         });
-        assert!(!consumed);
+        assert!(stopped.is_some());
+        let stopped = stopped.unwrap();
+        assert!(matches!(stopped.phase, Phase::Capture));
+        assert_eq!(stopped.node.0, 1);
         // Stop during first capture aborts propagation immediately.
         assert_eq!(seen, vec![(Phase::Capture, 1)]);
     }
@@ -242,7 +297,7 @@ mod tests {
     fn stop_in_target_aborts_bubble_phase() {
         let seq = mk_seq();
         let mut seen: Vec<(Phase, u32)> = Vec::new();
-        let consumed = run(&seq, &mut (), |d, _| {
+        let stopped = run(&seq, &mut (), |d, _| {
             seen.push((d.phase, d.node.0));
             if matches!(d.phase, Phase::Target) {
                 Outcome::Stop
@@ -250,7 +305,10 @@ mod tests {
                 Outcome::Continue
             }
         });
-        assert!(!consumed);
+        assert!(stopped.is_some());
+        let stopped = stopped.unwrap();
+        assert!(matches!(stopped.phase, Phase::Target));
+        assert_eq!(stopped.node.0, 2);
         assert_eq!(
             seen,
             vec![(Phase::Capture, 1), (Phase::Capture, 2), (Phase::Target, 2),]
@@ -261,7 +319,7 @@ mod tests {
     fn stop_in_bubble_aborts_remaining_bubble_entries() {
         let seq = mk_seq();
         let mut seen: Vec<(Phase, u32)> = Vec::new();
-        let consumed = run(&seq, &mut (), |d, _| {
+        let stopped = run(&seq, &mut (), |d, _| {
             seen.push((d.phase, d.node.0));
             if d.phase == Phase::Bubble && d.node.0 == 2 {
                 Outcome::Stop
@@ -269,7 +327,10 @@ mod tests {
                 Outcome::Continue
             }
         });
-        assert!(!consumed);
+        assert!(stopped.is_some());
+        let stopped = stopped.unwrap();
+        assert!(matches!(stopped.phase, Phase::Bubble));
+        assert_eq!(stopped.node.0, 2);
         assert_eq!(
             seen,
             vec![
@@ -281,19 +342,24 @@ mod tests {
         );
     }
 
+    // When a handler stops at the target, bubble entries are skipped and the
+    // returned dispatch location reflects the stop point.
     #[test]
-    fn stop_and_consume_aborts_remaining_phases() {
+    fn stop_reports_stop_location_at_target() {
         let seq = mk_seq();
         let mut seen: Vec<(Phase, u32)> = Vec::new();
-        let consumed = run(&seq, &mut (), |d, _| {
+        let stopped = run(&seq, &mut (), |d, _| {
             seen.push((d.phase, d.node.0));
             if d.phase == Phase::Target {
-                Outcome::StopAndConsume
+                Outcome::Stop
             } else {
                 Outcome::Continue
             }
         });
-        assert!(consumed);
+        assert!(stopped.is_some());
+        let stopped = stopped.unwrap();
+        assert!(matches!(stopped.phase, Phase::Target));
+        assert_eq!(stopped.node.0, 2);
         // Should include both capture entries and the target; bubbles are skipped.
         assert_eq!(
             seen,

--- a/understory_responder/src/lib.rs
+++ b/understory_responder/src/lib.rs
@@ -71,13 +71,13 @@
 //! #     Dispatch::bubble(Node(1)),
 //! # ];
 //! let mut default_prevented = false;
-//! let consumed = dispatcher::run(&seq, &mut default_prevented, |d, flag| {
+//! let stop_at = dispatcher::run(&seq, &mut default_prevented, |d, flag| {
 //!     if matches!(d.phase, Phase::Target) {
 //!         *flag = true;
 //!     }
 //!     Outcome::Continue
 //! });
-//! assert!(!consumed);
+//! assert!(stop_at.is_none());
 //! assert!(default_prevented);
 //! ```
 //!

--- a/understory_responder/src/types.rs
+++ b/understory_responder/src/types.rs
@@ -28,15 +28,14 @@ pub enum Phase {
 ///
 /// A higher‑level dispatcher (see crate docs) can use this as the return
 /// value from per‑node handlers to decide whether to continue within a phase
-/// or abort remaining phases.
+/// or abort remaining phases. Consumption / default‑prevention should be
+/// tracked on the event payload, not in this enum.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Outcome {
     /// Continue within the current phase.
     Continue,
     /// Stop propagation within the current phase.
     Stop,
-    /// Stop and mark consumed (for higher-level policies).
-    StopAndConsume,
 }
 
 /// Policy for breaking ties after equal primary depth.


### PR DESCRIPTION
`Outcome` previously tried to encode both propagation control and “consumed” semantics via `StopAndConsume`. That conflated two concerns that most ecosystems keep separate: whether traversal should stop, and whether the event has been handled / default prevented.

This change makes `Outcome` strictly about propagation (`Continue` | `Stop`) and teaches `dispatcher::run` to return where traversal stopped, if at all, instead of a consumed `bool`. Higher layers can still express consumption and default prevention, but those now live entirely on the event payload.

To make that pattern ergonomic, introduce an `EventState` trait and a `run_with_result` helper that wraps run and summarizes both mechanics (`stopped_at`) and semantics (`consumed`, `default_prevented`) in a small `DispatchResult`. This keeps the core dispatcher minimal and `no_std`, while giving frameworks a clean way to map their own “handled/default prevented” notions onto the responder without baking policy into `Outcome`.