### PR TITLE
index: introduce `Aabb2D::overlaps`

### DIFF
--- a/understory_index/src/backends/bvh.rs
+++ b/understory_index/src/backends/bvh.rs
@@ -196,7 +196,7 @@ impl<T: Scalar> Bvh<T> {
         slot: usize,
         old: &Aabb2D<T>,
     ) -> bool {
-        if arena[node_idx].bbox.intersect(old).is_empty() {
+        if !arena[node_idx].bbox.overlaps(old) {
             return false;
         }
         let kind = core::mem::replace(&mut arena[node_idx].kind, Kind::Leaf(Vec::new()));
@@ -321,13 +321,13 @@ impl<T: Scalar> Backend<T> for Bvh<T> {
         let mut stack = vec![root_idx];
         while let Some(i) = stack.pop() {
             let n = &self.arena[i.get()];
-            if n.bbox.intersect(&rect).is_empty() {
+            if !n.bbox.overlaps(&rect) {
                 continue;
             }
             match &n.kind {
                 Kind::Leaf(items) => {
                     for (s, b) in items {
-                        if !b.intersect(&rect).is_empty() {
+                        if b.overlaps(&rect) {
                             f(*s);
                         }
                     }

--- a/understory_index/src/backends/flatvec.rs
+++ b/understory_index/src/backends/flatvec.rs
@@ -67,7 +67,7 @@ impl<T: Copy + PartialOrd + Debug> Backend<T> for FlatVec<T> {
     fn visit_rect<F: FnMut(usize)>(&self, rect: Aabb2D<T>, mut f: F) {
         for (i, slot) in self.entries.iter().enumerate() {
             if let Some(a) = slot.as_ref()
-                && !a.intersect(&rect).is_empty()
+                && a.overlaps(&rect)
             {
                 f(i);
             }

--- a/understory_index/src/backends/rtree.rs
+++ b/understory_index/src/backends/rtree.rs
@@ -454,7 +454,7 @@ impl<T: Scalar, P: Copy + Debug> RTree<T, P> {
         old: &Aabb2D<T>,
     ) -> bool {
         let node_bbox = arena[node_idx].bbox;
-        if node_bbox.intersect(old).is_empty() {
+        if !node_bbox.overlaps(old) {
             return false;
         }
         if arena[node_idx].leaf {
@@ -519,7 +519,7 @@ impl<T: Scalar, P: Copy + Debug> RTree<T, P> {
         new: Aabb2D<T>,
     ) -> bool {
         let interest = old.union(new);
-        if arena[node_idx].bbox.intersect(&interest).is_empty() {
+        if !arena[node_idx].bbox.overlaps(&interest) {
             return false;
         }
         if arena[node_idx].leaf {
@@ -682,13 +682,13 @@ impl<T: Scalar, P: Copy + Debug> Backend<T> for RTree<T, P> {
         let mut stack = vec![root_idx];
         while let Some(i) = stack.pop() {
             let n = &self.arena[i.get()];
-            if n.bbox.intersect(&rect).is_empty() {
+            if !n.bbox.overlaps(&rect) {
                 continue;
             }
             if n.leaf {
                 for c in &n.children {
                     if let RChild::Item { slot, bbox, .. } = c
-                        && !bbox.intersect(&rect).is_empty()
+                        && bbox.overlaps(&rect)
                     {
                         f(*slot);
                     }

--- a/understory_index/src/types.rs
+++ b/understory_index/src/types.rs
@@ -54,6 +54,41 @@ impl<T: Copy + PartialOrd> Aabb2D<T> {
         }
     }
 
+    /// Determines whether this AABB overlaps with another in any way.
+    ///
+    /// Note that the edge of the AABB is considered to be part of itself, meaning
+    /// that two AABBs that share an edge are considered to overlap.
+    ///
+    /// Returns `true` if the AABBs overlap, `false` otherwise.
+    ///
+    /// If you want to compute the *intersection* of two AABBs, use the
+    /// [`intersect`][Self::intersect`] method instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use understory_index::Aabb2D;
+    ///
+    /// let aabb1 = Aabb2D::new(0.0, 0.0, 10.0, 10.0);
+    /// let aabb2 = Aabb2D::new(5.0, 5.0, 15.0, 15.0);
+    /// assert!(aabb1.overlaps(&aabb2));
+    ///
+    /// let aabb1 = Aabb2D::new(0.0, 0.0, 10.0, 10.0);
+    /// let aabb2 = Aabb2D::new(10.0, 0.0, 20.0, 10.0);
+    /// assert!(aabb1.overlaps(&aabb2));
+    ///
+    /// let aabb1 = Aabb2D::new(0.0, 0.0, 10.0, 10.0);
+    /// let aabb2 = Aabb2D::new(11.0, 0.0, 20.0, 10.0);
+    /// assert!(!aabb1.overlaps(&aabb2));
+    /// ```
+    #[inline]
+    pub fn overlaps(&self, other: &Self) -> bool {
+        self.min_x <= other.max_x
+            && self.max_x >= other.min_x
+            && self.min_y <= other.max_y
+            && self.max_y >= other.min_y
+    }
+
     /// The smallest AABB enclosing two AABBs.
     #[inline]
     pub(crate) fn union(&self, other: Self) -> Self {


### PR DESCRIPTION
Also rewrites dependents to use that method, instead of doing an `Aabb2D::intersects` followed by `Aabb2D::is_empty`. This old method of checking overlap will no longer work once https://github.com/endoli/understory/pull/47 lands.

`Aabb2D::overlaps` instead has well-defined edge behavior (edges are included, meaning empty/zero-area AABBs can overlap another AABB).