### PR TITLE
Understory focus: add focus policies, box-tree adapter, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_MIN_VER: "1.88"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree -p understory_responder"
+  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree -p understory_responder -p understory_focus"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default"
 
@@ -106,6 +106,9 @@ jobs:
 
       - name: check understory_responder README
         run: cargo rdme --workspace-project=understory_responder --heading-base-level=0 --check
+
+      - name: check understory_focus README
+        run: cargo rdme --workspace-project=understory_focus --heading-base-level=0 --check
 
   clippy-stable:
     name: cargo clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,8 +510,18 @@ version = "0.1.0"
 dependencies = [
  "kurbo",
  "understory_box_tree",
+ "understory_focus",
  "understory_index",
  "understory_responder",
+]
+
+[[package]]
+name = "understory_focus"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+ "understory_box_tree",
+ "understory_index",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "understory_index",
   "understory_box_tree",
+  "understory_focus",
   "understory_responder",
   "benches",
   "examples",

--- a/docs/issue_focus_direction_and_reading_order.md
+++ b/docs/issue_focus_direction_and_reading_order.md
@@ -1,0 +1,209 @@
+# Understory Focus Direction & Reading Order Plan
+
+This document narrows the design for two related pieces of the focus system:
+
+- Directional traversal scoring (`Up`/`Down`/`Left`/`Right`).
+- Reading order and LTR/RTL behavior for `Next`/`Prev`.
+
+It builds on the higher-level plan in `docs/issue_focus_navigation_and_policies.md` and the
+current implementation in `understory_focus`. For an overview of focus navigation, policies,
+and the role of `DefaultPolicy` in the broader stack, start there; this document focuses on
+the directional scoring and reading-order details.
+
+The main goals are:
+
+- Make the current behavior explicit and testable.
+- Identify tunable points (weights, fallback, axes).
+- Sketch how LTR/RTL should influence reading order and, when appropriate, directional semantics.
+
+We **do not** intend to implement all of this immediately; this is a design target to guide gradual refinement.
+
+## Current Behavior Summary
+
+### Linear traversal (`Next` / `Prev`)
+
+In `DefaultPolicy`:
+
+- Candidate set:
+  - Start from `FocusSpace.nodes`.
+  - Filter to `enabled` entries.
+- Ordering:
+  1. If both entries have `order: Some(i32)`, compare by `order` (lower first).
+  2. Otherwise fall back to **reading order** defined as:
+     - Compare by `rect.y0` (ascending).
+     - If `y0` is within a small epsilon, compare by `rect.x0` (ascending).
+- Traversal:
+  - `Next`: move forward in this sorted list.
+  - `Prev`: move backward in this sorted list.
+  - If the origin is not found in the list, `Next` picks the first; `Prev` picks the last.
+  - `WrapMode` controls whether we wrap or stop at the edges.
+
+### Directional traversal (arrows)
+
+In `DefaultPolicy`:
+
+- Candidate set:
+  - Start from `FocusSpace.nodes`.
+  - Filter to `enabled` entries.
+  - Exclude the origin itself.
+- Geometry:
+  - Use `rect.center()` for both origin and candidates.
+  - Compute `dx = cx - ox`, `dy = cy - oy`.
+- Forward hemiplane filter:
+  - `Right`: require `dx > 0`.
+  - `Left`: require `dx < 0`.
+  - `Down`: require `dy > 0`.
+  - `Up`: require `dy < 0`.
+- Scoring:
+  - Map (`dx`, `dy`) into `(primary, secondary)` depending on direction:
+    - Horizontal: `primary = dx`, `secondary = dy`.
+    - Vertical: `primary = dy`, `secondary = dx`.
+  - Score:
+    - `score = |primary| + W * |secondary|`
+    - Currently `W = 4.0`.
+  - Pick the candidate with the smallest finite score.
+- Fallback:
+  - If no candidate survives the hemiplane filter:
+    - `Up`/`Left` fall back to linear `Prev`.
+    - `Down`/`Right` fall back to linear `Next`.
+  - Fallback still uses `WrapMode` for wrapping/edge behavior.
+
+### LTR/RTL
+
+Today:
+
+- Reading order is implicitly top-to-bottom, left-to-right.
+- There is no explicit modeling of RTL; callers would have to invert coordinates or ordering externally.
+
+## Directional Scoring: Design Targets
+
+The current scoring is intentionally simple. We expect to refine it while keeping the same general shape:
+
+- **Hemiplane filter stays**:
+  - It matches intuition that "Right" should not move left of the origin, and vice versa.
+  - It keeps the candidate set small for scoring.
+
+- **Scoring function remains separable**:
+  - We want `score = |primary| + W * |secondary|` or similar:
+    - Primary axis: distance in the intended direction.
+    - Secondary axis: lateral deviation penalty.
+  - `W` should be a configurable constant in `DefaultPolicy` (and/or exposed via a constructor) rather than a hard-coded value.
+
+- **No cone/angle logic for now**:
+  - Cones (e.g., “within ±35° of the axis”) add complexity and require more nuanced tuning.
+  - Sticking to hemiplane + weighted Manhattan distance keeps behavior predictable and easy to reason about.
+
+### Tunables and future refinements
+
+Possible extensions, if we find real use cases that demand them:
+
+- **Different weights per direction**:
+  - e.g., horizontal arrows might be more tolerant of vertical deviation than vertical arrows, or vice versa.
+- **Softening the hemiplane when there are gaps**:
+  - If no candidate survives the strict hemiplane filter, we could consider:
+    - Allowing candidates with small negative `primary` (i.e., slightly behind the origin).
+    - Using a “soft” cone before falling back to linear order.
+- **Minimum “forward distance”**:
+  - Ignore candidates that are extremely close to the origin along the primary axis to avoid jittering between overlapping entries.
+
+These all fit into the existing structure; they’re refinements of scoring and filtering, not a new policy type.
+
+## Reading Order and LTR/RTL
+
+We want reading order and directional movement to agree with locale expectations where it matters, without complicating the core `FocusPolicy` trait.
+
+### Linear reading order
+
+Current:
+
+- Linear reading order is (row, column) with row = `rect.y0`, column = `rect.x0` ascending.
+- This matches LTR languages but not RTL.
+
+Design direction:
+
+- Introduce a simple reading-direction parameter at the policy or scope level:
+
+  ```rust
+  pub enum ReadingDirection {
+      Ltr,
+      Rtl,
+  }
+  ```
+
+- For linear ordering:
+  - Always sort by `y0` ascending first (top to bottom).
+  - For columns:
+    - LTR: `x0` ascending.
+    - RTL: `x0` descending.
+
+  This keeps the vertical “line” concept intact while flipping left/right expectations.
+
+### Interaction with directional arrows
+
+We don’t want directional behavior to become locale-dependent in a surprising way, but there are a couple of reasonable alignments:
+
+- Horizontal arrows:
+
+  - In LTR:
+    - `Right` tends to feel like `Next` along a row.
+    - `Left` tends to feel like `Prev`.
+  - In RTL:
+    - `Left` tends to feel like `Next`.
+    - `Right` tends to feel like `Prev`.
+
+  We **do not** plan to swap arrow meanings by locale; instead:
+
+  - The hemiplane filter and scoring continue to operate in the geometric coordinate system.
+  - The *fallback* mapping to linear order can consider reading direction:
+    - For example, in RTL, `Right` might fall back to linear `Prev` if blocked, while `Left` falls back to `Next`, mirroring the role of arrows in LTR.
+
+- Vertical arrows:
+
+  - Vertical behavior (`Up`/`Down`) is mostly unaffected by LTR/RTL.
+  - They continue to work in terms of rows (y-axis) with the same hemiplane and scoring logic.
+
+### Where to store reading direction
+
+We do **not** want to bake a `ReadingDirection` into `FocusSpace` itself. Instead:
+
+- Reading direction is a property of:
+  - The *scope* (e.g., a container, panel, or surface).
+  - Or the `DefaultPolicy` configuration used for that scope.
+
+Possible shapes:
+
+- `DefaultPolicy::new(reading: ReadingDirection, wrap: WrapMode)`:
+  - Keeps a `ReadingDirection` internally.
+  - Uses it in `compare_linear` and in deciding the linear fallback for horizontal arrows.
+
+This lets callers choose direction per scope without touching the trait signature.
+
+## Plan of Record
+
+Short-term (what we have now):
+
+- Keep the current behavior:
+  - Hemiplane + weighted Manhattan distance for arrows (with a fixed weight).
+  - LTR-only reading order using `(y0, x0)` for linear traversal.
+  - Locale-agnostic arrow semantics with simple linear fallback.
+- Make sure tests cover:
+  - Directional movement between three or more entries (already done in `focus_basics`).
+  - Fallback behavior when the hemiplane is empty.
+
+Next steps (non-breaking refinements):
+
+- Introduce `ReadingDirection` and a `DefaultPolicy::new(..)` constructor with:
+  - Internal fields for `reading_direction` and `wrap`.
+  - Adjust `compare_linear` to flip the column ordering in RTL.
+  - Optionally adjust horizontal directional *fallback* mapping to align better with reading order.
+- Expose a score weight parameter on `DefaultPolicy` (e.g., via constructor or builder) to make directional tuning explicit.
+
+Longer-term:
+
+- Only consider more advanced features (cones, softened hemiplane, row/column snapping) once we have real-world layouts (e.g., masonry grids, multi-row menus) that demonstrate a need.
+- If those needs are grid-specific and significantly different, address them in a dedicated policy (see `GridDirectionalPolicy` in `issue_focus_navigation_and_policies.md`) rather than complicating `DefaultPolicy`.
+
+Non-goals:
+
+- No locale-aware bidi text analysis in the focus layer; reading direction is a coarse per-scope setting.
+- Do not swap arrow semantics (e.g., treat “Right” as “Up”) based on locale; arrows continue to be geometric operations with simple locale-aware fallbacks.

