### PR TITLE
index: reorganize exports

### DIFF
--- a/understory_box_tree/README.md
+++ b/understory_box_tree/README.md
@@ -59,8 +59,11 @@ assumed to be finite (no NaNs). AABBs are loose for non-axis-aligned transforms 
 clips: we store an axis-aligned box that fully contains what is drawn, but it is not
 guaranteed to be tight.
 
-See [`understory_index::Index`], [`understory_index::RTreeF32`]/[`understory_index::RTreeF64`]/[`understory_index::RTreeI64`], and
-[`understory_index::BvhF32`]/[`understory_index::BvhF64`]/[`understory_index::BvhI64`] for details.
+See [`understory_index::Index`],
+[`understory_index::backends::RTreeF32`]/[`understory_index::backends::RTreeF64`]/[`understory_index::backends::RTreeI64`],
+and
+[`understory_index::backends::BvhF32`]/[`understory_index::backends::BvhF64`]/[`understory_index::backends::BvhI64`]
+for details.
 
 ## API overview
 

--- a/understory_box_tree/src/lib.rs
+++ b/understory_box_tree/src/lib.rs
@@ -42,8 +42,11 @@
 //! clips: we store an axis-aligned box that fully contains what is drawn, but it is not
 //! guaranteed to be tight.
 //!
-//! See [`understory_index::Index`], [`understory_index::RTreeF32`]/[`understory_index::RTreeF64`]/[`understory_index::RTreeI64`], and
-//! [`understory_index::BvhF32`]/[`understory_index::BvhF64`]/[`understory_index::BvhI64`] for details.
+//! See [`understory_index::Index`],
+//! [`understory_index::backends::RTreeF32`]/[`understory_index::backends::RTreeF64`]/[`understory_index::backends::RTreeI64`],
+//! and
+//! [`understory_index::backends::BvhF32`]/[`understory_index::backends::BvhF64`]/[`understory_index::backends::BvhI64`]
+//! for details.
 //!
 //! ## API overview
 //!

--- a/understory_box_tree/src/tree.rs
+++ b/understory_box_tree/src/tree.rs
@@ -5,7 +5,7 @@
 
 use alloc::vec::Vec;
 use kurbo::{Affine, Point, Rect, RoundedRect};
-use understory_index::{Aabb2D, Backend, FlatVec, IndexGeneric, Key as AabbKey};
+use understory_index::{Aabb2D, Backend, IndexGeneric, Key as AabbKey, backends::FlatVec};
 
 use crate::damage::Damage;
 use crate::types::{ClipBehavior, LocalNode, NodeFlags, NodeId};
@@ -1112,7 +1112,7 @@ mod tests {
 
     #[test]
     fn test_rtree_backend() {
-        use understory_index::RTreeF64;
+        use understory_index::backends::RTreeF64;
 
         // Use an R-tree backend and verify basic hit-testing still works.
         let mut tree: Tree<RTreeF64<NodeId>> = Tree::with_backend(RTreeF64::<NodeId>::default());
@@ -1130,7 +1130,7 @@ mod tests {
 
     #[test]
     fn test_bvh_backend() {
-        use understory_index::BvhF64;
+        use understory_index::backends::BvhF64;
 
         // Use a BVH backend and verify basic hit-testing still works.
         let mut tree: Tree<BvhF64> = Tree::with_backend(BvhF64::default());

--- a/understory_focus/src/adapters/box_tree.rs
+++ b/understory_focus/src/adapters/box_tree.rs
@@ -90,7 +90,7 @@ pub fn build_focus_space_for_scope<'a, B, P>(
     out: &'a mut Vec<FocusEntry<NodeId>>,
 ) -> FocusSpace<'a, NodeId>
 where
-    B: understory_index::backend::Backend<f64>,
+    B: understory_index::Backend<f64>,
     P: FocusPropsLookup<NodeId>,
 {
     out.clear();

--- a/understory_index/src/backends/mod.rs
+++ b/understory_index/src/backends/mod.rs
@@ -19,6 +19,10 @@
 //! Accumulators are widened (`f32`→`f64`, `f64`→`f64`, `i64`→`i128`) for robust comparisons.
 //! Bulk builders use an STR-like pass to seed packed leaves and parents.
 
-pub mod bvh;
-pub mod flatvec;
-pub mod rtree;
+pub(crate) mod bvh;
+pub(crate) mod flatvec;
+pub(crate) mod rtree;
+
+pub use bvh::{Bvh, BvhF32, BvhF64, BvhI64};
+pub use flatvec::FlatVec;
+pub use rtree::{RTree, RTreeF32, RTreeF64, RTreeI64};

--- a/understory_index/src/lib.rs
+++ b/understory_index/src/lib.rs
@@ -75,20 +75,17 @@
 
 extern crate alloc;
 
-pub mod backend;
+mod backend;
 pub mod backends;
-pub mod damage;
-pub mod index;
-pub mod types;
+mod damage;
+mod index;
+mod types;
 pub(crate) mod util;
 
 pub use backend::Backend;
-pub use backends::bvh::{BvhF32, BvhF64, BvhI64};
-pub use backends::flatvec::FlatVec;
-pub use backends::rtree::{RTreeF32, RTreeF64, RTreeI64};
 pub use damage::Damage;
 pub use index::{Index, IndexGeneric, Key};
-pub use types::Aabb2D;
+pub use types::{Aabb2D, Scalar, ScalarAcc};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
On `main`, almost everything is both exported publicly inside its own module as well as re-exported at the top-level. I've reorganized the exports such that everything is exported only at the top-level, except for the backends.

For the backends, this suggests removing the type alias re-exports and exports everything once under `understory_index::backends` (so we'd have `understory_index::backends::{Bvh, BvhF32, FlatVec, ...}`).

Alternatively, we could simply export all the backend stuff at the top-level.