### PR TITLE
Add `understory_selection` crate for generic selection state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_MIN_VER: "1.88"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree -p understory_responder -p understory_focus -p understory_precise_hit"
+  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree -p understory_responder -p understory_focus -p understory_precise_hit -p understory_selection"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default"
 
@@ -112,6 +112,9 @@ jobs:
 
       - name: check understory_focus README
         run: cargo rdme --workspace-project=understory_focus --heading-base-level=0 --check
+
+      - name: check understory_selection README
+        run: cargo rdme --workspace-project=understory_selection --heading-base-level=0 --check
 
   clippy-stable:
     name: cargo clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "understory_selection"
+version = "0.1.0"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "understory_box_tree",
   "understory_focus",
   "understory_precise_hit",
+  "understory_selection",
   "understory_responder",
   "benches",
   "examples",

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Not a layout engine.
   - Upstream code (your layout system) decides sizes and positions and then updates this tree.
 
+- `understory_focus`
+  - Focus navigation primitives: navigation intents, per‑node focus properties, and a spatial view of focusable candidates.
+  - Provides pluggable policies for directional and ordered navigation, and an optional adapter for integrating with `understory_box_tree`.
+  - Designed to be independent of any particular widget toolkit or event system.
+
 - `understory_precise_hit`
   - Geometry‑level, narrow‑phase hit testing for shapes in local 2D coordinates, built on `kurbo`.
   - Provides a small `PreciseHitTest` trait with `HitParams`/`HitScore` helpers and default impls for `Rect`, `Circle`, `RoundedRect`, and fill‑only `BezPath`.
@@ -30,7 +35,12 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Includes a tiny dispatcher helper (`dispatcher::run`) for executing handlers and honoring stop/cancelation.
   - Supports pointer capture with path reconstruction via a `ParentLookup` provider and bypasses scope filters.
 
-Both crates are `#![no_std]` and use `alloc`.
+- `understory_selection`
+  - Generic selection container that tracks a set of keys plus an optional primary and anchor, plus a revision counter for change detection.
+  - Generic over the key type `T` (no `Hash`/`Ord` requirement; only `PartialEq`), suitable for list selections, canvases, and other selection UIs.
+  - Intended to pair with `understory_box_tree` / `understory_precise_hit` for hit testing and `understory_responder` for event routing.
+
+All core crates are `#![no_std]` and use `alloc`.
 Examples and tests use `std`.
 
 ## Why this separation?
@@ -76,6 +86,8 @@ For example, a canvas or DWG or DXF viewer can reuse the box and index layers wi
   - `understory_index/README.md` has the API and a “Choosing a backend” guide.
   - `understory_box_tree/README.md` has usage, hit‑testing, and visible‑set examples.
   - `understory_responder/README.md` explains routing, capture, and how to integrate with a picker.
+  - `understory_focus/README.md` covers focus navigation policies and adapters.
+  - `understory_selection/README.md` documents the selection container, anchor/revision semantics, and click helpers.
 - Run examples.
   - `cargo run -p understory_examples --example index_basics`
   - `cargo run -p understory_examples --example box_tree_basics`