--- a/docs/issue_focus_navigation_and_policies.md
+++ b/docs/issue_focus_navigation_and_policies.md
@@ -1,0 +1,233 @@
+# Understory Focus Navigation & Policies Plan
+
+This document records the current design for focus navigation in Understory and how we intend to evolve focus policies over time. It ties together:
+
+- `understory_box_tree` for geometry and focusable flags.
+- `understory_focus` for focus spaces and navigation policies.
+- `understory_responder` for focus paths and enter/leave events.
+
+The goal is predictable, testable focus behavior without pushing high‑level policy into the geometry layer.
+
+## Current State
+
+### Geometry and focusability
+
+- `understory_box_tree`:
+  - Nodes carry `NodeFlags`, including `FOCUSABLE`.
+  - `QueryFilter` supports `.visible().pickable().focusable()`.
+  - `Tree` exposes:
+    - `world_bounds(NodeId)` for world‑space AABBs.
+    - Structural helpers: `parent_of`, `children_of`, `next_depth_first`, `prev_depth_first`.
+  - The box tree stays focused on geometry and spatial indexing; it does not know about focus order or keyboard policies.
+
+### Focus state and routing
+
+- `understory_responder`:
+  - `FocusState<K>` tracks the current root→target focus path and emits `FocusEvent::{Enter,Leave}` transitions when the path changes.
+  - `Router::dispatch_for` routes a keyboard/IME event along the focus path (capture → target → bubble).
+  - The responder is agnostic about *how* the next focus target is chosen; it expects a node id and a path.
+
+### Focus navigation crate
+
+- `understory_focus`:
+  - Models focus navigation as:
+    - `Navigation` intents (Next, Prev, Up, Down, Left, Right, EnterScope, ExitScope).
+    - `FocusProps` per node (enabled, order, group, autofocus, policy_hint).
+    - `FocusEntry<K>` and `FocusSpace<'a, K>`: a snapshot of focusable candidates with geometry.
+    - `FocusPolicy<K>`: trait for policies that pick the next node given an origin, direction, and `FocusSpace`.
+    - `DefaultPolicy` as the main, shipping policy implementation.
+  - `adapters::box_tree` (behind `box_tree_adapter` feature) converts a `Tree` subtree into a `FocusSpace<NodeId>` by:
+    - Traversing a scope subtree.
+    - Filtering to visible + focusable + enabled nodes.
+    - Using `world_bounds` for `FocusEntry::rect`.
+
+## Policy Abstraction
+
+### FocusPolicy and FocusSpace
+
+- `FocusPolicy<K>`:
+  - `fn next(&self, origin: K, direction: Navigation, space: &FocusSpace<'_, K>) -> Option<K>;`
+  - Generic over `K` so callers can use `understory_box_tree::NodeId` or any other id type.
+- `FocusSpace<'a, K>`:
+  - Holds a slice of `FocusEntry<K>`.
+  - All entries share the same coordinate space (e.g., box‑tree world space or scope‑local space).
+- `FocusEntry<K>`:
+  - `id: K`
+  - `rect: kurbo::Rect` in the focus space’s coordinate system.
+  - `order: Option<i32>` (explicit order override).
+  - `group: Option<FocusSymbol>` (for clustering).
+  - `enabled: bool`
+  - `scope_depth: u8` (relative depth inside the current scope).
+
+### FocusProps and FocusSymbol
+
+- `FocusProps` is the host‑side description of a node’s focus intent:
+  - `enabled`: whether the node participates in focus traversal.
+  - `order`: optional explicit ordering key for reading‑order policies.
+  - `group`: optional `FocusSymbol` for partitioning.
+  - `autofocus`: whether the node is a candidate for initial focus in a scope.
+  - `policy_hint`: optional `FocusSymbol` to steer policy choice per scope.
+- `FocusSymbol(u64)` is intentionally minimal:
+  - Hosts decide how to create and manage symbols (interned strings, enums, static constants).
+  - Typical uses:
+    - `group`: keep navigation within a logical cluster (grid, toolbar, inspector section).
+    - `policy_hint`: mark containers for a particular traversal style (reading‑order vs. grid‑like).
+
+## Default Policy Behavior
+
+`DefaultPolicy` is intended to be the main “just do the obvious thing” implementation. It composes a couple of behaviors:
+
+- Linear traversal (`Navigation::Next` / `Prev`):
+  - Builds a list of enabled entries from the `FocusSpace`.
+  - Sorts by:
+    1. `order` when present (lower first).
+    2. Otherwise, reading order: `(y0, x0)` in the focus space’s coordinate system.
+  - `Next` moves forward; `Prev` moves backward.
+  - `WrapMode` controls whether traversal wraps within the scope or stops at edges.
+
+- Directional traversal (`Up`, `Down`, `Left`, `Right`):
+  - Finds the origin entry (must be enabled).
+  - Uses centers of `rect` to compute deltas.
+  - Restricts to the forward hemiplane for the requested direction.
+  - Scores candidates using a simple “distance + heading penalty” heuristic:
+    - `score = |primary| + 4 * |secondary|`
+    - Prefers closer, more aligned candidates along the chosen axis.
+  - If no candidate survives the hemiplane filter, falls back to the linear behavior:
+    - Arrows map to linear `Prev`/`Next` with wrap honoring `WrapMode`.
+
+- Scope enter/exit (`EnterScope`, `ExitScope`):
+  - `DefaultPolicy` does not change focus on these; they are treated as higher‑level intents that a scope controller should interpret.
+
+## Should We Have More Than One Policy Impl?
+
+Short answer: yes, but we want to keep the set small and intentional.
+
+The trait abstraction allows many policies, but we want:
+
+- A single, ergonomic default (`DefaultPolicy`) that covers common cases.
+- A small number of additional concrete policies only when we have clear, distinct needs that are hard to express as configuration on `DefaultPolicy`.
+- Policy *selection* handled by a higher‑level “focus manager” rather than exploding the type surface.
+
+### DefaultPolicy (shipping today)
+
+- Recommended default for most scopes.
+- Composite behavior:
+  - Reading‑order + `order` for `Next`/`Prev`.
+  - Directional scoring + hemiplane filtering for arrows, with linear fallback.
+  - Wrap behavior via `WrapMode`.
+- Does **not** currently interpret `group` or `policy_hint` directly; these are left for higher‑level orchestration (see plan below).
+
+### Candidate future policies
+
+We foresee two likely additions if/when real use‑cases demand them:
+
+1. **ReadingOrderPolicy**
+   - Purpose: minimal, predictable focus order where geometry is secondary.
+   - Behavior:
+     - `Next`/`Prev` purely by `(order, y, x)`; ignores directional scoring entirely.
+     - Arrows either alias to `Next`/`Prev` or are left to higher layers.
+   - Use cases: forms, dialogs, and other “reading order is king” screens; tests that want a very simple model.
+
+2. **GridDirectionalPolicy**
+   - Purpose: tuned for grid/masonry layouts where row/column adjacency matters more than raw distance.
+   - Behavior sketch:
+     - Favors candidates sharing row/column with the origin when moving along corresponding axes.
+     - Uses `group` (e.g., a `GRID` symbol) to avoid jumping out of the grid until the user explicitly exits the scope.
+     - May ignore `order` entirely in favor of geometric adjacency.
+   - Use cases: dense grids, masonry layouts, or TV‑style focus where arrows need to feel “snappy” and localized.
+
+We will only add these once we have concrete usage (e.g., a masonry grid demo or a complex form) that shows `DefaultPolicy` is not sufficient or becomes too complex to tune via configuration.
+
+## Policy Selection and Focus Manager
+
+We do **not** plan to bake policy selection logic into `understory_focus` itself. Instead:
+
+- A host‑side “focus manager” or scope controller is responsible for:
+  - Building `FocusSpace` instances (e.g., via the box‑tree adapter).
+  - Choosing a `FocusPolicy` implementation per scope.
+  - Feeding navigation intents into the chosen policy.
+  - Converting the resulting node id into a root→target path and updating `FocusState`.
+  - Using `Router::dispatch_for` to route key events along the updated focus path.
+
+Policy selection can use:
+
+- `FocusProps::policy_hint`:
+  - Example: if the container’s props include `HINT_GRID_POLICY`, use `GridDirectionalPolicy` for that scope; otherwise `DefaultPolicy`.
+- `FocusProps::group`:
+  - Example: only consider candidates with the same `group` as the current focus when using a grid policy.
+
+This keeps `understory_focus` small and composable, while allowing toolkit/framework code to encode richer semantics.
+
+## Plan and Next Steps
+
+### Phase 1 (done)
+
+- Introduce `understory_focus`:
+  - `Navigation`, `FocusProps`, `FocusSymbol`, `FocusEntry`, `FocusSpace`, `WrapMode`, `FocusPolicy`.
+  - `DefaultPolicy` with linear + directional behavior and wrap.
+  - `adapters::box_tree::build_focus_space_for_scope`.
+- Add unit tests for `DefaultPolicy` (linear order, disabled skipping, wrap/no‑wrap, directional behavior).
+- Add adapter tests that exercise `Tree` → `FocusSpace` → `DefaultPolicy` end‑to‑end.
+
+### Phase 2 (short‑term)
+
+- Integrate `understory_focus` into the examples:
+  - Extend the `responder_ui_events_bridge` example (or a new one) to:
+    - Maintain `FocusProps` for `NodeId`s.
+    - Build a `FocusSpace` for the active scope from the box tree.
+    - Use `DefaultPolicy::next` to select next focus on Tab/arrow keys.
+    - Update `FocusState` and route via `Router::dispatch_for`.
+  - Add golden tests that assert focus traversal sequences over small layouts (including a simple grid).
+
+### Phase 3 (medium‑term)
+
+- Evaluate the need for additional policies based on real usage:
+  - If we see patterns where “reading order only” is needed, add `ReadingOrderPolicy`.
+  - Once we have a masonry/grid demo, consider `GridDirectionalPolicy` with group‑aware behavior.
+- Keep the underlying `FocusPolicy` trait stable; policy types can be added without breaking callers.
+
+### Non‑Goals
+
+- The box tree will not gain focus‑specific policies or logic beyond `NodeFlags::FOCUSABLE`.
+- `understory_focus` will not embed toolkit‑specific notions of widgets, roles, or a11y attributes; those integrate via AccessKit and higher layers.
+- We will not introduce a large family of policies; the intention is a small set of well‑defined building blocks plus host‑side orchestration.
+
+## Implementation Notes
+
+For now, `understory_focus` keeps its core types and `DefaultPolicy` implementation together in
+`src/lib.rs`. This keeps the crate easy to scan while the API and policy set are still small.
+
+If and when we add additional concrete policies (`ReadingOrderPolicy`, `GridDirectionalPolicy`)
+or more substantial helper code, we expect to split the implementation into submodules along
+roughly these lines:
+
+- `lib.rs`: crate docs, `Navigation`, `FocusSymbol`, `FocusProps`, `FocusEntry`, `FocusSpace`,
+  `WrapMode`, `FocusPolicy`, and re-exports.
+- `policy/default.rs`: `DefaultPolicy` and its helpers/tests.
+- `policy/reading_order.rs`, `policy/grid.rs`: future policy implementations, only if needed.
+
+This is a non-goal for the first iteration; the intent is to refactor only once we have real
+usage that justifies the extra structure.
+
+### Candidate Sets and Performance
+
+`DefaultPolicy` currently operates over a `FocusSpace<'a, K>` that exposes `&[FocusEntry<K>]`.
+Callers are expected to:
+
+- Build this space per **scope** (window/panel/toolbar), not for the entire application.
+- Use a reusable buffer (e.g., `Vec<FocusEntry<_>>` cleared and refilled as needed).
+- Prune aggressively at the adapter level (for example, only visible + focusable + enabled nodes,
+  and typically only nodes within the active viewport).
+
+This push-style API is intentionally simple and adequate for most UIs. If we encounter real
+workloads where even per-scope `FocusSpace` materialization becomes too expensive, we can add
+an additional, more pull-friendly abstraction without breaking existing code, for example:
+
+- A `FocusSource<K>` trait that yields `FocusEntry<K>`s on demand (with `FocusSpace` as one
+  implementation).
+- Or a “IDs + lookup” model where the policy iterates `&[K]` and pulls geometry/props via a
+  `FocusLookup<K>` trait.
+
+We are **not** committing to either shape yet; the plan is to keep the current `FocusSpace`
+API, measure real usage, and only introduce a pull-based source abstraction if and when it
+is clearly justified.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,7 @@ understory_responder = { path = "../understory_responder", features = [
   "box_tree_adapter",
   "std",
 ] }
