### PR TITLE
focus: make reading order `y` check use relative epsilon

### DIFF
--- a/docs/issue_focus_direction_and_reading_order.md
+++ b/docs/issue_focus_direction_and_reading_order.md
@@ -31,7 +31,7 @@ In `DefaultPolicy`:
   1. If both entries have `order: Some(i32)`, compare by `order` (lower first).
   2. Otherwise fall back to **reading order** defined as:
      - Compare by `rect.y0` (ascending).
-     - If `y0` is within a small epsilon, compare by `rect.x0` (ascending).
+     - If `y0` is within a small relative epsilon, compare by `rect.x0` (ascending).
 - Traversal:
   - `Next`: move forward in this sorted list.
   - `Prev`: move backward in this sorted list.

--- a/understory_focus/src/lib.rs
+++ b/understory_focus/src/lib.rs
@@ -383,10 +383,10 @@ fn compare_linear<K>(a: &FocusEntry<K>, b: &FocusEntry<K>) -> Ordering {
 }
 
 fn compare_rect_reading(a: &Rect, b: &Rect) -> Ordering {
-    const EPS: f64 = 1e-6;
+    const RELATIVE_EPS: f64 = 1e-6;
     let ay = a.y0;
     let by = b.y0;
-    if (ay - by).abs() > EPS {
+    if (ay - by).abs() > f64::max(ay.abs(), by.abs()) * RELATIVE_EPS {
         return ay.partial_cmp(&by).unwrap_or(Ordering::Equal);
     }
     let ax = a.x0;


### PR DESCRIPTION
For large magnitudes (e.g., stuff defined in `mm`) you'd want a higher epsilon than small magnitudes (e.g., stuff defined in `km`). Using a relative epsilon makes this somewhat more similar to a units-last-place check. This also still isn't perfect, as when both are placed around `0`, but one is slightly offset, this will treat the check as if we're working in a very, very small magnitude.

In `kurbo`, for these types of things users need to pass in an explicit tolerance, which in context of UIs can often be calculated as some fraction of the pixel size. That's something we could do here, too.