--- a/understory_selection/Cargo.toml
+++ b/understory_selection/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "understory_selection"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Selection management primitives for lists, canvases, and infinite-surface UIs."
+keywords = ["ui", "selection", "canvas", "no_std", "understory"]
+categories = ["gui", "data-structures", "no-std"]
+
+[dependencies]
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+
+# This crate is `no_std` + `alloc` by default; `std` is only needed when
+# dependants prefer to compile with the standard library.
+std = []
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_selection/LICENSE-APACHE
+++ b/understory_selection/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/understory_selection/LICENSE-MIT
+++ b/understory_selection/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/understory_selection/README.md
+++ b/understory_selection/README.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+# Understory Selection
+
+**Selection management primitives for lists, canvases, and infinite-surface UIs**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_selection.svg)](https://crates.io/crates/understory_selection)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_selection.svg)](https://docs.rs/understory_selection)
+[![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/endoli/understory/ci.yml?logo=github&label=CI)](https://github.com/endoli/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_selection
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Understory Selection: selection management primitives.
+
+This crate focuses on the _bookkeeping_ of a selection: the set of selected
+keys plus common higher-level concepts such as a primary item and an anchor
+used for range extension. It does **not** know anything about how your items
+are laid out or ordered; callers decide how to map user input (click, toggle,
+lasso) into concrete sets of keys.
+
+The core type is [`Selection`], a small, generic container that tracks:
+- The set of selected keys.
+- An optional **primary** key (typically the most recently interacted-with item).
+- An optional **anchor** key (used as a reference point for shift-click/range selection).
+- A monotonically increasing **revision** counter that bumps when the
+  selection changes.
+
+The container is intentionally opinionated and compact:
+- Keys live in a small `Vec<K>` with uniqueness enforced by equality.
+- No hashing or ordering constraints are imposed on `K`, making it easy to integrate
+  with existing ID types such as generational handles from a scene tree.
+- The API exposes simple operations that mirror common UI gestures like
+  “replace with a single item”, “toggle one item”, and “replace/extend with a batch”.
+
+## Minimal example
+
+```rust
+use understory_selection::Selection;
+
+// Using u32 as a stand-in for an application-specific ID.
+let mut selection = Selection::<u32>::new();
+
+// Simple click: replace selection with a single item.
+selection.select_only(10);
+assert_eq!(selection.primary(), Some(&10));
+
+// Ctrl-click: toggle a single item.
+selection.toggle(10);
+assert!(selection.is_empty());
+
+// Lasso or range gesture: compute the affected IDs elsewhere and
+// then replace the current selection with that batch.
+selection.replace_with([1, 2, 3]);
+assert_eq!(selection.len(), 3);
+```
+
+## Concepts
+
+[`Selection`] models three related pieces of state:
+
+- **Selection contents**: a set of keys, stored as a small `Vec<K>` with no duplicates.
+- **Primary**: an optional distinguished key, typically the most recently interacted-with
+  item. Many UIs use this as the “focus” of keyboard actions or the reference for
+  commands like “delete selection”.
+- **Anchor**: an optional reference key used as a starting point for range extension
+  (for example, shift-click in a list). The crate does not know how items are ordered;
+  callers are expected to compute ranges based on their own data structures and then
+  call methods like [`Selection::replace_with`] or [`Selection::extend_with`].
+
+The container is agnostic to the domain: it works equally well for list selections,
+canvas/infinite-surface editors, or any other place where you want to track a set of
+selected items plus a primary/anchor.
+
+## List-style click helpers
+
+Higher layers typically map pointer + modifier input into selection changes. For a
+simple list with `click` / `ctrl+click` / `shift+click` semantics, you might write
+a helper like this:
+
+```rust
+use understory_selection::Selection;
+
+#[derive(Default, Copy, Clone)]
+struct Modifiers {
+    ctrl: bool,
+    shift: bool,
+}
+
+fn handle_click(
+    selection: &mut Selection<u32>,
+    clicked: u32,
+    mods: Modifiers,
+    items_in_order: &[u32],
+) {
+    if !mods.ctrl && !mods.shift {
+        // Plain click: replace selection with a single item.
+        selection.select_only(clicked);
+        return;
+    }
+
+    if mods.ctrl && !mods.shift {
+        // Ctrl-click: toggle membership, keep anchor stable.
+        selection.toggle(clicked);
+        return;
+    }
+
+    if mods.shift {
+        // Shift-click: treat anchor as the pivot, build a range between
+        // anchor and the clicked item according to the list ordering, and
+        // replace the current selection with that range.
+        let anchor = selection
+            .anchor()
+            .copied()
+            .unwrap_or(clicked);
+
+        let index_of = |value: u32| {
+            items_in_order
+                .iter()
+                .position(|&id| id == value)
+                .expect("anchor and clicked must be in items_in_order")
+        };
+
+        let a = index_of(anchor);
+        let b = index_of(clicked);
+        let (start, end) = if a <= b { (a, b) } else { (b, a) };
+
+        let range = items_in_order[start..=end].iter().copied();
+        selection.replace_with(range);
+    }
+}
+
+let items = [10_u32, 20, 30, 40];
+let mut sel = Selection::new();
+
+// Click on 20.
+handle_click(&mut sel, 20, Modifiers::default(), &items);
+assert_eq!(sel.items(), &[20]);
+
+// Shift-click on 40: select the range 20..=40.
+handle_click(
+    &mut sel,
+    40,
+    Modifiers { ctrl: false, shift: true },
+    &items,
+);
+assert_eq!(sel.items(), &[20, 30, 40]);
+```
+
+This crate is `no_std` and uses `alloc`.
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>), or
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>),
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ../AUTHORS
+[LICENSE-APACHE]: LICENSE-APACHE
+[LICENSE-MIT]: LICENSE-MIT

