### PR TITLE
Clarify `Aabb2D` edge orientations

### DIFF
--- a/understory_index/src/types.rs
+++ b/understory_index/src/types.rs
@@ -9,13 +9,13 @@ use core::fmt::Debug;
 /// Axis-aligned bounding box in 2D.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Aabb2D<T> {
-    /// Minimum x (left)
+    /// Minimum x (left in X-right spaces)
     pub min_x: T,
-    /// Minimum y (top)
+    /// Minimum y (top in Y-down spaces)
     pub min_y: T,
-    /// Maximum x (right)
+    /// Maximum x (right in X-right spaces)
     pub max_x: T,
-    /// Maximum y (bottom)
+    /// Maximum y (bottom in Y-down spaces)
     pub max_y: T,
 }
 


### PR DESCRIPTION
(X-left will be rare... but Y-up is definitely possible.)

Allowing us to use words like "left" and "top" in documentation is useful, and by explicitly making this relative to the choice of coordinate system the code itself can be kept agnostic.