### PR TITLE
Add `understory_precise_hit` crate and 2D precise hit adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_MIN_VER: "1.88"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree -p understory_responder -p understory_focus"
+  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree -p understory_responder -p understory_focus -p understory_precise_hit"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default"
 
@@ -103,6 +103,9 @@ jobs:
 
       - name: check understory_box_tree README
         run: cargo rdme --workspace-project=understory_box_tree --heading-base-level=0 --check
+
+      - name: check understory_precise_hit README
+        run: cargo rdme --workspace-project=understory_precise_hit --heading-base-level=0 --check
 
       - name: check understory_responder README
         run: cargo rdme --workspace-project=understory_responder --heading-base-level=0 --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "understory_box_tree",
  "understory_focus",
  "understory_index",
+ "understory_precise_hit",
  "understory_responder",
 ]
 
@@ -529,11 +530,19 @@ name = "understory_index"
 version = "0.0.1"
 
 [[package]]
+name = "understory_precise_hit"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+]
+
+[[package]]
 name = "understory_responder"
 version = "0.1.0"
 dependencies = [
  "kurbo",
  "understory_box_tree",
+ "understory_precise_hit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "understory_index",
   "understory_box_tree",
   "understory_focus",
+  "understory_precise_hit",
   "understory_responder",
   "benches",
   "examples",

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Not a layout engine.
   - Upstream code (your layout system) decides sizes and positions and then updates this tree.
 
+- `understory_precise_hit`
+  - Geometry‑level, narrow‑phase hit testing for shapes in local 2D coordinates, built on `kurbo`.
+  - Provides a small `PreciseHitTest` trait with `HitParams`/`HitScore` helpers and default impls for `Rect`, `Circle`, `RoundedRect`, and fill‑only `BezPath`.
+  - Designed to be paired with a broad‑phase index (e.g. `understory_index` + `understory_box_tree`) and event routing (`understory_responder`), with rich metadata carried in responder `meta` types.
+
 - `understory_responder`
   - A deterministic event router that builds the responder chain sequence: capture → target → bubble.
   - Consumes pre‑resolved hits (from a picker or the box tree) and emits an ordered dispatch sequence.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,9 +7,11 @@ publish = false
 [dependencies]
 understory_responder = { path = "../understory_responder", features = [
   "box_tree_adapter",
+  "hit2d_adapter",
   "std",
 ] }
 kurbo = { workspace = true, default-features = true }
 understory_box_tree = { path = "../understory_box_tree" }
 understory_focus = { path = "../understory_focus" }
 understory_index = { path = "../understory_index" }
+understory_precise_hit = { path = "../understory_precise_hit" }

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,10 @@ These examples form a short, progressive walkthrough from routing basics to inte
   - Resolve hits from `understory_box_tree`, route them, and compute hover transitions. Includes a tiny ASCII tree and prints box rects and query coordinates.
   - Run: `cargo run -p understory_examples --example responder_box_tree`
 
+- responder_precise_hit
+  - Combine `understory_box_tree` (broad phase) with `understory_precise_hit` (precise geometry hits) and route the result through the responder.
+  - Run: `cargo run -p understory_examples --example responder_precise_hit`
+
 - responder_focus
   - Dispatch to focused target via `dispatch_for` and compute focus transitions with `FocusState`.
   - Run: `cargo run -p understory_examples --example responder_focus`

--- a/examples/examples/responder_precise_hit.rs
+++ b/examples/examples/responder_precise_hit.rs
@@ -1,0 +1,150 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Broad + narrow phase hit testing: box tree + `understory_precise_hit`.
+//!
+//! This example shows how to combine:
+//! - `understory_box_tree` for broad-phase AABB culling and z-order,
+//! - `understory_precise_hit` for precise local hit testing on geometry,
+//! - `understory_responder` for routing via `ResolvedHit`.
+//!
+//! Run:
+//! - `cargo run -p understory_examples --example responder_precise_hit`
+
+use std::collections::HashMap;
+
+use kurbo::{Affine, Circle, Point, Rect, Vec2};
+use understory_box_tree::{LocalNode, NodeFlags, NodeId, QueryFilter, Tree};
+use understory_precise_hit::{HitParams, HitScore, PreciseHitTest};
+use understory_responder::adapters::hit2d::{KeyHit, resolved_hits_from_precise};
+use understory_responder::dispatcher;
+use understory_responder::router::Router;
+use understory_responder::types::{Outcome, ResolvedHit, WidgetLookup};
+
+/// Simple scene data: each node has either a rect or a circle for precise hits.
+#[derive(Clone, Copy, Debug)]
+enum Shape {
+    Rect(Rect),
+    Circle(Circle),
+}
+
+/// Implement precise hit testing by delegating to the underlying geometry.
+impl PreciseHitTest for Shape {
+    fn hit_test_local(&self, pt: Point, params: &HitParams) -> Option<HitScore> {
+        match self {
+            Shape::Rect(r) => r.hit_test_local(pt, params),
+            Shape::Circle(c) => c.hit_test_local(pt, params),
+        }
+    }
+}
+
+fn main() {
+    // Build a small box tree with two children having different shapes.
+    let mut tree = Tree::new();
+
+    let root = tree.insert(
+        None,
+        LocalNode {
+            local_bounds: Rect::new(0.0, 0.0, 200.0, 200.0),
+            flags: NodeFlags::VISIBLE | NodeFlags::PICKABLE,
+            ..Default::default()
+        },
+    );
+
+    // Node A: axis-aligned rect.
+    let rect = Rect::new(20.0, 40.0, 120.0, 140.0);
+    let node_a = tree.insert(
+        Some(root),
+        LocalNode {
+            local_bounds: rect,
+            z_index: 0,
+            ..Default::default()
+        },
+    );
+
+    // Node B: circle translated to the right, same AABB size for illustration.
+    let circle = Circle::new((0.0, 0.0), 40.0);
+    let node_b = tree.insert(
+        Some(root),
+        LocalNode {
+            local_bounds: Rect::new(140.0, 40.0, 220.0, 140.0),
+            local_transform: Affine::translate(Vec2::new(180.0, 90.0)),
+            z_index: 5,
+            ..Default::default()
+        },
+    );
+
+    // Map NodeId → precise shape in local coordinates.
+    let mut shapes: HashMap<NodeId, Shape> = HashMap::new();
+    shapes.insert(node_a, Shape::Rect(rect));
+    shapes.insert(node_b, Shape::Circle(circle));
+
+    let _damage = tree.commit();
+
+    // Minimal lookup: echo NodeId as WidgetId.
+    struct Lookup;
+    impl WidgetLookup<NodeId> for Lookup {
+        type WidgetId = NodeId;
+        fn widget_of(&self, node: &NodeId) -> Option<Self::WidgetId> {
+            Some(*node)
+        }
+    }
+
+    let router: Router<NodeId, Lookup> = Router::new(Lookup);
+
+    // Query a few points and show how coarse box hits are refined by geometry.
+    let params = HitParams {
+        fill_tolerance: 2.0,
+        ..HitParams::default()
+    };
+    for (label, pt) in [
+        ("rect A interior", Point::new(30.0, 80.0)),
+        ("circle B interior", Point::new(200.0, 90.0)),
+        (
+            "coarse hit only (inside B AABB, outside circle)",
+            Point::new(150.0, 50.0),
+        ),
+    ] {
+        println!("\n== Query: {} @ ({:.1}, {:.1}) ==", label, pt.x, pt.y);
+
+        // Broad phase: candidate NodeIds whose AABB contains the world-space point.
+        let filter = QueryFilter::new().visible().pickable();
+        let broad_hits: Vec<NodeId> = tree
+            .intersect_rect(Rect::from_points(pt, pt), filter)
+            .collect();
+
+        println!("Broad-phase candidates: {:?}", broad_hits);
+
+        // Narrow phase: transform point into each node's local space and run precise hit.
+        let mut precise_candidates = Vec::new();
+        for id in &broad_hits {
+            if let Some(shape) = shapes.get(id)
+                && let Some(world_to_local) = tree.world_transform(*id).map(|tf| tf.inverse())
+            {
+                let local_pt = world_to_local * pt;
+                precise_candidates.push((*id, *shape, local_pt));
+            }
+        }
+
+        let mut key_hits: Vec<KeyHit<NodeId>> = Vec::new();
+        for (id, shape, local_pt) in precise_candidates {
+            if let Some(score) = shape.hit_test_local(local_pt, &params) {
+                key_hits.push(understory_responder::adapters::hit2d::KeyHit {
+                    key: id,
+                    distance: score.distance,
+                });
+            }
+        }
+
+        println!("Narrow-phase hits: {:?}", key_hits);
+
+        // Wrap into ResolvedHit and feed to the router.
+        let resolved: Vec<ResolvedHit<NodeId, ()>> = resolved_hits_from_precise(&key_hits);
+        let dispatch = router.handle_with_hits(&resolved);
+
+        let _ = dispatcher::run(&dispatch, &mut (), |d, _| {
+            println!("  {:?}  node={:?} widget={:?}", d.phase, d.node, d.widget);
+            Outcome::Continue
+        });
+    }
+}

--- a/understory_precise_hit/Cargo.toml
+++ b/understory_precise_hit/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "understory_precise_hit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Geometry-level precise hit testing helpers for Understory (kurbo-based)."
+keywords = ["hit-test", "geometry", "ui", "graphics"]
+categories = ["graphics", "no-std"]
+
+[features]
+default = ["std"]
+std = ["kurbo/std"]
+libm = ["kurbo/libm"]
+
+[dependencies]
+kurbo.workspace = true
+
+[lints]
+workspace = true

--- a/understory_precise_hit/LICENSE-APACHE
+++ b/understory_precise_hit/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/understory_precise_hit/LICENSE-MIT
+++ b/understory_precise_hit/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/understory_precise_hit/README.md
+++ b/understory_precise_hit/README.md
@@ -1,0 +1,99 @@
+<div align="center">
+
+# Understory Precise Hit
+
+**Geometry-level precise hit testing for 2D UI and graphics**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_precise_hit.svg)](https://crates.io/crates/understory_precise_hit)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_precise_hit.svg)](https://docs.rs/understory_precise_hit)
+[![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/endoli/understory/ci.yml?logo=github&label=CI)](https://github.com/endoli/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_precise_hit
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Geometry-level precise hit testing utilities.
+
+This crate provides small, reusable primitives for doing narrow-phase
+hit testing in local 2D coordinates, built on top of [`kurbo`]. It is
+intentionally decoupled from any particular scene tree or event router.
+
+# Typical usage
+
+- Use your own broad-phase index (e.g., `understory_index` or
+  `understory_box_tree`) to cull candidates.
+- Transform the query point into a shape's local coordinates.
+- Call [`PreciseHitTest::hit_test_local`] on the shape.
+- Use the returned [`HitScore`] only for *scoring and tie-breaking*.
+  Any rich metadata (segment indices, glyphs, winding info, etc.) should
+  be carried alongside the score in your own structures (for example as
+  the `meta` payload in a responder hit type).
+
+# Key types
+
+- [`HitParams`] – per-query parameters such as fill/stroke tolerances and
+  a hint for preferring fill vs stroke when both are possible.
+- [`HitScore`] – a small scoring record `{ distance, kind }` used for
+  ranking candidates. Lower distance is preferred; [`HitKind`] is a coarse
+  class (fill, stroke, handle, other).
+- [`PreciseHitTest`] – a trait implemented by shapes that can answer
+  “does this local-space point hit me?” queries.
+
+## Shapes and scope
+
+This crate includes [`PreciseHitTest`] implementations for several
+[`kurbo`] primitives:
+
+- [`Rect`] – axis-aligned rectangle, with configurable fill tolerance.
+- [`Circle`] – circle, treated as a filled disk.
+- [`RoundedRect`] – rounded rectangle, treated as a filled shape; tolerant
+  hits are based on its bounding box.
+- [`BezPath`] – **fill-only** path hit using [`kurbo::Shape::contains`].
+  The fill rule is whatever `kurbo` uses for `contains`; it is not
+  currently configurable here. Stroke hits for paths are intentionally left
+  to higher-level engines, which can wrap their own stroke representations
+  and still implement [`PreciseHitTest`].
+
+The [`stroke`] module provides helpers for stroke-oriented tests (for
+example, a simple [`stroke::StrokedLine`] type). These are minimal
+building blocks and not a full stroke model; engines are expected to build
+richer stroke behavior on top.
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>), or
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>),
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ../AUTHORS
+[LICENSE-APACHE]: LICENSE-APACHE
+[LICENSE-MIT]: LICENSE-MIT

