### PR TITLE
box_tree: Add subtree filtering support to QueryFilter

### DIFF
--- a/understory_box_tree/README.md
+++ b/understory_box_tree/README.md
@@ -70,7 +70,7 @@ See [`understory_index::Index`], [`understory_index::RTreeF32`]/[`understory_ind
 - [`NodeFlags`]: visibility, picking, and focusable controls.
 - [`NodeId`]: generational handle of a node.
 - [`QueryFilter`]: restricts hit/intersect results (visible/pickable/focusable).
-  See [`NodeFlags::VISIBLE`], [`NodeFlags::PICKABLE`], and [`NodeFlags::FOCUSABLE`].
+  See [`NodeFlags::VISIBLE`], [`NodeFlags::PICKABLE`], [`NodeFlags::FOCUSABLE`], and [`QueryFilter::in_subtree`] for subtree filtering.
 
 Key operations:
 - [`Tree::insert`](Tree::insert) → [`NodeId`]

--- a/understory_box_tree/src/lib.rs
+++ b/understory_box_tree/src/lib.rs
@@ -53,7 +53,7 @@
 //! - [`NodeFlags`]: visibility, picking, and focusable controls.
 //! - [`NodeId`]: generational handle of a node.
 //! - [`QueryFilter`]: restricts hit/intersect results (visible/pickable/focusable).
-//!   See [`NodeFlags::VISIBLE`], [`NodeFlags::PICKABLE`], and [`NodeFlags::FOCUSABLE`].
+//!   See [`NodeFlags::VISIBLE`], [`NodeFlags::PICKABLE`], [`NodeFlags::FOCUSABLE`], and [`QueryFilter::in_subtree`] for subtree filtering.
 //!
 //! Key operations:
 //! - [`Tree::insert`](Tree::insert) → [`NodeId`]

--- a/understory_responder/src/adapters/box_tree.rs
+++ b/understory_responder/src/adapters/box_tree.rs
@@ -171,7 +171,7 @@ pub mod navigation {
             return false;
         };
 
-        filter.matches(flags)
+        filter.matches(tree, id, flags)
     }
 
     /// Find the root node of the subtree containing the given node.
@@ -245,9 +245,7 @@ pub mod navigation {
                 },
             );
 
-            let filter = QueryFilter {
-                required_flags: NodeFlags::VISIBLE,
-            };
+            let filter = QueryFilter::new().visible();
 
             // From root, next visible should be b (skipping hidden a)
             let next = next_depth_first_filtered(&tree, root, filter).unwrap();
@@ -300,9 +298,7 @@ pub mod navigation {
                 },
             );
 
-            let filter = QueryFilter {
-                required_flags: NodeFlags::PICKABLE,
-            };
+            let filter = QueryFilter::new().pickable();
 
             // From root, next pickable should be b (skipping non-pickable a)
             let next = next_depth_first_filtered(&tree, root, filter).unwrap();
@@ -335,9 +331,7 @@ pub mod navigation {
                 },
             );
 
-            let filter = QueryFilter {
-                required_flags: NodeFlags::PICKABLE,
-            };
+            let filter = QueryFilter::new().pickable();
 
             // Should return None since no nodes are pickable
             assert!(next_depth_first_filtered(&tree, root, filter).is_none());
@@ -375,9 +369,7 @@ pub mod navigation {
                 },
             );
 
-            let filter = QueryFilter {
-                required_flags: NodeFlags::VISIBLE,
-            };
+            let filter = QueryFilter::new().visible();
 
             // From visible_child (last visible), next should wrap to root
             let next = next_depth_first_filtered(&tree, visible_child, filter).unwrap();
@@ -409,9 +401,7 @@ pub mod navigation {
                 },
             );
 
-            let filter = QueryFilter {
-                required_flags: NodeFlags::VISIBLE,
-            };
+            let filter = QueryFilter::new().visible();
 
             // Should work with live nodes
             assert!(next_depth_first_filtered(&tree, root, filter).is_some());
@@ -462,9 +452,7 @@ pub mod navigation {
                 },
             );
 
-            let filter = QueryFilter {
-                required_flags: NodeFlags::VISIBLE,
-            };
+            let filter = QueryFilter::new().visible();
 
             // From child1_visible (last visible in subtree1), should wrap to root1 (not cross to subtree2)
             let next = next_depth_first_filtered(&tree, child1_visible, filter).unwrap();


### PR DESCRIPTION
Add subtree_root field to QueryFilter to enable restricting spatial queries  to specific subtrees. This allows applications to scope hit testing and  rectangle queries to particular branches of the tree.

- Add QueryFilter::in_subtree() builder method
- Add Tree::is_descendant_of() helper for subtree membership checks  
- Update QueryFilter::matches() to respect subtree boundaries
- Add tests demonstrating subtree isolation
- Update documentation

The descendant check is O(depth), there could be ways to improve this but I haven't done it here