--- a/understory_selection/src/lib.rs
+++ b/understory_selection/src/lib.rs
@@ -1,0 +1,449 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=understory_selection --heading-base-level=0
+
+//! Understory Selection: selection management primitives.
+//!
+//! This crate focuses on the _bookkeeping_ of a selection: the set of selected
+//! keys plus common higher-level concepts such as a primary item and an anchor
+//! used for range extension. It does **not** know anything about how your items
+//! are laid out or ordered; callers decide how to map user input (click, toggle,
+//! lasso) into concrete sets of keys.
+//!
+//! The core type is [`Selection`], a small, generic container that tracks:
+//! - The set of selected keys.
+//! - An optional **primary** key (typically the most recently interacted-with item).
+//! - An optional **anchor** key (used as a reference point for shift-click/range selection).
+//! - A monotonically increasing **revision** counter that bumps when the
+//!   selection changes.
+//!
+//! The container is intentionally opinionated and compact:
+//! - Keys live in a small `Vec<K>` with uniqueness enforced by equality.
+//! - No hashing or ordering constraints are imposed on `K`, making it easy to integrate
+//!   with existing ID types such as generational handles from a scene tree.
+//! - The API exposes simple operations that mirror common UI gestures like
+//!   “replace with a single item”, “toggle one item”, and “replace/extend with a batch”.
+//!
+//! ## Minimal example
+//!
+//! ```rust
+//! use understory_selection::Selection;
+//!
+//! // Using u32 as a stand-in for an application-specific ID.
+//! let mut selection = Selection::<u32>::new();
+//!
+//! // Simple click: replace selection with a single item.
+//! selection.select_only(10);
+//! assert_eq!(selection.primary(), Some(&10));
+//!
+//! // Ctrl-click: toggle a single item.
+//! selection.toggle(10);
+//! assert!(selection.is_empty());
+//!
+//! // Lasso or range gesture: compute the affected IDs elsewhere and
+//! // then replace the current selection with that batch.
+//! selection.replace_with([1, 2, 3]);
+//! assert_eq!(selection.len(), 3);
+//! ```
+//!
+//! ## Concepts
+//!
+//! [`Selection`] models three related pieces of state:
+//!
+//! - **Selection contents**: a set of keys, stored as a small `Vec<K>` with no duplicates.
+//! - **Primary**: an optional distinguished key, typically the most recently interacted-with
+//!   item. Many UIs use this as the “focus” of keyboard actions or the reference for
+//!   commands like “delete selection”.
+//! - **Anchor**: an optional reference key used as a starting point for range extension
+//!   (for example, shift-click in a list). The crate does not know how items are ordered;
+//!   callers are expected to compute ranges based on their own data structures and then
+//!   call methods like [`Selection::replace_with`] or [`Selection::extend_with`].
+//!
+//! The container is agnostic to the domain: it works equally well for list selections,
+//! canvas/infinite-surface editors, or any other place where you want to track a set of
+//! selected items plus a primary/anchor.
+//!
+//! ## List-style click helpers
+//!
+//! Higher layers typically map pointer + modifier input into selection changes. For a
+//! simple list with `click` / `ctrl+click` / `shift+click` semantics, you might write
+//! a helper like this:
+//!
+//! ```rust
+//! use understory_selection::Selection;
+//!
+//! #[derive(Default, Copy, Clone)]
+//! struct Modifiers {
+//!     ctrl: bool,
+//!     shift: bool,
+//! }
+//!
+//! fn handle_click(
+//!     selection: &mut Selection<u32>,
+//!     clicked: u32,
+//!     mods: Modifiers,
+//!     items_in_order: &[u32],
+//! ) {
+//!     if !mods.ctrl && !mods.shift {
+//!         // Plain click: replace selection with a single item.
+//!         selection.select_only(clicked);
+//!         return;
+//!     }
+//!
+//!     if mods.ctrl && !mods.shift {
+//!         // Ctrl-click: toggle membership, keep anchor stable.
+//!         selection.toggle(clicked);
+//!         return;
+//!     }
+//!
+//!     if mods.shift {
+//!         // Shift-click: treat anchor as the pivot, build a range between
+//!         // anchor and the clicked item according to the list ordering, and
+//!         // replace the current selection with that range.
+//!         let anchor = selection
+//!             .anchor()
+//!             .copied()
+//!             .unwrap_or(clicked);
+//!
+//!         let index_of = |value: u32| {
+//!             items_in_order
+//!                 .iter()
+//!                 .position(|&id| id == value)
+//!                 .expect("anchor and clicked must be in items_in_order")
+//!         };
+//!
+//!         let a = index_of(anchor);
+//!         let b = index_of(clicked);
+//!         let (start, end) = if a <= b { (a, b) } else { (b, a) };
+//!
+//!         let range = items_in_order[start..=end].iter().copied();
+//!         selection.replace_with(range);
+//!     }
+//! }
+//!
+//! let items = [10_u32, 20, 30, 40];
+//! let mut sel = Selection::new();
+//!
+//! // Click on 20.
+//! handle_click(&mut sel, 20, Modifiers::default(), &items);
+//! assert_eq!(sel.items(), &[20]);
+//!
+//! // Shift-click on 40: select the range 20..=40.
+//! handle_click(
+//!     &mut sel,
+//!     40,
+//!     Modifiers { ctrl: false, shift: true },
+//!     &items,
+//! );
+//! assert_eq!(sel.items(), &[20, 30, 40]);
+//! ```
+//!
+//! This crate is `no_std` and uses `alloc`.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+/// A small selection container tracking a set of keys plus primary/anchor and a revision.
+///
+/// `Selection` does not impose hashing or ordering constraints on `T`; it only
+/// requires equality for most mutation and query methods. Internally it stores keys
+/// in a small `Vec<T>` and enforces uniqueness by scanning for existing entries.
+///
+/// This keeps the type easy to integrate with existing ID types (for example,
+/// generational handles from a scene or box tree) without forcing them to be `Ord`
+/// or `Hash`.
+#[derive(Clone, Debug, Default)]
+pub struct Selection<T> {
+    items: Vec<T>,
+    primary: Option<usize>,
+    anchor: Option<usize>,
+    revision: u64,
+}
+
+impl<T> Selection<T> {
+    /// Creates an empty selection.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            items: Vec::new(),
+            primary: None,
+            anchor: None,
+            revision: 0,
+        }
+    }
+
+    /// Returns `true` if the selection is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Returns the number of selected keys.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns a slice of all selected keys in their internal order.
+    ///
+    /// The order is stable within a single `SelectionSet` instance but should not
+    /// be relied upon for application semantics; callers are free to interpret it
+    /// however they find convenient.
+    #[must_use]
+    pub fn items(&self) -> &[T] {
+        &self.items
+    }
+
+    /// Returns an iterator over the selected keys.
+    pub fn iter(&self) -> core::slice::Iter<'_, T> {
+        self.items.iter()
+    }
+
+    /// Returns a reference to the primary key, if any.
+    ///
+    /// The primary is typically the most recently interacted-with item in the selection.
+    #[must_use]
+    pub fn primary(&self) -> Option<&T> {
+        self.primary.map(|idx| &self.items[idx])
+    }
+
+    /// Returns a reference to the anchor key, if any.
+    ///
+    /// The anchor is often used as the starting point for range extension (for example,
+    /// shift-click in a list). The crate does not compute ranges; callers are expected
+    /// to derive them from their own data structures.
+    #[must_use]
+    pub fn anchor(&self) -> Option<&T> {
+        self.anchor.map(|idx| &self.items[idx])
+    }
+
+    /// Returns the current revision counter.
+    ///
+    /// The revision is a monotonically increasing counter local to this `Selection`
+    /// instance. It is bumped only when a mutation changes the semantic contents:
+    /// selected items, primary, or anchor. No-op calls (for example, selecting the
+    /// already-selected singleton) leave it unchanged.
+    ///
+    /// This is useful for observers that want a cheap “did anything actually change?”
+    /// marker without comparing the full contents.
+    #[must_use]
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    /// Removes all keys from the selection and clears primary/anchor.
+    pub fn clear(&mut self) {
+        if self.items.is_empty() && self.primary.is_none() && self.anchor.is_none() {
+            return;
+        }
+
+        self.items.clear();
+        self.primary = None;
+        self.anchor = None;
+        self.bump_revision();
+    }
+
+    fn bump_revision(&mut self) {
+        self.revision = self.revision.wrapping_add(1);
+    }
+}
+
+impl<T> Selection<T>
+where
+    T: PartialEq,
+{
+    /// Returns `true` if the selection currently contains `key`.
+    #[must_use]
+    pub fn contains(&self, key: &T) -> bool {
+        self.position_of(key).is_some()
+    }
+
+    /// Replaces the selection with a single key, setting both primary and anchor.
+    ///
+    /// This is the typical mapping for a simple click without modifiers.
+    pub fn select_only(&mut self, key: T) {
+        if self.items.len() == 1
+            && self.items.first() == Some(&key)
+            && self.primary == Some(0)
+            && self.anchor == Some(0)
+        {
+            return;
+        }
+
+        self.items.clear();
+        self.items.push(key);
+        self.primary = Some(0);
+        self.anchor = Some(0);
+        self.bump_revision();
+    }
+
+    /// Replaces the current selection with the provided batch of keys.
+    ///
+    /// - Duplicates in the input are ignored.
+    /// - If the previous anchor key is still present, it remains the anchor.
+    ///   Otherwise the first unique key becomes the anchor (if any keys are present).
+    /// - The primary key defaults to the first unique key (if any keys are present).
+    pub fn replace_with<I>(&mut self, keys: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut new_items: Vec<T> = Vec::new();
+        for key in keys {
+            if !new_items.iter().any(|existing| existing == &key) {
+                new_items.push(key);
+            }
+        }
+
+        let new_primary = if new_items.is_empty() { None } else { Some(0) };
+
+        // Preserve the previous anchor if its key is still present in the new set.
+        let mut new_anchor = None;
+        if let Some(old_anchor_idx) = self.anchor
+            && let Some(old_key) = self.items.get(old_anchor_idx)
+        {
+            new_anchor = new_items.iter().position(|k| k == old_key);
+        }
+        if new_anchor.is_none() {
+            new_anchor = new_primary;
+        }
+
+        if new_items == self.items && self.primary == new_primary && self.anchor == new_anchor {
+            return;
+        }
+
+        self.items = new_items;
+        self.primary = new_primary;
+        self.anchor = new_anchor;
+        self.bump_revision();
+    }
+
+    /// Extends the selection with the provided batch of keys.
+    ///
+    /// - Existing keys remain selected.
+    /// - New keys are appended; duplicates in the input are ignored.
+    /// - The **primary** key is updated to the last unique key added, if any.
+    /// - The **anchor** is left unchanged.
+    pub fn extend_with<I>(&mut self, keys: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut last_added = None;
+        for key in keys {
+            if self.position_of(&key).is_none() {
+                self.items.push(key);
+                last_added = Some(self.items.len() - 1);
+            }
+        }
+
+        if let Some(idx) = last_added {
+            // Even if primary already points at `idx`, new items were added.
+            self.primary = Some(idx);
+            self.bump_revision();
+        }
+    }
+
+    /// Adds `key` to the selection if it is not already present.
+    ///
+    /// - If `key` is newly added, it becomes the primary key.
+    /// - The anchor is left unchanged.
+    pub fn add(&mut self, key: T) {
+        if let Some(idx) = self.position_of(&key) {
+            if self.primary != Some(idx) {
+                self.primary = Some(idx);
+                self.bump_revision();
+            }
+        } else {
+            self.items.push(key);
+            self.primary = Some(self.items.len() - 1);
+            self.bump_revision();
+        }
+    }
+
+    /// Removes `key` from the selection if present.
+    ///
+    /// - If the removed key was primary or anchor, those roles are cleared.
+    /// - If the selection becomes empty, both primary and anchor are cleared.
+    pub fn remove(&mut self, key: &T) {
+        if let Some(idx) = self.position_of(key) {
+            self.remove_at(idx);
+            self.bump_revision();
+        }
+    }
+
+    /// Toggles `key` in the selection.
+    ///
+    /// - If `key` is not selected, it is added and becomes the primary key.
+    /// - If `key` is already selected, it is removed. If this empties the selection,
+    ///   both primary and anchor are cleared.
+    pub fn toggle(&mut self, key: T) {
+        if let Some(idx) = self.position_of(&key) {
+            self.remove_at(idx);
+            self.bump_revision();
+        } else {
+            self.items.push(key);
+            self.primary = Some(self.items.len() - 1);
+            self.bump_revision();
+        }
+    }
+
+    /// Sets the primary key to `key` if it is already selected.
+    pub fn set_primary(&mut self, key: &T) {
+        if let Some(idx) = self.position_of(key)
+            && self.primary != Some(idx)
+        {
+            self.primary = Some(idx);
+            self.bump_revision();
+        }
+    }
+
+    /// Sets the anchor key to `key` if it is already selected.
+    pub fn set_anchor(&mut self, key: &T) {
+        if let Some(idx) = self.position_of(key)
+            && self.anchor != Some(idx)
+        {
+            self.anchor = Some(idx);
+            self.bump_revision();
+        }
+    }
+
+    /// Clears the anchor while leaving the selection and primary untouched.
+    pub fn clear_anchor(&mut self) {
+        if self.anchor.is_some() {
+            self.anchor = None;
+            self.bump_revision();
+        }
+    }
+
+    /// Returns the position of `key` within the selection, if present.
+    fn position_of(&self, key: &T) -> Option<usize> {
+        self.items.iter().position(|k| k == key)
+    }
+
+    /// Removes the item at `idx`, updating primary and anchor accordingly.
+    fn remove_at(&mut self, idx: usize) {
+        self.items.remove(idx);
+
+        let update_index = |slot: &mut Option<usize>| {
+            if let Some(current) = *slot {
+                if current == idx {
+                    *slot = None;
+                } else if current > idx {
+                    *slot = Some(current - 1);
+                }
+            }
+        };
+
+        update_index(&mut self.primary);
+        update_index(&mut self.anchor);
+
+        if self.items.is_empty() {
+            self.primary = None;
+            self.anchor = None;
+        }
+    }
+}

