### PR TITLE
index: refactor `visit_point` to use `Aabb2D::contains_point`

### DIFF
--- a/understory_index/src/backends/bvh.rs
+++ b/understory_index/src/backends/bvh.rs
@@ -292,17 +292,16 @@ impl<T: Scalar> Backend<T> for Bvh<T> {
         let Some(root_idx) = self.root else {
             return;
         };
-        let p = Aabb2D::new(x, y, x, y);
         let mut stack = vec![root_idx];
         while let Some(i) = stack.pop() {
             let n = &self.arena[i.get()];
-            if n.bbox.intersect(&p).is_empty() {
+            if !n.bbox.contains_point(x, y) {
                 continue;
             }
             match &n.kind {
                 Kind::Leaf(items) => {
                     for (s, b) in items {
-                        if !b.intersect(&p).is_empty() {
+                        if b.contains_point(x, y) {
                             f(*s);
                         }
                     }

--- a/understory_index/src/backends/rtree.rs
+++ b/understory_index/src/backends/rtree.rs
@@ -651,17 +651,16 @@ impl<T: Scalar, P: Copy + Debug> Backend<T> for RTree<T, P> {
         let Some(root_idx) = self.root else {
             return;
         };
-        let p = Aabb2D::new(x, y, x, y);
         let mut stack = vec![root_idx];
         while let Some(i) = stack.pop() {
             let n = &self.arena[i.get()];
-            if n.bbox.intersect(&p).is_empty() {
+            if !n.bbox.contains_point(x, y) {
                 continue;
             }
             if n.leaf {
                 for c in &n.children {
                     if let RChild::Item { slot, bbox, .. } = c
-                        && !bbox.intersect(&p).is_empty()
+                        && bbox.contains_point(x, y)
                     {
                         f(*slot);
                     }


### PR DESCRIPTION
The current version is based on `Aabb2D::is_empty` being `false` for zero-area AABBs, which we'll be changing.