-understory_box_tree = { path = "../understory_box_tree" }
-understory_index = { path = "../understory_index" }
 kurbo = { workspace = true, default-features = true }
+understory_box_tree = { path = "../understory_box_tree" }
+understory_focus = { path = "../understory_focus" }
+understory_index = { path = "../understory_index" }

--- a/examples/examples/focus_basics.rs
+++ b/examples/examples/focus_basics.rs
@@ -1,0 +1,66 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Focus policy basics.
+//!
+//! Demonstrate driving focus over a tiny 2D layout using `understory_focus`.
+//!
+//! Run:
+//! - `cargo run -p understory_examples --example focus_basics`
+
+use kurbo::Rect;
+use understory_focus::{DefaultPolicy, FocusEntry, FocusPolicy, FocusSpace, Navigation, WrapMode};
+
+fn main() {
+    // Three buttons laid out left-to-right.
+    let entries = vec![
+        FocusEntry {
+            id: "left",
+            rect: Rect::new(0.0, 0.0, 80.0, 40.0),
+            order: None,
+            group: None,
+            enabled: true,
+            scope_depth: 0,
+        },
+        FocusEntry {
+            id: "center",
+            rect: Rect::new(90.0, 0.0, 170.0, 40.0),
+            order: None,
+            group: None,
+            enabled: true,
+            scope_depth: 0,
+        },
+        FocusEntry {
+            id: "right",
+            rect: Rect::new(180.0, 0.0, 260.0, 40.0),
+            order: None,
+            group: None,
+            enabled: true,
+            scope_depth: 0,
+        },
+    ];
+
+    let space = FocusSpace { nodes: &entries };
+    let policy = DefaultPolicy {
+        wrap: WrapMode::Scope,
+    };
+
+    let mut current = "left";
+    println!("Start focus at: {current}");
+
+    for nav in [
+        Navigation::Right, // left -> center (directional)
+        Navigation::Left,  // center -> left (directional)
+        Navigation::Next,  // left -> center (linear)
+        Navigation::Next,  // center -> right (linear)
+        Navigation::Prev,  // right -> center (linear backward)
+        Navigation::Prev,  // center -> left (linear backward)
+    ] {
+        if let Some(next) = policy.next(current, nav, &space) {
+            println!("{nav:?}: {current} -> {next}");
+            current = next;
+        } else {
+            println!("{nav:?}: {current} (no change)");
+        }
+    }
+}