--- a/understory_selection/tests/selection.rs
+++ b/understory_selection/tests/selection.rs
@@ -1,0 +1,161 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Tests for the `understory_selection` crate.
+//!
+//! These exercises the core `Selection<T>` API, with a focus on how contents,
+//! primary/anchor roles, and the revision counter interact.
+
+use understory_selection::Selection;
+
+#[test]
+fn empty_selection_basics() {
+    let sel = Selection::<u32>::new();
+    assert!(sel.is_empty());
+    assert_eq!(sel.len(), 0);
+    assert_eq!(sel.primary(), None);
+    assert_eq!(sel.anchor(), None);
+    assert_eq!(sel.revision(), 0);
+}
+
+#[test]
+fn select_only_sets_primary_anchor_and_bumps_revision() {
+    let mut sel = Selection::new();
+    sel.select_only(1);
+
+    assert_eq!(sel.items(), &[1]);
+    assert_eq!(sel.primary(), Some(&1));
+    assert_eq!(sel.anchor(), Some(&1));
+    assert_eq!(sel.revision(), 1);
+
+    // No-op: selecting the same singleton again should not change revision.
+    sel.select_only(1);
+    assert_eq!(sel.revision(), 1);
+}
+
+#[test]
+fn clear_empties_and_bumps_revision_only_on_change() {
+    let mut sel = Selection::new();
+    sel.clear();
+    assert_eq!(sel.revision(), 0);
+
+    sel.select_only(1);
+    assert_eq!(sel.revision(), 1);
+
+    sel.clear();
+    assert!(sel.is_empty());
+    assert_eq!(sel.primary(), None);
+    assert_eq!(sel.anchor(), None);
+    assert_eq!(sel.revision(), 2);
+}
+
+#[test]
+fn replace_with_dedups_and_preserves_anchor_when_possible() {
+    let mut sel = Selection::new();
+
+    sel.replace_with([1, 2, 2, 3]);
+    assert_eq!(sel.items(), &[1, 2, 3]);
+    assert_eq!(sel.primary(), Some(&1));
+    assert_eq!(sel.anchor(), Some(&1));
+
+    // Set anchor explicitly to 2.
+    sel.set_anchor(&2);
+    let rev_after_anchor = sel.revision();
+    assert_eq!(sel.anchor(), Some(&2));
+
+    // Replace with a set that still contains 2: anchor should remain 2.
+    sel.replace_with([2, 3, 4]);
+    assert_eq!(sel.items(), &[2, 3, 4]);
+    assert_eq!(sel.anchor(), Some(&2));
+    assert!(sel.revision() > rev_after_anchor);
+
+    // Replace with a set that does not contain the old anchor: anchor falls back to first.
+    sel.replace_with([10, 11]);
+    assert_eq!(sel.items(), &[10, 11]);
+    assert_eq!(sel.primary(), Some(&10));
+    assert_eq!(sel.anchor(), Some(&10));
+}
+
+#[test]
+fn extend_with_adds_items_and_does_not_move_anchor() {
+    let mut sel = Selection::new();
+    sel.replace_with([1, 2]);
+    sel.set_anchor(&1);
+    let rev_before = sel.revision();
+
+    sel.extend_with([2, 3, 3, 4]);
+    assert_eq!(sel.items(), &[1, 2, 3, 4]);
+    assert_eq!(sel.anchor(), Some(&1));
+    assert!(sel.revision() > rev_before);
+}
+
+#[test]
+fn add_and_remove_update_primary_and_revision() {
+    let mut sel = Selection::new();
+    sel.add(1);
+    sel.add(2);
+    assert_eq!(sel.items(), &[1, 2]);
+    assert_eq!(sel.primary(), Some(&2));
+
+    let rev_before = sel.revision();
+    // Adding an already-selected key should only move primary.
+    sel.add(1);
+    assert_eq!(sel.primary(), Some(&1));
+    assert!(sel.revision() > rev_before);
+
+    // Removing a non-existent key is a no-op.
+    let rev_before_remove = sel.revision();
+    sel.remove(&99);
+    assert_eq!(sel.revision(), rev_before_remove);
+
+    // Removing an existing key updates contents and revision.
+    sel.remove(&1);
+    assert_eq!(sel.items(), &[2]);
+    assert!(sel.revision() > rev_before_remove);
+}
+
+#[test]
+fn toggle_adds_and_removes_with_revision() {
+    let mut sel = Selection::new();
+
+    sel.toggle(1);
+    assert_eq!(sel.items(), &[1]);
+    assert_eq!(sel.primary(), Some(&1));
+    let rev_after_add = sel.revision();
+
+    sel.toggle(1);
+    assert!(sel.items().is_empty());
+    assert!(sel.primary().is_none());
+    assert!(sel.anchor().is_none());
+    assert!(sel.revision() > rev_after_add);
+}
+
+#[test]
+fn set_primary_and_anchor_are_noops_when_unchanged() {
+    let mut sel = Selection::new();
+    sel.replace_with([1, 2, 3]);
+    sel.set_primary(&2);
+    sel.set_anchor(&1);
+    let rev_after_init = sel.revision();
+
+    // Setting to the same values should not bump revision.
+    sel.set_primary(&2);
+    sel.set_anchor(&1);
+    assert_eq!(sel.revision(), rev_after_init);
+}
+
+#[test]
+fn clear_anchor_only_changes_when_anchor_is_some() {
+    let mut sel = Selection::new();
+    sel.replace_with([1, 2]);
+    sel.set_anchor(&2);
+    let rev_with_anchor = sel.revision();
+
+    sel.clear_anchor();
+    assert!(sel.anchor().is_none());
+    assert!(sel.revision() > rev_with_anchor);
+
+    let rev_without_anchor = sel.revision();
+    sel.clear_anchor();
+    assert_eq!(sel.revision(), rev_without_anchor);
+}