--- a/understory_precise_hit/src/lib.rs
+++ b/understory_precise_hit/src/lib.rs
@@ -1,0 +1,406 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Geometry-level precise hit testing utilities.
+//!
+//! This crate provides small, reusable primitives for doing narrow-phase
+//! hit testing in local 2D coordinates, built on top of [`kurbo`]. It is
+//! intentionally decoupled from any particular scene tree or event router.
+//!
+//! # Typical usage
+//!
+//! - Use your own broad-phase index (e.g., `understory_index` or
+//!   `understory_box_tree`) to cull candidates.
+//! - Transform the query point into a shape's local coordinates.
+//! - Call [`PreciseHitTest::hit_test_local`] on the shape.
+//! - Use the returned [`HitScore`] only for *scoring and tie-breaking*.
+//!   Any rich metadata (segment indices, glyphs, winding info, etc.) should
+//!   be carried alongside the score in your own structures (for example as
+//!   the `meta` payload in a responder hit type).
+//!
+//! # Key types
+//!
+//! - [`HitParams`] – per-query parameters such as fill/stroke tolerances and
+//!   a hint for preferring fill vs stroke when both are possible.
+//! - [`HitScore`] – a small scoring record `{ distance, kind }` used for
+//!   ranking candidates. Lower distance is preferred; [`HitKind`] is a coarse
+//!   class (fill, stroke, handle, other).
+//! - [`PreciseHitTest`] – a trait implemented by shapes that can answer
+//!   “does this local-space point hit me?” queries.
+//!
+//! ## Shapes and scope
+//!
+//! This crate includes [`PreciseHitTest`] implementations for several
+//! [`kurbo`] primitives:
+//!
+//! - [`Rect`] – axis-aligned rectangle, with configurable fill tolerance.
+//! - [`Circle`] – circle, treated as a filled disk.
+//! - [`RoundedRect`] – rounded rectangle, treated as a filled shape; tolerant
+//!   hits are based on its bounding box.
+//! - [`BezPath`] – **fill-only** path hit using [`kurbo::Shape::contains`].
+//!   The fill rule is whatever `kurbo` uses for `contains`; it is not
+//!   currently configurable here. Stroke hits for paths are intentionally left
+//!   to higher-level engines, which can wrap their own stroke representations
+//!   and still implement [`PreciseHitTest`].
+//!
+//! The [`stroke`] module provides helpers for stroke-oriented tests (for
+//! example, a simple [`stroke::StrokedLine`] type). These are minimal
+//! building blocks and not a full stroke model; engines are expected to build
+//! richer stroke behavior on top.
+
+#![no_std]
+
+extern crate alloc;
+
+use core::cmp::Ordering;
+
+#[cfg(not(feature = "std"))]
+use kurbo::common::FloatFuncs as _;
+use kurbo::{BezPath, Circle, Point, Rect, RoundedRect, Shape};
+
+/// Stroke-oriented helpers and primitives.
+pub mod stroke;
+
+/// Kind of hit produced by a precise test.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HitKind {
+    /// Hit the interior/fill of a shape.
+    Fill,
+    /// Hit the stroked outline of a shape.
+    Stroke,
+    /// Hit a control handle or other auxiliary affordance.
+    Handle,
+    /// Hit, but kind is unspecified/other.
+    Other,
+}
+
+/// Parameters controlling precise hit tests.
+#[derive(Clone, Copy, Debug)]
+pub struct HitParams {
+    /// Tolerance in local units for hits against filled regions.
+    ///
+    /// This is typically used to slightly inflate shapes for touch/pointer
+    /// input or fuzzy selection, or to treat points very near the boundary
+    /// as hits.
+    pub fill_tolerance: f64,
+    /// Tolerance in local units for hits against stroked outlines.
+    ///
+    /// Engines that distinguish between fill and stroke hits can use this to
+    /// widen or narrow stroke pick regions independently of fill behavior.
+    pub stroke_tolerance: f64,
+    /// Prefer fill hits over stroke hits when both are possible at the same
+    /// location.
+    ///
+    /// This is a hint for callers when combining multiple `HitScore`s for the
+    /// same key; the trait itself does not enforce any policy.
+    pub prefer_fill: bool,
+}
+
+impl Default for HitParams {
+    fn default() -> Self {
+        Self {
+            fill_tolerance: 0.0,
+            stroke_tolerance: 0.0,
+            prefer_fill: true,
+        }
+    }
+}
+
+/// Score returned from a precise hit.
+///
+/// Lower distance is considered a better (closer) hit for tie-breaking.
+#[derive(Clone, Copy, Debug)]
+pub struct HitScore {
+    /// Geometric distance in local coordinate space.
+    pub distance: f64,
+    /// Classification of what was hit.
+    pub kind: HitKind,
+}
+
+impl HitScore {
+    /// Convenience constructor for a filled hit at distance 0.
+    pub const fn filled() -> Self {
+        Self {
+            distance: 0.0,
+            kind: HitKind::Fill,
+        }
+    }
+
+    /// Compare two scores, preferring smaller distance; ties keep original order.
+    pub fn cmp_distance(&self, other: &Self) -> Ordering {
+        self.distance
+            .partial_cmp(&other.distance)
+            .unwrap_or(Ordering::Equal)
+    }
+}
+
+/// Trait for precise 2D hit testing in local coordinates.
+///
+/// Implementors are free to use any strategy, but should treat the
+/// tolerances in [`HitParams`] as inclusive radii when appropriate.
+pub trait PreciseHitTest {
+    /// Perform a precise hit test against `pt` in the shape's local
+    /// coordinate space.
+    ///
+    /// Returns `Some(HitScore)` when the point is considered a hit.
+    fn hit_test_local(&self, pt: Point, params: &HitParams) -> Option<HitScore>;
+}
+
+/// Simple rectangular precise hit implementation.
+impl PreciseHitTest for Rect {
+    fn hit_test_local(&self, pt: Point, params: &HitParams) -> Option<HitScore> {
+        // Expand the rect by fill_tolerance on all sides for a near-miss hit.
+        let inflated = if params.fill_tolerance > 0.0 {
+            self.inflate(params.fill_tolerance, params.fill_tolerance)
+        } else {
+            *self
+        };
+        if inflated.contains(pt) {
+            // Use distance to the original rect edge as score; interior points are 0.
+            let dx = if pt.x < self.x0 {
+                self.x0 - pt.x
+            } else if pt.x > self.x1 {
+                pt.x - self.x1
+            } else {
+                0.0
+            };
+            let dy = if pt.y < self.y0 {
+                self.y0 - pt.y
+            } else if pt.y > self.y1 {
+                pt.y - self.y1
+            } else {
+                0.0
+            };
+            let dist = (dx * dx + dy * dy).sqrt();
+            Some(HitScore {
+                distance: dist,
+                kind: HitKind::Fill,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Precise hit implementation for circular shapes using [`Circle`].
+///
+/// The hit is considered a fill hit when the distance from the point to the
+/// center is within the radius plus tolerance.
+impl PreciseHitTest for Circle {
+    fn hit_test_local(&self, pt: Point, params: &HitParams) -> Option<HitScore> {
+        let center = self.center;
+        let dx = pt.x - center.x;
+        let dy = pt.y - center.y;
+        let dist = (dx * dx + dy * dy).sqrt();
+        let radius = self.radius;
+        let tol = params.fill_tolerance;
+        if dist <= radius + tol {
+            // Distance inside the circle is 0, outside is how far we exceeded the radius.
+            let distance = if dist <= radius { 0.0 } else { dist - radius };
+            Some(HitScore {
+                distance,
+                kind: HitKind::Fill,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Precise hit implementation for rounded rectangles using [`RoundedRect`].
+///
+/// This uses the shape's own `contains`/`bounding_box` implementation and
+/// applies `fill_tolerance` as an inflation on the bounding box for a simple
+/// near-miss behavior.
+impl PreciseHitTest for RoundedRect {
+    fn hit_test_local(&self, pt: Point, params: &HitParams) -> Option<HitScore> {
+        // First, reject quickly using the bounding box plus fill tolerance.
+        let bounds = self.bounding_box();
+        let inflated = if params.fill_tolerance > 0.0 {
+            bounds.inflate(params.fill_tolerance, params.fill_tolerance)
+        } else {
+            bounds
+        };
+        if !inflated.contains(pt) {
+            return None;
+        }
+
+        // Within the inflated bounds: treat `contains` as a filled hit.
+        if self.contains(pt) {
+            Some(HitScore::filled())
+        } else if params.fill_tolerance > 0.0 {
+            // For now we do not compute exact distance to the corner curves.
+            // Report a generic tolerant hit with distance equal to the
+            // configured tolerance.
+            Some(HitScore {
+                distance: params.fill_tolerance,
+                kind: HitKind::Fill,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Precise hit implementation for filled bezier paths using [`BezPath`].
+///
+/// This uses the path's `contains` and `bounding_box` methods for a fill-only
+/// hit test and applies `fill_tolerance` as an inflation on the bounding
+/// box for near-miss behavior.
+impl PreciseHitTest for BezPath {
+    fn hit_test_local(&self, pt: Point, params: &HitParams) -> Option<HitScore> {
+        let bounds = self.bounding_box();
+        let inflated = if params.fill_tolerance > 0.0 {
+            bounds.inflate(params.fill_tolerance, params.fill_tolerance)
+        } else {
+            bounds
+        };
+        if !inflated.contains(pt) {
+            return None;
+        }
+        if self.contains(pt) {
+            Some(HitScore::filled())
+        } else if params.fill_tolerance > 0.0 {
+            Some(HitScore {
+                distance: params.fill_tolerance,
+                kind: HitKind::Fill,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Generic precise hit test for any [`kurbo::Shape`].
+///
+/// This provides a fallback implementation using the shape's `contains` and
+/// `bounding_box` methods. We deliberately avoid a blanket `impl<T: Shape>` to
+/// make it straightforward for engines to provide their own specialized
+/// implementations without running into coherence issues.
+pub fn hit_test_shape<S: Shape>(shape: &S, pt: Point, params: &HitParams) -> Option<HitScore> {
+    let bounds = shape.bounding_box();
+    let inflated = if params.fill_tolerance > 0.0 {
+        bounds.inflate(params.fill_tolerance, params.fill_tolerance)
+    } else {
+        bounds
+    };
+
+    if !inflated.contains(pt) {
+        return None;
+    }
+
+    if shape.contains(pt) {
+        Some(HitScore::filled())
+    } else if params.fill_tolerance > 0.0 {
+        Some(HitScore {
+            distance: params.fill_tolerance,
+            kind: HitKind::Fill,
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stroke::StrokedLine;
+    use kurbo::{BezPath, Line, Rect, RoundedRect};
+
+    #[test]
+    fn rect_hit_inside() {
+        let r = Rect::new(0.0, 0.0, 10.0, 10.0);
+        let pt = Point::new(5.0, 5.0);
+        let score = r
+            .hit_test_local(pt, &HitParams::default())
+            .expect("expected hit");
+        assert_eq!(score.kind, HitKind::Fill);
+        assert_eq!(score.distance, 0.0);
+    }
+
+    #[test]
+    fn rect_miss_outside_without_tolerance() {
+        let r = Rect::new(0.0, 0.0, 10.0, 10.0);
+        let pt = Point::new(11.0, 5.0);
+        assert!(r.hit_test_local(pt, &HitParams::default()).is_none());
+    }
+
+    #[test]
+    fn rect_hit_with_tolerance() {
+        let r = Rect::new(0.0, 0.0, 10.0, 10.0);
+        let pt = Point::new(10.5, 5.0);
+        let score = r
+            .hit_test_local(
+                pt,
+                &HitParams {
+                    fill_tolerance: 1.0,
+                    ..HitParams::default()
+                },
+            )
+            .expect("expected tolerant hit");
+        assert!(score.distance > 0.0);
+    }
+
+    #[test]
+    fn circle_hit_and_miss() {
+        let c = Circle::new((0.0, 0.0), 5.0);
+        let inside = Point::new(1.0, 1.0);
+        let outside = Point::new(10.0, 0.0);
+
+        let inside_score = c
+            .hit_test_local(inside, &HitParams::default())
+            .expect("expected inside hit");
+        assert_eq!(inside_score.distance, 0.0);
+
+        assert!(c.hit_test_local(outside, &HitParams::default()).is_none());
+    }
+
+    #[test]
+    fn rounded_rect_hit_and_miss() {
+        let rect = Rect::new(0.0, 0.0, 10.0, 10.0);
+        let rr = RoundedRect::from_rect(rect, 2.0);
+        let inside = Point::new(5.0, 5.0);
+        let outside = Point::new(20.0, 20.0);
+
+        assert!(rr.hit_test_local(inside, &HitParams::default()).is_some());
+        assert!(rr.hit_test_local(outside, &HitParams::default()).is_none());
+    }
+
+    #[test]
+    fn bezpath_hit_within_bounds() {
+        let mut path = BezPath::new();
+        path.move_to((0.0, 0.0));
+        path.line_to((10.0, 0.0));
+        path.line_to((10.0, 10.0));
+        path.line_to((0.0, 10.0));
+        path.close_path();
+
+        let inside = Point::new(5.0, 5.0);
+        let outside = Point::new(20.0, 20.0);
+
+        assert!(path.hit_test_local(inside, &HitParams::default()).is_some());
+        assert!(
+            path.hit_test_local(outside, &HitParams::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn stroked_line_hit_and_miss() {
+        let line = Line::new((0.0, 0.0), (10.0, 0.0));
+        let stroked = StrokedLine {
+            line,
+            half_width: 1.0,
+        };
+
+        let center = Point::new(5.0, 0.0);
+        let near = Point::new(5.0, 0.5);
+        let outside = Point::new(5.0, 5.0);
+
+        let params = HitParams::default();
+
+        assert!(stroked.hit_test_local(center, &params).is_some());
+        assert!(stroked.hit_test_local(near, &params).is_some());
+        assert!(stroked.hit_test_local(outside, &params).is_none());
+    }
+}

--- a/understory_precise_hit/src/stroke.rs
+++ b/understory_precise_hit/src/stroke.rs
@@ -1,0 +1,85 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Stroke-oriented helpers for precise hit testing.
+//!
+//! These types are intentionally small building blocks rather than a full
+//! stroke model. Engines are expected to compose their own stroke behavior
+//! (joins, caps, variable width, etc.) on top of these primitives.
+
+#[cfg(not(feature = "std"))]
+use kurbo::common::FloatFuncs as _;
+use kurbo::{Line, Point};
+
+use crate::{HitKind, HitParams, HitScore, PreciseHitTest};
+
+/// A simple stroked line segment (centerline + half-width).
+///
+/// The precise hit test uses the distance from the query point to the line
+/// segment and compares it against the half-width plus
+/// [`HitParams::stroke_tolerance`]. This does not model joins, caps, or
+/// variable-width strokes; it is a minimal helper for straight segments.
+#[derive(Clone, Copy, Debug)]
+pub struct StrokedLine {
+    /// The centerline segment in local coordinates.
+    pub line: Line,
+    /// Half of the stroke width in local units.
+    pub half_width: f64,
+}
+
+impl PreciseHitTest for StrokedLine {
+    fn hit_test_local(&self, pt: Point, params: &HitParams) -> Option<HitScore> {
+        let p0 = self.line.p0;
+        let p1 = self.line.p1;
+        let vx = p1.x - p0.x;
+        let vy = p1.y - p0.y;
+        let wx = pt.x - p0.x;
+        let wy = pt.y - p0.y;
+        let len2 = vx * vx + vy * vy;
+        let t = if len2 > 0.0 {
+            (wx * vx + wy * vy) / len2
+        } else {
+            0.0
+        };
+        let t = t.clamp(0.0, 1.0);
+        let proj_x = p0.x + t * vx;
+        let proj_y = p0.y + t * vy;
+        let dx = pt.x - proj_x;
+        let dy = pt.y - proj_y;
+        let dist = (dx * dx + dy * dy).sqrt();
+
+        let limit = self.half_width + params.stroke_tolerance;
+        if dist <= limit {
+            Some(HitScore {
+                distance: dist,
+                kind: HitKind::Stroke,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stroked_line_hit_and_miss() {
+        let line = Line::new((0.0, 0.0), (10.0, 0.0));
+        let stroked = StrokedLine {
+            line,
+            half_width: 1.0,
+        };
+
+        let center = Point::new(5.0, 0.0);
+        let near = Point::new(5.0, 0.5);
+        let outside = Point::new(5.0, 5.0);
+
+        let params = HitParams::default();
+
+        assert!(stroked.hit_test_local(center, &params).is_some());
+        assert!(stroked.hit_test_local(near, &params).is_some());
+        assert!(stroked.hit_test_local(outside, &params).is_none());
+    }
+}

--- a/understory_responder/Cargo.toml
+++ b/understory_responder/Cargo.toml
@@ -11,15 +11,22 @@ categories = ["gui", "data-structures"]
 [features]
 default = []
 # Enable std mode for deps that support it.
-std = ["kurbo/std", "understory_box_tree/std"]
+std = ["kurbo/std", "understory_box_tree/std", "understory_precise_hit?/std"]
 # Enable no_std numeric support via libm for deps that support it.
-libm = ["kurbo/libm", "understory_box_tree/libm"]
+libm = [
+  "kurbo/libm",
+  "understory_box_tree/libm",
+  "understory_precise_hit?/libm",
+]
 # Adapter depends on box tree + kurbo; default to libm for no_std builds.
 box_tree_adapter = ["dep:understory_box_tree", "dep:kurbo", "libm"]
+# Adapter for precise 2D hit testing using `understory_precise_hit`.
+hit2d_adapter = ["dep:understory_precise_hit", "dep:kurbo"]
 
 [dependencies]
 understory_box_tree = { path = "../understory_box_tree", default-features = false, optional = true }
 kurbo = { workspace = true, default-features = false, optional = true }
+understory_precise_hit = { path = "../understory_precise_hit", default-features = false, optional = true }
 
 [lints]
 workspace = true

--- a/understory_responder/src/adapters/hit2d.rs
+++ b/understory_responder/src/adapters/hit2d.rs
@@ -1,0 +1,189 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Helpers for integrating 2D precise hit tests with the responder.
+//!
+//! This adapter is intentionally minimal: it bridges geometry-level
+//! [`understory_precise_hit::PreciseHitTest`] implementations with the responder's
+//! [`ResolvedHit`] type, without imposing a specific tree or index.
+
+use alloc::vec::Vec;
+
+use kurbo::Point;
+use understory_precise_hit::{HitParams, PreciseHitTest};
+
+use crate::types::{DepthKey, Localizer, ResolvedHit};
+
+/// Narrow-phase hit result for a single key.
+///
+/// The generic `K` is typically your node or widget identifier.
+#[derive(Clone, Debug)]
+pub struct KeyHit<K> {
+    /// The key that was hit (e.g., a `NodeId`).
+    pub key: K,
+    /// Distance score from the precise hit test.
+    pub distance: f64,
+}
+
+/// Convert a list of precise key hits into resolver hits for the router.
+///
+/// This helper is agnostic to any particular tree; it assumes the caller has
+/// already performed broad-phase culling and precise tests and simply wants
+/// a convenient way to produce `ResolvedHit` values.
+pub fn resolved_hits_from_precise<K>(hits: &[KeyHit<K>]) -> Vec<ResolvedHit<K, ()>>
+where
+    K: Copy,
+{
+    hits.iter()
+        .map(|h| ResolvedHit {
+            node: h.key,
+            path: None,
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "DepthKey uses f32; precision loss is acceptable for hit sorting."
+            )]
+            depth_key: DepthKey::Distance(h.distance as f32),
+            localizer: Localizer::default(),
+            meta: (),
+        })
+        .collect()
+}
+
+/// Run precise hit tests for a collection of shaped keys.
+///
+/// The caller supplies an iterator of `(key, shape)` pairs, where each shape
+/// implements [`PreciseHitTest`] in its local coordinate space and the
+/// provided `local_point` is already transformed into that space.
+pub fn precise_hits_for_point<K, S, I>(
+    candidates: I,
+    local_point: Point,
+    params: HitParams,
+) -> Vec<KeyHit<K>>
+where
+    K: Copy,
+    S: PreciseHitTest,
+    I: IntoIterator<Item = (K, S)>,
+{
+    let mut hits = Vec::new();
+    for (key, shape) in candidates {
+        if let Some(score) = shape.hit_test_local(local_point, &params) {
+            hits.push(KeyHit {
+                key,
+                distance: score.distance,
+            });
+        }
+    }
+    hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use understory_precise_hit::{HitKind, HitScore};
+
+    #[derive(Clone, Copy)]
+    struct TestShape(bool);
+
+    impl PreciseHitTest for TestShape {
+        fn hit_test_local(&self, _pt: Point, _params: &HitParams) -> Option<HitScore> {
+            if self.0 {
+                Some(HitScore {
+                    distance: 1.0,
+                    kind: HitKind::Fill,
+                })
+            } else {
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn empty_precise_hits() {
+        let hits: Vec<KeyHit<u32>> = precise_hits_for_point::<u32, TestShape, _>(
+            [(1, TestShape(false))],
+            Point::new(0.0, 0.0),
+            HitParams::default(),
+        );
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn resolved_hits_distance_mapping() {
+        let key_hits = vec![
+            KeyHit {
+                key: 1_u32,
+                distance: 2.0,
+            },
+            KeyHit {
+                key: 2_u32,
+                distance: 0.5,
+            },
+        ];
+        let resolved = resolved_hits_from_precise(&key_hits);
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].node, 1);
+        assert!(matches!(resolved[0].depth_key, DepthKey::Distance(d) if (d - 2.0).abs() < 1e-6));
+    }
+}
+
+// Integration-style test exercising a full broad → narrow flow with a box tree.
+//
+// This models the "coarse hit, precise miss" scenario: the box tree's AABB
+// contains the point, but the precise geometry test rejects it, so no hits
+// are produced for routing.
+#[cfg(all(test, feature = "box_tree_adapter"))]
+mod integration_tests {
+    use super::*;
+    use alloc::vec;
+    use kurbo::{Circle, Rect};
+    use understory_box_tree::{LocalNode, NodeFlags, QueryFilter, Tree};
+
+    #[test]
+    fn coarse_hit_rejected_by_precise_test() {
+        let mut tree = Tree::new();
+
+        // Single node whose AABB contains the query point.
+        let node = tree.insert(
+            None,
+            LocalNode {
+                local_bounds: Rect::new(-10.0, -10.0, 10.0, 10.0),
+                flags: NodeFlags::VISIBLE | NodeFlags::PICKABLE,
+                ..Default::default()
+            },
+        );
+        let _damage = tree.commit();
+
+        // Broad phase: point lies inside the node's bounds.
+        let pt = Point::new(9.0, 0.0);
+        let filter = QueryFilter::new().visible().pickable();
+        let candidates: Vec<_> = tree
+            .intersect_rect(Rect::from_points(pt, pt), filter)
+            .collect();
+        assert_eq!(candidates, vec![node]);
+
+        // Narrow phase: circle is strictly inside the rect; the query point is
+        // inside the rect AABB but outside the circle, so `hit_test_local` must
+        // return `None`.
+        let circle = Circle::new((0.0, 0.0), 5.0);
+        let local_pt = pt;
+        let params = HitParams::default();
+
+        // Direct check on the precise test.
+        assert!(
+            circle.hit_test_local(local_pt, &params).is_none(),
+            "point should be outside the precise geometry"
+        );
+
+        // Adapter flow: feed the same candidate through `precise_hits_for_point`.
+        let key_hits: Vec<KeyHit<_>> = precise_hits_for_point([(node, circle)], local_pt, params);
+        assert!(
+            key_hits.is_empty(),
+            "coarse hit should be filtered out by precise hit test"
+        );
+
+        // Downstream `ResolvedHit` list is also empty.
+        let resolved = resolved_hits_from_precise(&key_hits);
+        assert!(resolved.is_empty());
+    }
+}

--- a/understory_responder/src/adapters/mod.rs
+++ b/understory_responder/src/adapters/mod.rs
@@ -11,6 +11,10 @@
 //! - [`box_tree`] (`box_tree_adapter` feature): Integration with [`understory_box_tree`] for 2D spatial queries
 //!   and UI navigation. Converts spatial query results into responder hits and provides filtered
 //!   tree traversal for keyboard navigation and focus cycling.
+//! - [`hit2d`] (`hit2d_adapter` feature): Helpers for feeding precise 2D geometry hits into the responder.
 
 #[cfg(feature = "box_tree_adapter")]
 pub mod box_tree;
+
+#[cfg(feature = "hit2d_adapter")]
+pub mod hit2d;


### PR DESCRIPTION
- Introduce `understory_precise_hit`:
  - New `no_std` crate for narrow-phase 2D hit testing built on `kurbo`.
  - Defines `HitParams` (fill/stroke tolerances + `prefer_fill`), `HitKind`, `HitScore` (distance + kind), and `PreciseHitTest` for local-space queries.
  - Provides default `PreciseHitTest` impls for `Rect`, `Circle`, `RoundedRect`, and fill-only `BezPath` (via `kurbo::Shape::contains`).
  - Adds a `stroke` module with a minimal `StrokedLine` helper (distance-to-segment hit; no joins/caps/variable-width).
  - Crate-level docs and README explain that `HitScore` is deliberately minimal and that rich metadata belongs in engine-level types (e.g. responder meta).
- Wire precise hits into the responder:
  - Add `hit2d_adapter` feature to `understory_responder`.
  - New module `understory_responder::adapters::hit2d`:
    - `KeyHit<K> { key, distance }` and `precise_hits_for_point` for running `PreciseHitTest` on (key, shape) candidates.
    - `resolved_hits_from_precise` converts `KeyHit` into `ResolvedHit<K, ()>` using `DepthKey::Distance`, leaving rich metadata to callers’ meta.
  - Includes unit tests for adapter behavior and an integration-style test that exercises the “coarse AABB hit but precise miss” flow with `Tree + Circle + hit2d_adapter`.
- Example showing end-to-end usage:
  - New `responder_precise_hit` example:
    - Uses `understory_box_tree` for broad-phase AABB culling.
    - Maps `NodeId` → simple `Shape` enum (`Rect` / `Circle`) implementing `PreciseHitTest`.
    - Demonstrates:
      - interior hits on rect and circle;
      - a point inside a node’s AABB but outside the circle (coarse hit only), which the precise test rejects.
    - Uses `hit2d_adapter` to produce `ResolvedHit<NodeId, ()>` and routes them through `Router::handle_with_hits`.