--- a/understory_focus/Cargo.toml
+++ b/understory_focus/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "understory_focus"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Focus navigation primitives for Understory: ordering, directional policies, and scopes."
+keywords = ["ui", "focus", "navigation", "no_std", "understory"]
+categories = ["gui", "data-structures"]
+
+[dependencies]
+kurbo.workspace = true
+understory_box_tree = { path = "../understory_box_tree", default-features = false, optional = true }
+understory_index = { path = "../understory_index", optional = true }
+
+[lints]
+workspace = true
+
+[features]
+# Default to std builds for examples/tests/docs.
+default = ["std"]
+# Forward our `std`/`libm` features to Kurbo. With workspace `kurbo` having
+# default-features = false, this fully controls Kurbo's std/no_std mode.
+std = ["kurbo/std"]
+libm = ["kurbo/libm"]
+# Adapter for `understory_box_tree::Tree` → `FocusSpace`.
+box_tree_adapter = ["dep:understory_box_tree", "dep:understory_index"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_focus/LICENSE-APACHE
+++ b/understory_focus/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/understory_focus/LICENSE-MIT
+++ b/understory_focus/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/understory_focus/README.md
+++ b/understory_focus/README.md
@@ -1,0 +1,137 @@
+<div align="center">
+
+# Understory Focus
+
+**Focus navigation primitives for Understory**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_focus.svg)](https://crates.io/crates/understory_focus)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_focus.svg)](https://docs.rs/understory_focus)
+[![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/endoli/understory/ci.yml?logo=github&label=CI)](https://github.com/endoli/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_focus
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Understory Focus: focus navigation primitives.
+
+This crate models focus navigation as a combination of:
+- **Navigation intents** ([`Navigation`]) such as [`Navigation::Next`], [`Navigation::Prev`],
+  or arrow directions.
+- **Per-node focus properties** ([`FocusProps`]) such as enabled state, explicit order, and
+  optional grouping or policy hints.
+- A **spatial view of candidates** ([`FocusEntry`] / [`FocusSpace`]) that describes where
+  focusable nodes live in a chosen 2D coordinate space (for example, a surface/world space
+  or a container-local space).
+- Pluggable **policies** ([`FocusPolicy`]) that select the next focused node given an
+  origin, a direction, and a read-only view of focusable candidates.
+
+## Minimal example
+
+A simple focus loop over two buttons laid out left-to-right:
+
+```rust
+use kurbo::Rect;
+use understory_focus::{
+    DefaultPolicy, FocusEntry, FocusPolicy, FocusSpace, Navigation, WrapMode,
+};
+
+let entries = vec![
+    FocusEntry {
+        id: 1_u32,
+        rect: Rect::new(0.0, 0.0, 10.0, 10.0),
+        order: None,
+        group: None,
+        enabled: true,
+        scope_depth: 0,
+    },
+    FocusEntry {
+        id: 2_u32,
+        rect: Rect::new(20.0, 0.0, 30.0, 10.0),
+        order: None,
+        group: None,
+        enabled: true,
+        scope_depth: 0,
+    },
+];
+
+let space = FocusSpace { nodes: &entries };
+let policy = DefaultPolicy { wrap: WrapMode::Scope };
+
+// Tab moves from the first button to the second…
+assert_eq!(policy.next(1, Navigation::Next, &space), Some(2));
+// …and wraps back to the first.
+assert_eq!(policy.next(2, Navigation::Next, &space), Some(1));
+```
+
+## Patterns: groups and policy hints
+
+[`FocusSymbol`] is a small, copyable handle you can use to describe
+higher-level focus intent without baking policy into the geometry layer.
+
+- Use [`FocusProps::group`] to keep navigation within a logical cluster
+  (for example, a grid, toolbar, or inspector section) before jumping
+  elsewhere.
+- Use [`FocusProps::policy_hint`] to mark containers that should use a
+  specific traversal style (for example, reading-order vs. grid-like).
+
+```rust
+use understory_focus::{FocusProps, FocusSymbol};
+
+const GROUP_GRID: FocusSymbol = FocusSymbol(1);
+const HINT_GRID_POLICY: FocusSymbol = FocusSymbol(10);
+
+// A cell inside a grid: share GROUP_GRID so a policy can keep arrows
+// within the grid until the user explicitly exits the scope.
+let cell_props = FocusProps {
+    group: Some(GROUP_GRID),
+    ..FocusProps::default()
+};
+
+// The grid container itself: mark it with a policy hint so the host
+// can choose an appropriate FocusPolicy implementation.
+let grid_props = FocusProps {
+    policy_hint: Some(HINT_GRID_POLICY),
+    ..FocusProps::default()
+};
+```
+
+The core types are generic over the node identifier `K`, so callers can use any small,
+copyable handle (for example `understory_box_tree::NodeId` when used with the box tree,
+or an application-specific id).
+Geometry is expressed in terms of [`kurbo::Rect`], which matches the rest of the Understory
+crates and allows directional policies to reason about spatial layout. A [`FocusSpace`]
+should use a consistent coordinate space for all of its entries (for example, the world
+space of a box tree or the local space of a focus scope).
+
+## Features
+
+- `std` (default): enables `std` support for dependencies such as `kurbo`.
+- `libm`: enables `no_std` + `alloc` builds that rely on `libm` for floating-point math;
+  typically used when integrating into embedded or `no_std` environments.
+- `box_tree_adapter`: enables the [`adapters::box_tree`] module and pulls in
+  `understory_box_tree` and `understory_index` so you can build a [`FocusSpace`] directly
+  from an `understory_box_tree::Tree`.
+
+This crate is `no_std` and uses `alloc`.
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under the Apache License, Version 2.0 ([LICENSE] or <http://www.apache.org/licenses/LICENSE-2.0>)
+
+<!-- Needs to be defined here for rustdoc's benefit -->
+[LICENSE]: LICENSE

--- a/understory_focus/src/adapters.rs
+++ b/understory_focus/src/adapters.rs
@@ -1,0 +1,13 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Integration helpers for other Understory crates.
+//!
+//! Modules in this file are behind feature flags so `understory_focus` can
+//! remain usable in contexts that do not depend on those crates.
+//!
+//! - [`box_tree`] (`box_tree_adapter` feature): build [`crate::FocusSpace`]
+//!   views from an [`understory_box_tree::Tree`].
+
+#[cfg(feature = "box_tree_adapter")]
+pub mod box_tree;

--- a/understory_focus/src/adapters/box_tree.rs
+++ b/understory_focus/src/adapters/box_tree.rs
@@ -1,0 +1,281 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Box-tree adapter: build focus spaces from an `understory_box_tree::Tree`.
+//!
+//! This module converts box-tree structure and world-space bounds into
+//! [`crate::FocusEntry`] values suitable for focus policies.
+//! It treats a subtree rooted at a given [`understory_box_tree::NodeId`] as a
+//! focus scope and performs a depth-first traversal to collect candidates.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use kurbo::Rect;
+//! use understory_box_tree::{LocalNode, NodeFlags, Tree};
+//! use understory_focus::adapters::box_tree::build_focus_space_for_scope;
+//! use understory_focus::{DefaultPolicy, FocusPolicy, Navigation, WrapMode};
+//!
+//! // Build a tiny box tree: root with a single focusable child.
+//! let mut tree = Tree::new();
+//! let root = tree.insert(
+//!     None,
+//!     LocalNode {
+//!         local_bounds: Rect::new(0.0, 0.0, 200.0, 200.0),
+//!         flags: NodeFlags::VISIBLE,
+//!         ..LocalNode::default()
+//!     },
+//! );
+//! let button = tree.insert(
+//!     Some(root),
+//!     LocalNode {
+//!         local_bounds: Rect::new(20.0, 20.0, 80.0, 60.0),
+//!         flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+//!         ..LocalNode::default()
+//!     },
+//! );
+//! let _ = tree.commit();
+//!
+//! // Build a focus space for the subtree rooted at `root`.
+//! let mut buf = Vec::new();
+//! let space = build_focus_space_for_scope(&tree, root, &(), &mut buf);
+//! let policy = DefaultPolicy { wrap: WrapMode::Scope };
+//!
+//! // In this trivial case, "next" from the only focusable node just wraps.
+//! assert_eq!(policy.next(button, Navigation::Next, &space), Some(button));
+//! ```
+
+use alloc::vec::Vec;
+use understory_box_tree::{NodeFlags, NodeId, Tree};
+
+use crate::{FocusEntry, FocusProps, FocusSpace};
+
+/// Lookup for per-node [`FocusProps`].
+///
+/// Hosts can implement this trait over a `HashMap`, ECS storage, or any other
+/// mapping from node identifiers to focus properties. The adapter will fall
+/// back to [`FocusProps::default`] when a node has no entry.
+pub trait FocusPropsLookup<K> {
+    /// Return focus properties for the given node identifier.
+    fn props(&self, id: &K) -> FocusProps;
+}
+
+impl<K> FocusPropsLookup<K> for ()
+where
+    K: Copy,
+{
+    fn props(&self, _id: &K) -> FocusProps {
+        FocusProps::default()
+    }
+}
+
+/// Build a [`FocusSpace`] for a subtree rooted at `scope_root`.
+///
+/// - Traverses the box tree in depth-first order starting at `scope_root`.
+/// - Includes only nodes that are:
+///   - Live in the tree.
+///   - Marked focusable via [`NodeFlags::FOCUSABLE`].
+///   - Marked visible via [`NodeFlags::VISIBLE`] (to avoid focusing hidden nodes).
+///   - Enabled according to [`FocusProps::enabled`].
+/// - Uses [`Tree::world_bounds`](Tree::world_bounds) to populate `rect` and
+///   computes `scope_depth` relative to `scope_root` (root has depth 0).
+///
+/// The `out` buffer is cleared and reused to store [`FocusEntry`] values; the
+/// returned [`FocusSpace`] borrows from this buffer, so `out` must outlive the
+/// focus space.
+pub fn build_focus_space_for_scope<'a, B, P>(
+    tree: &Tree<B>,
+    scope_root: NodeId,
+    props_lookup: &P,
+    out: &'a mut Vec<FocusEntry<NodeId>>,
+) -> FocusSpace<'a, NodeId>
+where
+    B: understory_index::backend::Backend<f64>,
+    P: FocusPropsLookup<NodeId>,
+{
+    out.clear();
+
+    if !tree.is_alive(scope_root) {
+        return FocusSpace { nodes: &[] };
+    }
+
+    // Depth-first traversal with an explicit stack to stay within the subtree
+    // rooted at `scope_root`. Track depth relative to the scope root.
+    let mut stack: Vec<(NodeId, u8)> = Vec::new();
+    stack.push((scope_root, 0));
+
+    while let Some((id, depth)) = stack.pop() {
+        if !tree.is_alive(id) {
+            continue;
+        }
+
+        if let (Some(flags), Some(bounds)) = (tree.flags(id), tree.world_bounds(id)) {
+            let fp = props_lookup.props(&id);
+            let focusable = flags.contains(NodeFlags::FOCUSABLE);
+            let visible = flags.contains(NodeFlags::VISIBLE);
+            if focusable && visible && fp.enabled {
+                out.push(FocusEntry {
+                    id,
+                    rect: bounds,
+                    order: fp.order,
+                    group: fp.group,
+                    enabled: fp.enabled,
+                    scope_depth: depth,
+                });
+            }
+        }
+
+        // Push children in reverse order so the traversal of the stack matches
+        // the natural left-to-right order from the tree.
+        let children = tree.children_of(id);
+        let next_depth = depth.saturating_add(1);
+        for &child in children.iter().rev() {
+            stack.push((child, next_depth));
+        }
+    }
+
+    FocusSpace {
+        nodes: out.as_slice(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kurbo::Rect;
+    use understory_box_tree::LocalNode;
+
+    #[test]
+    fn builds_focus_space_for_focusable_nodes() {
+        let mut tree = Tree::new();
+
+        // Root: visible but not focusable.
+        let root = tree.insert(
+            None,
+            LocalNode {
+                flags: NodeFlags::VISIBLE,
+                ..LocalNode::default()
+            },
+        );
+        // Child A: visible + focusable.
+        let a = tree.insert(
+            Some(root),
+            LocalNode {
+                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                ..LocalNode::default()
+            },
+        );
+        // Child B: hidden.
+        let _b = tree.insert(
+            Some(root),
+            LocalNode {
+                flags: NodeFlags::empty(),
+                ..LocalNode::default()
+            },
+        );
+        let _ = tree.commit();
+
+        let mut buf = Vec::new();
+        let space = build_focus_space_for_scope(&tree, root, &(), &mut buf);
+
+        assert_eq!(space.nodes.len(), 1);
+        let entry = &space.nodes[0];
+        assert_eq!(entry.id, a);
+        assert!(entry.enabled);
+        assert_eq!(entry.scope_depth, 1);
+    }
+
+    #[test]
+    fn respects_custom_focus_props() {
+        let mut tree = Tree::new();
+        let root = tree.insert(
+            None,
+            LocalNode {
+                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                ..LocalNode::default()
+            },
+        );
+        let disabled_child = tree.insert(
+            Some(root),
+            LocalNode {
+                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                ..LocalNode::default()
+            },
+        );
+        let _ = tree.commit();
+
+        struct MapLookup {
+            disabled: NodeId,
+        }
+        impl FocusPropsLookup<NodeId> for MapLookup {
+            fn props(&self, id: &NodeId) -> FocusProps {
+                if *id == self.disabled {
+                    FocusProps {
+                        enabled: false,
+                        ..FocusProps::default()
+                    }
+                } else {
+                    FocusProps::default()
+                }
+            }
+        }
+
+        let lookup = MapLookup {
+            disabled: disabled_child,
+        };
+        let mut buf = Vec::new();
+        let space = build_focus_space_for_scope(&tree, root, &lookup, &mut buf);
+
+        // Root is focusable and enabled; disabled_child should be skipped.
+        assert_eq!(space.nodes.len(), 1);
+        assert_eq!(space.nodes[0].id, root);
+    }
+
+    #[test]
+    fn integration_tree_focus_space_and_policy() {
+        use crate::{DefaultPolicy, FocusPolicy, Navigation, WrapMode};
+
+        let mut tree = Tree::new();
+
+        // Root is visible but not focusable; children are visible + focusable.
+        let root = tree.insert(
+            None,
+            LocalNode {
+                local_bounds: Rect::new(0.0, 0.0, 200.0, 200.0),
+                flags: NodeFlags::VISIBLE,
+                ..LocalNode::default()
+            },
+        );
+        let left = tree.insert(
+            Some(root),
+            LocalNode {
+                local_bounds: Rect::new(10.0, 10.0, 40.0, 40.0),
+                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                ..LocalNode::default()
+            },
+        );
+        let right = tree.insert(
+            Some(root),
+            LocalNode {
+                local_bounds: Rect::new(80.0, 10.0, 110.0, 40.0),
+                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                ..LocalNode::default()
+            },
+        );
+        let _ = tree.commit();
+
+        // Build a focus space over the subtree rooted at `root`.
+        let mut buf = Vec::new();
+        let space = build_focus_space_for_scope(&tree, root, &(), &mut buf);
+        assert_eq!(space.nodes.len(), 2);
+
+        let policy = DefaultPolicy {
+            wrap: WrapMode::Scope,
+        };
+
+        // Linear "next" from left moves to right.
+        assert_eq!(policy.next(left, Navigation::Next, &space), Some(right));
+        // Directional "Right" from left also prefers the right-hand child.
+        assert_eq!(policy.next(left, Navigation::Right, &space), Some(right));
+    }
+}

--- a/understory_focus/src/lib.rs
+++ b/understory_focus/src/lib.rs
@@ -1,0 +1,691 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Understory Focus: focus navigation primitives.
+//!
+//! This crate models focus navigation as a combination of:
+//! - **Navigation intents** ([`Navigation`]) such as [`Navigation::Next`], [`Navigation::Prev`],
+//!   or arrow directions.
+//! - **Per-node focus properties** ([`FocusProps`]) such as enabled state, explicit order, and
+//!   optional grouping or policy hints.
+//! - A **spatial view of candidates** ([`FocusEntry`] / [`FocusSpace`]) that describes where
+//!   focusable nodes live in a chosen 2D coordinate space (for example, a surface/world space
+//!   or a container-local space).
+//! - Pluggable **policies** ([`FocusPolicy`]) that select the next focused node given an
+//!   origin, a direction, and a read-only view of focusable candidates.
+//!
+//! ## Minimal example
+//!
+//! A simple focus loop over two buttons laid out left-to-right:
+//!
+//! ```rust
+//! use kurbo::Rect;
+//! use understory_focus::{
+//!     DefaultPolicy, FocusEntry, FocusPolicy, FocusSpace, Navigation, WrapMode,
+//! };
+//!
+//! let entries = vec![
+//!     FocusEntry {
+//!         id: 1_u32,
+//!         rect: Rect::new(0.0, 0.0, 10.0, 10.0),
+//!         order: None,
+//!         group: None,
+//!         enabled: true,
+//!         scope_depth: 0,
+//!     },
+//!     FocusEntry {
+//!         id: 2_u32,
+//!         rect: Rect::new(20.0, 0.0, 30.0, 10.0),
+//!         order: None,
+//!         group: None,
+//!         enabled: true,
+//!         scope_depth: 0,
+//!     },
+//! ];
+//!
+//! let space = FocusSpace { nodes: &entries };
+//! let policy = DefaultPolicy { wrap: WrapMode::Scope };
+//!
+//! // Tab moves from the first button to the second…
+//! assert_eq!(policy.next(1, Navigation::Next, &space), Some(2));
+//! // …and wraps back to the first.
+//! assert_eq!(policy.next(2, Navigation::Next, &space), Some(1));
+//! ```
+//!
+//! ## Patterns: groups and policy hints
+//!
+//! [`FocusSymbol`] is a small, copyable handle you can use to describe
+//! higher-level focus intent without baking policy into the geometry layer.
+//!
+//! - Use [`FocusProps::group`] to keep navigation within a logical cluster
+//!   (for example, a grid, toolbar, or inspector section) before jumping
+//!   elsewhere.
+//! - Use [`FocusProps::policy_hint`] to mark containers that should use a
+//!   specific traversal style (for example, reading-order vs. grid-like).
+//!
+//! ```rust
+//! use understory_focus::{FocusProps, FocusSymbol};
+//!
+//! const GROUP_GRID: FocusSymbol = FocusSymbol(1);
+//! const HINT_GRID_POLICY: FocusSymbol = FocusSymbol(10);
+//!
+//! // A cell inside a grid: share GROUP_GRID so a policy can keep arrows
+//! // within the grid until the user explicitly exits the scope.
+//! let cell_props = FocusProps {
+//!     group: Some(GROUP_GRID),
+//!     ..FocusProps::default()
+//! };
+//!
+//! // The grid container itself: mark it with a policy hint so the host
+//! // can choose an appropriate FocusPolicy implementation.
+//! let grid_props = FocusProps {
+//!     policy_hint: Some(HINT_GRID_POLICY),
+//!     ..FocusProps::default()
+//! };
+//! ```
+//!
+//! The core types are generic over the node identifier `K`, so callers can use any small,
+//! copyable handle (for example `understory_box_tree::NodeId` when used with the box tree,
+//! or an application-specific id).
+//! Geometry is expressed in terms of [`kurbo::Rect`], which matches the rest of the Understory
+//! crates and allows directional policies to reason about spatial layout. A [`FocusSpace`]
+//! should use a consistent coordinate space for all of its entries (for example, the world
+//! space of a box tree or the local space of a focus scope).
+//!
+//! ## Features
+//!
+//! - `std` (default): enables `std` support for dependencies such as `kurbo`.
+//! - `libm`: enables `no_std` + `alloc` builds that rely on `libm` for floating-point math;
+//!   typically used when integrating into embedded or `no_std` environments.
+//! - `box_tree_adapter`: enables the [`adapters::box_tree`] module and pulls in
+//!   `understory_box_tree` and `understory_index` so you can build a [`FocusSpace`] directly
+//!   from an `understory_box_tree::Tree`.
+//!
+//! This crate is `no_std` and uses `alloc`.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+use kurbo::Rect;
+
+#[cfg(feature = "box_tree_adapter")]
+pub mod adapters;
+
+/// Direction of focus navigation.
+///
+/// These values represent high-level navigation intents such as Tab/Shift+Tab and
+/// arrow-key movement. Concrete policies interpret them according to their own rules.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Navigation {
+    /// Move to the next candidate in the container's forward order (for example, Tab).
+    Next,
+    /// Move to the previous candidate in the container's backward order (for example, Shift+Tab).
+    Prev,
+    /// Move in the up direction relative to the current focus.
+    Up,
+    /// Move in the down direction relative to the current focus.
+    Down,
+    /// Move in the left direction relative to the current focus.
+    Left,
+    /// Move in the right direction relative to the current focus.
+    Right,
+    /// Enter a child scope (for example, when Tab enters a composite widget or grid).
+    EnterScope,
+    /// Exit the current scope (for example, Escape returning to the parent scope).
+    ExitScope,
+}
+
+/// Symbol-like identifier used for grouping and policy hints.
+///
+/// This is a small, copyable handle that callers can use to partition focusable
+/// elements into groups or to select a traversal policy. The host is responsible
+/// for managing the meaning and lifecycle of individual symbols (for example via
+/// an interned string table, enum-to-symbol mapping, or static constants).
+///
+/// Typical uses:
+/// - As [`FocusProps::group`] to keep navigation within a logical cluster (for example,
+///   a grid or toolbar) before jumping elsewhere.
+/// - As [`FocusProps::policy_hint`] to indicate that a container prefers a specific
+///   traversal style (for example, reading-order vs. grid-like movement).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct FocusSymbol(pub u64);
+
+/// Per-node focus properties provided by the host.
+///
+/// These properties are layered on top of the underlying scene or box tree:
+/// they do not affect spatial indexing or hit testing directly, but are
+/// consulted by focus traversal policies.
+#[derive(Clone, Debug)]
+pub struct FocusProps {
+    /// Whether this node can be targeted by focus.
+    ///
+    /// Disabled nodes are skipped during focus traversal but may remain in the
+    /// spatial index for hit testing or layout purposes.
+    pub enabled: bool,
+    /// Optional explicit ordering key.
+    ///
+    /// When present, policies that support ordered traversal may sort candidates
+    /// by this value in addition to their geometric ordering.
+    pub order: Option<i32>,
+    /// Optional group identifier.
+    ///
+    /// Groups allow policies to partition focusable elements (for example, to
+    /// keep navigation within a grid or logical cluster).
+    pub group: Option<FocusSymbol>,
+    /// Whether this node should be considered as an initial focus candidate
+    /// when its containing scope is first activated.
+    pub autofocus: bool,
+    /// Optional policy hint.
+    ///
+    /// Callers can use this to indicate a preferred traversal policy for a
+    /// container or subtree (for example, "reading order", "grid", or "directional").
+    /// Interpretation is left to the host and the active policy implementation.
+    pub policy_hint: Option<FocusSymbol>,
+}
+
+impl Default for FocusProps {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            order: None,
+            group: None,
+            autofocus: false,
+            policy_hint: None,
+        }
+    }
+}
+
+/// A single focusable candidate within a [`FocusSpace`].
+///
+/// `FocusEntry` bundles the node identifier with its spatial bounds and
+/// effective focus-related properties. Policies operate over collections of
+/// these entries.
+#[derive(Clone, Debug)]
+pub struct FocusEntry<K> {
+    /// Identifier for this focusable node.
+    pub id: K,
+    /// Bounds in the coordinate space of the surrounding [`FocusSpace`].
+    ///
+    /// Callers are free to choose the coordinate space (for example, the
+    /// surface/world space of a box tree or a container-local space), but all
+    /// entries within a given [`FocusSpace`] should use the same space so that
+    /// directional policies can compare positions meaningfully.
+    pub rect: Rect,
+    /// Optional explicit ordering key.
+    pub order: Option<i32>,
+    /// Optional group identifier for partitioning.
+    pub group: Option<FocusSymbol>,
+    /// Whether this node is enabled for focus.
+    pub enabled: bool,
+    /// Depth of this node within the current focus scope.
+    ///
+    /// Policies can use this to refine ordering (for example, preferring
+    /// shallower nodes when multiple candidates overlap).
+    pub scope_depth: u8,
+}
+
+/// A read-only view of focusable candidates.
+///
+/// A `FocusSpace` is typically built by a higher-level adapter (for example,
+/// from an `understory_box_tree::Tree` plus an application-provided map of
+/// `FocusProps`). Policies should treat it as an immutable snapshot.
+#[derive(Clone, Debug)]
+pub struct FocusSpace<'a, K> {
+    /// Focusable candidates visible to the current scope and policy.
+    pub nodes: &'a [FocusEntry<K>],
+}
+
+/// Wrap mode configuration for focus traversal.
+///
+/// Policies may consult this to decide whether navigation should wrap around
+/// within a scope or stop at the edges.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum WrapMode {
+    /// Do not wrap; reaching the end of the sequence yields no next candidate.
+    Never,
+    /// Wrap within the current focus scope.
+    Scope,
+    /// Wrap globally across all visible scopes (policy-defined).
+    Global,
+}
+
+/// Trait for focus traversal policies.
+///
+/// A policy receives a navigation intent, the current origin node, and a
+/// read-only view of focusable candidates, and returns the next focused node
+/// if any. Implementations are free to use spatial reasoning, ordering keys,
+/// grouping, or scope depth as needed.
+pub trait FocusPolicy<K>
+where
+    K: Copy + Eq,
+{
+    /// Compute the next focus target given an origin, navigation intent, and focus space.
+    fn next(&self, origin: K, direction: Navigation, space: &FocusSpace<'_, K>) -> Option<K>;
+}
+
+/// Default focus traversal policy placeholder.
+///
+/// This type captures common configuration such as wrap mode; its behavior is
+/// intentionally minimal for now and may evolve as the focus system matures.
+#[derive(Copy, Clone, Debug)]
+pub struct DefaultPolicy {
+    /// Wrap behavior when traversing focusable candidates.
+    pub wrap: WrapMode,
+}
+
+impl Default for DefaultPolicy {
+    fn default() -> Self {
+        Self {
+            wrap: WrapMode::Scope,
+        }
+    }
+}
+
+impl<K> FocusPolicy<K> for DefaultPolicy
+where
+    K: Copy + Eq,
+{
+    fn next(&self, origin: K, direction: Navigation, space: &FocusSpace<'_, K>) -> Option<K> {
+        match direction {
+            Navigation::Next => next_linear(origin, space, self.wrap, Step::Forward),
+            Navigation::Prev => next_linear(origin, space, self.wrap, Step::Backward),
+            Navigation::Up | Navigation::Down | Navigation::Left | Navigation::Right => {
+                next_directional(origin, direction, space).or_else(|| {
+                    // Fallback to linear traversal if no directional candidate is found.
+                    let step = match direction {
+                        Navigation::Up | Navigation::Left => Step::Backward,
+                        Navigation::Down | Navigation::Right => Step::Forward,
+                        _ => Step::Forward,
+                    };
+                    next_linear(origin, space, self.wrap, step)
+                })
+            }
+            // Scope enter/exit are higher-level intents; the default policy does
+            // not change focus in response to them.
+            Navigation::EnterScope | Navigation::ExitScope => None,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+enum Step {
+    Forward,
+    Backward,
+}
+
+fn next_linear<K>(origin: K, space: &FocusSpace<'_, K>, wrap: WrapMode, step: Step) -> Option<K>
+where
+    K: Copy + Eq,
+{
+    let nodes = space.nodes;
+    if nodes.is_empty() {
+        return None;
+    }
+
+    // Collect enabled candidates and sort them by explicit order and
+    // reading order (y, then x).
+    let mut indices: Vec<usize> = nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(i, e)| e.enabled.then_some(i))
+        .collect();
+    if indices.is_empty() {
+        return None;
+    }
+
+    indices.sort_by(|&ia, &ib| compare_linear(&nodes[ia], &nodes[ib]));
+
+    // Locate the origin within the sorted candidates, if present.
+    let origin_pos = indices.iter().position(|&i| nodes[i].id == origin);
+
+    match step {
+        Step::Forward => match origin_pos {
+            Some(pos) => {
+                if pos + 1 < indices.len() {
+                    Some(nodes[indices[pos + 1]].id)
+                } else if matches!(wrap, WrapMode::Scope | WrapMode::Global) {
+                    Some(nodes[indices[0]].id)
+                } else {
+                    None
+                }
+            }
+            None => Some(nodes[indices[0]].id),
+        },
+        Step::Backward => match origin_pos {
+            Some(pos) => {
+                if pos > 0 {
+                    Some(nodes[indices[pos - 1]].id)
+                } else if matches!(wrap, WrapMode::Scope | WrapMode::Global) {
+                    Some(nodes[indices[indices.len() - 1]].id)
+                } else {
+                    None
+                }
+            }
+            None => Some(nodes[indices[indices.len() - 1]].id),
+        },
+    }
+}
+
+fn compare_linear<K>(a: &FocusEntry<K>, b: &FocusEntry<K>) -> Ordering {
+    // First, honor explicit order when present.
+    match (a.order, b.order) {
+        (Some(ao), Some(bo)) => ao
+            .cmp(&bo)
+            .then_with(|| compare_rect_reading(&a.rect, &b.rect)),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => compare_rect_reading(&a.rect, &b.rect),
+    }
+}
+
+fn compare_rect_reading(a: &Rect, b: &Rect) -> Ordering {
+    const EPS: f64 = 1e-6;
+    let ay = a.y0;
+    let by = b.y0;
+    if (ay - by).abs() > EPS {
+        return ay.partial_cmp(&by).unwrap_or(Ordering::Equal);
+    }
+    let ax = a.x0;
+    let bx = b.x0;
+    ax.partial_cmp(&bx).unwrap_or(Ordering::Equal)
+}
+
+fn next_directional<K>(origin: K, direction: Navigation, space: &FocusSpace<'_, K>) -> Option<K>
+where
+    K: Copy + Eq,
+{
+    let nodes = space.nodes;
+    if nodes.is_empty() {
+        return None;
+    }
+
+    let origin_entry = nodes.iter().find(|e| e.id == origin && e.enabled)?;
+    let oc = origin_entry.rect.center();
+
+    let mut best_idx: Option<usize> = None;
+    let mut best_score: f64 = f64::INFINITY;
+
+    for (i, candidate) in nodes.iter().enumerate() {
+        if !candidate.enabled || candidate.id == origin {
+            continue;
+        }
+        let cc = candidate.rect.center();
+        let dx = cc.x - oc.x;
+        let dy = cc.y - oc.y;
+
+        let (primary, secondary, forward_sign) = match direction {
+            Navigation::Right => (dx, dy, 1.0),
+            Navigation::Left => (dx, dy, -1.0),
+            Navigation::Down => (dy, dx, 1.0),
+            Navigation::Up => (dy, dx, -1.0),
+            _ => continue,
+        };
+
+        // Restrict to the forward hemiplane.
+        if forward_sign * primary <= 0.0 {
+            continue;
+        }
+
+        let abs_primary = primary.abs();
+        let abs_secondary = secondary.abs();
+        // Favor closer candidates and penalize off-axis motion.
+        let score = abs_primary + 4.0 * abs_secondary;
+
+        if !score.is_finite() {
+            continue;
+        }
+
+        if score < best_score {
+            best_score = score;
+            best_idx = Some(i);
+        }
+    }
+
+    best_idx.map(|i| nodes[i].id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn linear_next_prev_with_wrap() {
+        let entries = vec![
+            FocusEntry {
+                id: 1_u32,
+                rect: Rect::new(0.0, 0.0, 10.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+            FocusEntry {
+                id: 2_u32,
+                rect: Rect::new(20.0, 0.0, 30.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+        ];
+        let space = FocusSpace { nodes: &entries };
+        let policy = DefaultPolicy {
+            wrap: WrapMode::Scope,
+        };
+
+        assert_eq!(policy.next(1, Navigation::Next, &space), Some(2));
+        assert_eq!(policy.next(2, Navigation::Next, &space), Some(1));
+        assert_eq!(policy.next(1, Navigation::Prev, &space), Some(2));
+    }
+
+    #[test]
+    fn directional_prefers_forward_candidates() {
+        let entries = vec![
+            FocusEntry {
+                id: 1_u32,
+                rect: Rect::new(0.0, 0.0, 10.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+            // Right of origin.
+            FocusEntry {
+                id: 2_u32,
+                rect: Rect::new(20.0, 0.0, 30.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+            // Left of origin.
+            FocusEntry {
+                id: 3_u32,
+                rect: Rect::new(-30.0, 0.0, -20.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+        ];
+        let space = FocusSpace { nodes: &entries };
+        let policy = DefaultPolicy::default();
+
+        assert_eq!(policy.next(1, Navigation::Right, &space), Some(2));
+        assert_eq!(policy.next(1, Navigation::Left, &space), Some(3));
+    }
+
+    #[test]
+    fn linear_respects_explicit_order() {
+        let entries = vec![
+            FocusEntry {
+                id: 1_u32,
+                rect: Rect::new(20.0, 0.0, 30.0, 10.0),
+                order: Some(2),
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+            FocusEntry {
+                id: 2_u32,
+                rect: Rect::new(0.0, 0.0, 10.0, 10.0),
+                order: Some(1),
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+        ];
+        let space = FocusSpace { nodes: &entries };
+        let policy = DefaultPolicy {
+            wrap: WrapMode::Scope,
+        };
+
+        // Despite the reading-order geometry, explicit order should win.
+        assert_eq!(policy.next(2, Navigation::Next, &space), Some(1));
+        assert_eq!(policy.next(1, Navigation::Prev, &space), Some(2));
+    }
+
+    #[test]
+    fn linear_skips_disabled_entries() {
+        let entries = vec![
+            FocusEntry {
+                id: 1_u32,
+                rect: Rect::new(0.0, 0.0, 10.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+            FocusEntry {
+                id: 2_u32,
+                rect: Rect::new(20.0, 0.0, 30.0, 10.0),
+                order: None,
+                group: None,
+                enabled: false,
+                scope_depth: 0,
+            },
+            FocusEntry {
+                id: 3_u32,
+                rect: Rect::new(40.0, 0.0, 50.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+        ];
+        let space = FocusSpace { nodes: &entries };
+        let policy = DefaultPolicy {
+            wrap: WrapMode::Scope,
+        };
+
+        // Next from 1 should skip disabled 2 and go to 3.
+        assert_eq!(policy.next(1, Navigation::Next, &space), Some(3));
+        // Prev from 3 should skip disabled 2 and go back to 1.
+        assert_eq!(policy.next(3, Navigation::Prev, &space), Some(1));
+    }
+
+    #[test]
+    fn linear_no_wrap_stops_at_edges() {
+        let entries = vec![
+            FocusEntry {
+                id: 1_u32,
+                rect: Rect::new(0.0, 0.0, 10.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+            FocusEntry {
+                id: 2_u32,
+                rect: Rect::new(20.0, 0.0, 30.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+        ];
+        let space = FocusSpace { nodes: &entries };
+        let policy = DefaultPolicy {
+            wrap: WrapMode::Never,
+        };
+
+        assert_eq!(policy.next(2, Navigation::Next, &space), None);
+        assert_eq!(policy.next(1, Navigation::Prev, &space), None);
+    }
+
+    #[test]
+    fn directional_skips_disabled_and_self() {
+        let entries = vec![
+            FocusEntry {
+                id: 1_u32,
+                rect: Rect::new(0.0, 0.0, 10.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+            // Right but disabled.
+            FocusEntry {
+                id: 2_u32,
+                rect: Rect::new(20.0, 0.0, 30.0, 10.0),
+                order: None,
+                group: None,
+                enabled: false,
+                scope_depth: 0,
+            },
+            // Further right and enabled.
+            FocusEntry {
+                id: 3_u32,
+                rect: Rect::new(40.0, 0.0, 50.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+        ];
+        let space = FocusSpace { nodes: &entries };
+        let policy = DefaultPolicy::default();
+
+        // Right from 1 should skip disabled 2 and pick 3.
+        assert_eq!(policy.next(1, Navigation::Right, &space), Some(3));
+        // Left from 1 has no directional candidate, so it falls back to
+        // linear backward traversal with wrap, which selects 3.
+        assert_eq!(policy.next(1, Navigation::Left, &space), Some(3));
+    }
+
+    #[test]
+    fn directional_falls_back_to_linear_when_blocked() {
+        let entries = vec![
+            FocusEntry {
+                id: 1_u32,
+                rect: Rect::new(0.0, 0.0, 10.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+            // All candidates lie to the left of the origin.
+            FocusEntry {
+                id: 2_u32,
+                rect: Rect::new(-30.0, 0.0, -20.0, 10.0),
+                order: None,
+                group: None,
+                enabled: true,
+                scope_depth: 0,
+            },
+        ];
+        let space = FocusSpace { nodes: &entries };
+        let policy = DefaultPolicy {
+            wrap: WrapMode::Scope,
+        };
+
+        // Right finds no directional candidate, so it should fall back to
+        // linear "next", which wraps to id 2 in this two-element space.
+        assert_eq!(policy.next(1, Navigation::Right, &space), Some(2));
+    }
+}

--- a/understory_responder/src/focus.rs
+++ b/understory_responder/src/focus.rs
@@ -15,6 +15,37 @@
 //! assert_eq!(f.update_path(&[1, 2]), vec![FocusEvent::Enter(1), FocusEvent::Enter(2)]);
 //! assert_eq!(f.update_path(&[1, 3]), vec![FocusEvent::Leave(2), FocusEvent::Enter(3)]);
 //! ```
+//!
+//! ## With a spatial focus policy (conceptual)
+//!
+//! The focus state pairs naturally with a spatial policy (for example from the
+//! `understory_focus` crate):
+//!
+//! ```ignore
+//! use understory_focus::{DefaultPolicy, FocusEntry, FocusPolicy, FocusSpace, Navigation, WrapMode};
+//! use understory_responder::focus::{FocusEvent, FocusState};
+//!
+//! # type NodeId = u32;
+//! # let root: NodeId = 1;
+//! # let current: NodeId = 2;
+//! # let next: NodeId = 3;
+//! # let entries: Vec<FocusEntry<NodeId>> = Vec::new();
+//! // 1. Build a FocusSpace from your geometry layer (e.g., box tree).
+//! let space = FocusSpace { nodes: &entries };
+//! let policy = DefaultPolicy { wrap: WrapMode::Scope };
+//!
+//! // 2. Choose the next focused node based on navigation intent.
+//! let next = policy.next(current, Navigation::Right, &space).unwrap_or(current);
+//!
+//! // 3. Resolve the node id to a root→target path and feed it into FocusState.
+//! let mut focus_state: FocusState<NodeId> = FocusState::new();
+//! let new_path: Vec<NodeId> = vec![root, next];
+//! let events: Vec<FocusEvent<NodeId>> = focus_state.update_path(&new_path);
+//! # let _ = events;
+//! ```
+//!
+//! In a real application, this path would typically come from a parent lookup
+//! or a precomputed path table rather than a hard-coded vector.
 
 use alloc::vec::Vec;
 


### PR DESCRIPTION
- Add new `understory_focus` crate with `Navigation`, `FocusProps`, `FocusEntry`, `FocusSpace`, `FocusSymbol`, `WrapMode`, `FocusPolicy`, and `DefaultPolicy`.
- Implement directional + linear focus traversal in `DefaultPolicy` with wrap modes and unit tests.
- Add `adapters::box_tree::build_focus_space_for_scope` to derive `FocusSpace<NodeId>` from `understory_box_tree::Tree`, plus integration tests.
- Document crate features (`std`, `libm`, `box_tree_adapter`) and update README via `cargo-rdme` style docs.
- Add `examples/focus_basics.rs` to demonstrate focus traversal over a small layout.
- Record design and evolution plans in `docs/issue_focus_navigation_and_policies.md` and `docs/issue_focus_direction_and_reading_order.md`.