### PR DESCRIPTION
Add a new `understory_selection` crate to the workspace, providing a small, generic selection container that higher layers can use for lists, canvases, and other selection UIs.

Highlights

- `no_std` + `alloc`.
- `Selection<T>` type:
  - Stores unique `T` items in a `Vec<T>` (no `Hash`/`Ord` constraints; only `T: PartialEq` for mutation/query APIs).
  - Tracks:
    - `primary`: `Option<usize>` – the distinguished “primary” element.
    - `anchor`: `Option<usize>` – a stable pivot for range-like operations.
    - `revision`: `u64` – a monotonic change counter.
  - Public API:
    - Queries: `new`, `is_empty`, `len`, `items`, `iter`, `contains`, `primary`, `anchor`, `revision`.
    - Mutations: `clear`, `select_only`, `replace_with`, `extend_with`, `add`, `remove`, `toggle`, `set_primary`, `set_anchor`, `clear_anchor`.
  - Semantics:
    - `revision` only bumps when the semantic state changes (contents, primary, or anchor). No-op calls (e.g. `clear` on empty, `select_only` on same singleton, `set_primary`/`set_anchor` to existing values) leave it unchanged.
    - `select_only` and `replace_with` are “pivot-setting” operations (set primary and anchor; `replace_with` preserves the previous anchor if its key is still present).
    - `add`, `extend_with`, `toggle` are “modifiers”: they update contents and primary, and only affect anchor when removing the anchored element.