### PR TITLE
box-tree: make `Tree` generic over index backend

### DIFF
--- a/understory_index/src/index.rs
+++ b/understory_index/src/index.rs
@@ -74,6 +74,25 @@ where
     P: Copy + Debug,
     B: Backend<T>,
 {
+    /// Create an empty index using an explicit backend instance.
+    ///
+    /// This is useful when higher layers want to choose a backend type or
+    /// configure it before wiring it into the index.
+    pub fn with_backend(backend: B) -> Self {
+        Self {
+            entries: Vec::new(),
+            free_list: Vec::new(),
+            backend,
+        }
+    }
+}
+
+impl<T, P, B> IndexGeneric<T, P, B>
+where
+    T: Copy + PartialOrd + Debug,
+    P: Copy + Debug,
+    B: Backend<T>,
+{
     /// Reserve space for at least `n` entries.
     pub fn reserve(&mut self, n: usize) {
         self.entries.reserve(n);


### PR DESCRIPTION
- Change `Tree` to `Tree<B: Backend<f64> = FlatVec<f64>>`, keeping `Tree::new()` using `FlatVec` by default.
- Add `Tree::with_backend(B)` so callers can opt into `RTreeF64`/`BvhF64` backends from `understory_index`.
- Add `IndexGeneric::with_backend` to construct an index around an explicit backend instance.