### PR TITLE
Improve/clarify `Aabb2D::intersect` semantics

### DIFF
--- a/understory_index/src/types.rs
+++ b/understory_index/src/types.rs
@@ -40,6 +40,11 @@ impl<T: Copy + PartialOrd> Aabb2D<T> {
     }
 
     /// The intersection of two AABBs.
+    ///
+    /// If you want to determine whether two rectangles intersect, use the [`Self::overlaps`]
+    /// method instead.
+    ///
+    /// The resulting bounding box has zero area if there is no overlap.
     #[inline]
     pub fn intersect(&self, other: &Self) -> Self {
         let min_x = max_t(self.min_x, other.min_x);
@@ -49,8 +54,8 @@ impl<T: Copy + PartialOrd> Aabb2D<T> {
         Self {
             min_x,
             min_y,
-            max_x,
-            max_y,
+            max_x: max_t(min_x, max_x),
+            max_y: max_t(min_y, max_y),
         }
     }
 


### PR DESCRIPTION
Also expands documentation.

Previously, for bounding boxes without overlap inverted AABBs could be returned by the method. This might be OK mathematically, be is perhaps unexpected, especially given the naming of fields of the struct (`min_x`, `max_x`, `min_y`, `max_y`). 

Alternatively, we could simply name the fields (`x0`, x1`, `y0`, `y1`) and have methods like `is_positive`, `is_negative`, `is_zero_area`. Note [`kurbo::intersect`](https://docs.rs/kurbo/0.13.0/kurbo/struct.Rect.html#method.intersect) does ensure the area is always positive, but I think this is not strictly necessary.