### PR TITLE
Add `understory_view2d` viewport crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_MIN_VER: "1.88"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree -p understory_responder -p understory_focus -p understory_precise_hit -p understory_selection"
+  RUST_MIN_VER_PKGS: "-p understory_index -p understory_box_tree -p understory_responder -p understory_focus -p understory_precise_hit -p understory_selection -p understory_view2d"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default"
 
@@ -109,6 +109,9 @@ jobs:
 
       - name: check understory_responder README
         run: cargo rdme --workspace-project=understory_responder --heading-base-level=0 --check
+
+      - name: check understory_view2d README
+        run: cargo rdme --workspace-project=understory_view2d --heading-base-level=0 --check
 
       - name: check understory_focus README
         run: cargo rdme --workspace-project=understory_focus --heading-base-level=0 --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,13 @@ name = "understory_selection"
 version = "0.1.0"
 
 [[package]]
+name = "understory_view2d"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,9 @@ members = [
   "understory_box_tree",
   "understory_focus",
   "understory_precise_hit",
-  "understory_selection",
   "understory_responder",
+  "understory_selection",
+  "understory_view2d",
   "benches",
   "examples",
 ]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Generic over the key type `T` (no `Hash`/`Ord` requirement; only `PartialEq`), suitable for list selections, canvases, and other selection UIs.
   - Intended to pair with `understory_box_tree` / `understory_precise_hit` for hit testing and `understory_responder` for event routing.
 
+- `understory_view2d`
+  - 2D and 1D view/viewport primitives:
+    - `Viewport2D` for canvas/CAD‑style views: camera state (pan + zoom), coordinate conversion between world and device space, view fitting (center vs align‑min), and simple clamping against optional world bounds.
+    - `Viewport1D` for timeline/axis‑style views: X‑only zoom/pan with range fitting and clamping, plus helpers for suggesting grid spacing.
+  - Headless and renderer‑agnostic; intended to be driven by `ui-events` at higher layers and paired with `understory_box_tree` / imaging crates for canvas and timeline applications.
+
 All core crates are `#![no_std]` and use `alloc`.
 Examples and tests use `std`.
 
@@ -88,6 +94,7 @@ For example, a canvas or DWG or DXF viewer can reuse the box and index layers wi
   - `understory_responder/README.md` explains routing, capture, and how to integrate with a picker.
   - `understory_focus/README.md` covers focus navigation policies and adapters.
   - `understory_selection/README.md` documents the selection container, anchor/revision semantics, and click helpers.
+  - `understory_view2d/README.md` documents the 2D and 1D viewport types, clamping/fit modes, and examples of using visible regions for culling.
 - Run examples.
   - `cargo run -p understory_examples --example index_basics`
   - `cargo run -p understory_examples --example box_tree_basics`

--- a/understory_view2d/Cargo.toml
+++ b/understory_view2d/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "understory_view2d"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "2D view and viewport primitives for Understory: pan/zoom, coordinate conversion, and view fitting."
+keywords = ["ui", "viewport", "camera", "no_std", "understory"]
+categories = ["gui", "graphics", "no-std"]
+
+[dependencies]
+kurbo.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+# Default to std builds for examples/tests/docs.
+default = ["std"]
+# Forward our `std`/`libm` features to Kurbo. With workspace `kurbo` having
+# default-features = false, this fully controls Kurbo's std/no_std mode.
+std = ["kurbo/std"]
+libm = ["kurbo/libm"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_view2d/LICENSE-APACHE
+++ b/understory_view2d/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/understory_view2d/LICENSE-MIT
+++ b/understory_view2d/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/understory_view2d/README.md
+++ b/understory_view2d/README.md
@@ -1,0 +1,149 @@
+<div align="center">
+
+# Understory View 2D
+
+**2D view and viewport primitives for Understory**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_view2d.svg)](https://crates.io/crates/understory_view2d)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_view2d.svg)](https://docs.rs/understory_view2d)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/endoli/understory/ci.yml?logo=github&label=CI)](https://github.com/endoli/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_view2d
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Understory View 2D: 1D and 2D view/viewport primitives.
+
+This crate provides small, headless models of world‑space views where the
+view extents are typically expressed in device pixels. It focuses on:
+- Camera / viewport state (pan + zoom).
+- Coordinate conversion between world and view/device (pixel) space.
+- View fitting and centering/alignment helpers.
+- Simple zoom / pan constraints.
+
+It does **not** own any scene graph or rendering backend. Callers are
+expected to:
+- Maintain their own scene or display tree.
+- Use [`Viewport2D`] / [`Viewport1D`] to derive transforms and
+  visible‑region bounds.
+- Wire input events (for example, from `ui-events`) into pan/zoom
+  operations at a higher layer.
+- Optionally combine `world_units_per_pixel` helpers with display DPI and
+  external unit libraries (for example `joto_constants`) to reason about
+  physical sizes.
+
+## Minimal 2D example
+
+```rust
+use kurbo::{Point, Rect};
+use understory_view2d::Viewport2D;
+
+// Device/view rect: 800x600 window.
+let view_rect = Rect::new(0.0, 0.0, 800.0, 600.0);
+let mut view = Viewport2D::new(view_rect);
+
+// Optional world bounds for fitting/clamping.
+view.set_world_bounds(Some(Rect::new(-100.0, -100.0, 100.0, 100.0)));
+view.fit_world();
+
+// Convert a device-space point into world space (for hit testing, etc.).
+let device_pt = Point::new(400.0, 300.0);
+let world_pt = view.view_to_world_point(device_pt);
+```
+
+## Minimal 1D example (timeline/axis)
+
+```rust
+use understory_view2d::Viewport1D;
+
+// 0..800 view span in pixels.
+let span = 0.0..800.0;
+let mut view = Viewport1D::new(span);
+
+// World bounds in \"time\" units.
+view.set_world_bounds(Some(0.0..120.0));
+view.fit_world();
+
+// Convert a device-space X coordinate into world-space time.
+let device_x = 400.0;
+let world_t = view.view_to_world_x(device_x);
+```
+
+## Design notes
+
+- Cameras are axis‑aligned with a **uniform** zoom factor.
+- Panning operates in view space; zooming is expressed as a scalar.
+- Rotation is intentionally left out of the initial design and can be
+  added later as a backwards‑compatible extension.
+- Controllers that interpret `ui-events` and more complex behaviors such
+  as inertia are expected to live in higher‑level crates built on top of
+  this one.
+
+## Culling example
+
+`Viewport2D` can be used to compute a visible world rectangle for culling.
+For example, given a list of world‑space rectangles, you can retain only
+those that intersect the current view:
+
+```rust
+use kurbo::Rect;
+use understory_view2d::Viewport2D;
+
+let view_rect = Rect::new(0.0, 0.0, 800.0, 600.0);
+let view = Viewport2D::new(view_rect);
+
+let visible_world = view.visible_world_rect();
+let world_items: &[Rect] = &[
+    Rect::new(-10.0, -10.0, 10.0, 10.0),
+    Rect::new(1_000.0, 1_000.0, 1_100.0, 1_100.0),
+];
+
+let visible_items: Vec<Rect> = world_items
+    .iter()
+    .copied()
+    .filter(|r| r.intersect(visible_world).area() > 0.0)
+    .collect();
+assert!(!visible_items.is_empty());
+```
+
+This crate is `no_std`.
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>), or
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>),
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ../AUTHORS
+[LICENSE-APACHE]: LICENSE-APACHE
+[LICENSE-MIT]: LICENSE-MIT
+

--- a/understory_view2d/src/lib.rs
+++ b/understory_view2d/src/lib.rs
@@ -1,0 +1,111 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=understory_view2d --heading-base-level=0
+
+//! Understory View 2D: 1D and 2D view/viewport primitives.
+//!
+//! This crate provides small, headless models of world‑space views where the
+//! view extents are typically expressed in device pixels. It focuses on:
+//! - Camera / viewport state (pan + zoom).
+//! - Coordinate conversion between world and view/device (pixel) space.
+//! - View fitting and centering/alignment helpers.
+//! - Simple zoom / pan constraints.
+//!
+//! It does **not** own any scene graph or rendering backend. Callers are
+//! expected to:
+//! - Maintain their own scene or display tree.
+//! - Use [`Viewport2D`] / [`Viewport1D`] to derive transforms and
+//!   visible‑region bounds.
+//! - Wire input events (for example, from `ui-events`) into pan/zoom
+//!   operations at a higher layer.
+//! - Optionally combine `world_units_per_pixel` helpers with display DPI and
+//!   external unit libraries (for example `joto_constants`) to reason about
+//!   physical sizes.
+//!
+//! ## Minimal 2D example
+//!
+//! ```rust
+//! use kurbo::{Point, Rect};
+//! use understory_view2d::Viewport2D;
+//!
+//! // Device/view rect: 800x600 window.
+//! let view_rect = Rect::new(0.0, 0.0, 800.0, 600.0);
+//! let mut view = Viewport2D::new(view_rect);
+//!
+//! // Optional world bounds for fitting/clamping.
+//! view.set_world_bounds(Some(Rect::new(-100.0, -100.0, 100.0, 100.0)));
+//! view.fit_world();
+//!
+//! // Convert a device-space point into world space (for hit testing, etc.).
+//! let device_pt = Point::new(400.0, 300.0);
+//! let world_pt = view.view_to_world_point(device_pt);
+//! ```
+//!
+//! ## Minimal 1D example (timeline/axis)
+//!
+//! ```rust
+//! use understory_view2d::Viewport1D;
+//!
+//! // 0..800 view span in pixels.
+//! let span = 0.0..800.0;
+//! let mut view = Viewport1D::new(span);
+//!
+//! // World bounds in \"time\" units.
+//! view.set_world_bounds(Some(0.0..120.0));
+//! view.fit_world();
+//!
+//! // Convert a device-space X coordinate into world-space time.
+//! let device_x = 400.0;
+//! let world_t = view.view_to_world_x(device_x);
+//! ```
+//!
+//! ## Design notes
+//!
+//! - Cameras are axis‑aligned with a **uniform** zoom factor.
+//! - Panning operates in view space; zooming is expressed as a scalar.
+//! - Rotation is intentionally left out of the initial design and can be
+//!   added later as a backwards‑compatible extension.
+//! - Controllers that interpret `ui-events` and more complex behaviors such
+//!   as inertia are expected to live in higher‑level crates built on top of
+//!   this one.
+//!
+//! ## Culling example
+//!
+//! `Viewport2D` can be used to compute a visible world rectangle for culling.
+//! For example, given a list of world‑space rectangles, you can retain only
+//! those that intersect the current view:
+//!
+//! ```rust
+//! use kurbo::Rect;
+//! use understory_view2d::Viewport2D;
+//!
+//! let view_rect = Rect::new(0.0, 0.0, 800.0, 600.0);
+//! let view = Viewport2D::new(view_rect);
+//!
+//! let visible_world = view.visible_world_rect();
+//! let world_items: &[Rect] = &[
+//!     Rect::new(-10.0, -10.0, 10.0, 10.0),
+//!     Rect::new(1_000.0, 1_000.0, 1_100.0, 1_100.0),
+//! ];
+//!
+//! let visible_items: Vec<Rect> = world_items
+//!     .iter()
+//!     .copied()
+//!     .filter(|r| r.intersect(visible_world).area() > 0.0)
+//!     .collect();
+//! assert!(!visible_items.is_empty());
+//! ```
+//!
+//! This crate is `no_std`.
+
+#![no_std]
+
+mod modes;
+mod viewport1d;
+mod viewport2d;
+
+pub use modes::{ClampMode, FitMode};
+pub use viewport1d::{Viewport1D, Viewport1DDebugInfo};
+pub use viewport2d::{Viewport2D, Viewport2DDebugInfo};

--- a/understory_view2d/src/modes.rs
+++ b/understory_view2d/src/modes.rs
@@ -1,0 +1,39 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Clamp behavior for panning and fitting relative to optional world bounds.
+///
+/// This enum is shared by both [`crate::Viewport2D`] and [`crate::Viewport1D`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum ClampMode {
+    /// Do not apply any clamping; the view may move/zoom freely.
+    None,
+    /// Clamp so that the view never moves completely outside the world bounds.
+    ///
+    /// When world bounds are present, this mode keeps at least some portion of
+    /// them visible if possible.
+    #[default]
+    KeepSomeVisible,
+}
+
+/// How fitted content should be positioned inside the view.
+///
+/// This mode is consulted by [`crate::Viewport2D::fit_world`],
+/// [`crate::Viewport2D::fit_rect`] and [`crate::Viewport1D::fit_world`],
+/// [`crate::Viewport1D::fit_range`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum FitMode {
+    /// Center the fitted content within the view extent.
+    ///
+    /// For [`crate::Viewport2D`] this centers the fitted rectangle in the view
+    /// rect; for [`crate::Viewport1D`] this centers the fitted range in the
+    /// view span.
+    #[default]
+    Center,
+    /// Align the minimum corner of the fitted content with the view origin.
+    ///
+    /// For [`crate::Viewport2D`] this aligns the world‑space minimum corner with
+    /// the view rect origin; for [`crate::Viewport1D`] this aligns the range
+    /// minimum with the start of the view span.
+    AlignMin,
+}

--- a/understory_view2d/src/viewport1d.rs
+++ b/understory_view2d/src/viewport1d.rs
@@ -1,0 +1,456 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::ops::Range;
+
+use kurbo::Point;
+
+use crate::modes::{ClampMode, FitMode};
+
+/// 1D viewport over a world‑space axis.
+///
+/// `Viewport1D` tracks a span in view/device coordinates and a uniform pan+zoom
+/// transform along a single world axis. It is conventionally used for the
+/// horizontal (X) axis in time/timeline views or scroll regions where only the
+/// X dimension is zoomed.
+#[derive(Clone, Debug)]
+pub struct Viewport1D {
+    view_span: Range<f64>,
+    world_bounds: Option<Range<f64>>,
+    zoom: f64,
+    pan: f64,
+    min_zoom: f64,
+    max_zoom: f64,
+    clamp_mode: ClampMode,
+    fit_mode: FitMode,
+}
+
+impl Viewport1D {
+    /// Creates a new 1D viewport over the given view span.
+    ///
+    /// - `view_span` is expressed in view/device units (typically pixels).
+    /// - Initial zoom is `1.0`.
+    /// - Initial pan is zero (world origin maps to `view_span.start`).
+    /// - Zoom is clamped to the range `[1e-6, 1e6]` by default.
+    #[must_use]
+    pub fn new(view_span: Range<f64>) -> Self {
+        Self {
+            view_span,
+            world_bounds: None,
+            zoom: 1.0,
+            pan: 0.0,
+            min_zoom: 1e-6,
+            max_zoom: 1e6,
+            clamp_mode: ClampMode::default(),
+            fit_mode: FitMode::default(),
+        }
+    }
+
+    /// Returns the current view span in device coordinates.
+    #[must_use]
+    pub fn view_span(&self) -> Range<f64> {
+        self.view_span.clone()
+    }
+
+    /// Sets the view span in device coordinates.
+    ///
+    /// This does not change zoom or pan, but it may affect the visible world
+    /// region. Clamping is applied afterwards if world bounds are set.
+    pub fn set_view_span(&mut self, span: Range<f64>) {
+        if self.view_span.start == span.start && self.view_span.end == span.end {
+            return;
+        }
+        self.view_span = span;
+        self.clamp_to_bounds();
+    }
+
+    /// Sets optional world bounds used for clamping and view fitting.
+    pub fn set_world_bounds(&mut self, bounds: Option<Range<f64>>) {
+        if self.world_bounds_is_eq(&bounds) {
+            return;
+        }
+        self.world_bounds = bounds;
+        self.clamp_to_bounds();
+    }
+
+    /// Returns the current world bounds, if any.
+    #[must_use]
+    pub fn world_bounds(&self) -> Option<Range<f64>> {
+        self.world_bounds.clone()
+    }
+
+    /// Returns the current uniform zoom factor.
+    #[must_use]
+    pub fn zoom(&self) -> f64 {
+        self.zoom
+    }
+
+    /// Sets the minimum and maximum zoom factors.
+    ///
+    /// The provided range is normalized so that `min_zoom <= max_zoom`. The
+    /// current zoom is clamped into the new range.
+    pub fn set_zoom_limits(&mut self, min_zoom: f64, max_zoom: f64) {
+        let (min_zoom, max_zoom) = if min_zoom <= max_zoom {
+            (min_zoom, max_zoom)
+        } else {
+            (max_zoom, min_zoom)
+        };
+        self.min_zoom = min_zoom;
+        self.max_zoom = max_zoom;
+        self.set_zoom(self.zoom);
+    }
+
+    /// Sets the zoom factor, clamping it into the configured zoom range.
+    pub fn set_zoom(&mut self, zoom: f64) {
+        let clamped = zoom.clamp(self.min_zoom, self.max_zoom);
+        if (self.zoom - clamped).abs() < f64::EPSILON {
+            return;
+        }
+        self.zoom = clamped;
+        self.clamp_to_bounds();
+    }
+
+    /// Sets the clamp mode for panning relative to world bounds.
+    pub fn set_clamp_mode(&mut self, mode: ClampMode) {
+        if self.clamp_mode != mode {
+            self.clamp_mode = mode;
+            self.clamp_to_bounds();
+        }
+    }
+
+    /// Returns the current clamp mode.
+    #[must_use]
+    pub fn clamp_mode(&self) -> ClampMode {
+        self.clamp_mode
+    }
+
+    /// Sets how fitted content should be positioned inside the view span.
+    pub fn set_fit_mode(&mut self, mode: FitMode) {
+        self.fit_mode = mode;
+    }
+
+    /// Returns the current fit mode.
+    #[must_use]
+    pub fn fit_mode(&self) -> FitMode {
+        self.fit_mode
+    }
+
+    /// Pans the view by a delta in view/device space.
+    ///
+    /// This adjusts the pan offset and then applies clamping relative to world
+    /// bounds if configured.
+    pub fn pan_by_view(&mut self, delta: f64) {
+        if delta == 0.0 {
+            return;
+        }
+        self.pan += delta;
+        self.clamp_to_bounds();
+    }
+
+    /// Zooms around a given anchor point in view/device coordinates.
+    ///
+    /// The anchor point remains fixed in view space as much as possible under
+    /// the new zoom level.
+    pub fn zoom_about_view_point(&mut self, anchor_view_x: f64, factor: f64) {
+        if factor <= 0.0 {
+            return;
+        }
+        let old_zoom = self.zoom;
+        let new_zoom = (old_zoom * factor).clamp(self.min_zoom, self.max_zoom);
+        if (new_zoom - old_zoom).abs() < f64::EPSILON {
+            return;
+        }
+
+        let old_world = self.view_to_world_x(anchor_view_x);
+        self.zoom = new_zoom;
+        let new_anchor_view = self.world_to_view_x(old_world);
+        let delta_view = anchor_view_x - new_anchor_view;
+        self.pan_by_view(delta_view);
+    }
+
+    /// Fits the entire world bounds into the view span, preserving aspect ratio.
+    ///
+    /// If no world bounds are set, this is a no‑op.
+    pub fn fit_world(&mut self) {
+        if let Some(bounds) = self.world_bounds.clone() {
+            self.fit_range(bounds);
+        }
+    }
+
+    /// Fits the given world‑space range into the view span, preserving aspect ratio.
+    pub fn fit_range(&mut self, world_range: Range<f64>) {
+        let w_len = world_range.end - world_range.start;
+        if w_len <= 0.0 {
+            return;
+        }
+        let v_len = self.view_span.end - self.view_span.start;
+        if v_len <= 0.0 {
+            return;
+        }
+
+        let target_zoom = v_len / w_len.max(f64::MIN_POSITIVE);
+        let zoom = target_zoom.clamp(self.min_zoom, self.max_zoom);
+        self.zoom = zoom;
+
+        self.pan = match self.fit_mode {
+            FitMode::Center => {
+                let view_center = (self.view_span.start + self.view_span.end) * 0.5;
+                let world_center = (world_range.start + world_range.end) * 0.5;
+                view_center - (world_center * zoom)
+            }
+            FitMode::AlignMin => {
+                // Align world min to view start.
+                self.view_span.start - world_range.start * zoom
+            }
+        };
+
+        self.clamp_to_bounds();
+    }
+
+    /// Returns the visible world‑space range.
+    #[must_use]
+    pub fn visible_world_range(&self) -> Range<f64> {
+        let start = self.view_to_world_x(self.view_span.start);
+        let end = self.view_to_world_x(self.view_span.end);
+        if start <= end { start..end } else { end..start }
+    }
+
+    /// Converts a world‑space X coordinate into view/device coordinates.
+    #[must_use]
+    pub fn world_to_view_x(&self, x: f64) -> f64 {
+        self.view_span.start + self.pan + self.zoom * x
+    }
+
+    /// Converts a view/device‑space X coordinate into world coordinates.
+    #[must_use]
+    pub fn view_to_world_x(&self, x: f64) -> f64 {
+        (x - self.view_span.start - self.pan) / self.zoom
+    }
+
+    /// Convenience conversion from a `Point`, using its X coordinate.
+    ///
+    /// This helper ignores the point's Y coordinate and uses only `pt.x`. It is
+    /// intended for timelines and other horizontal 1D views where the X axis is
+    /// the world axis of interest.
+    #[must_use]
+    pub fn view_to_world_point_x(&self, pt: Point) -> f64 {
+        self.view_to_world_x(pt.x)
+    }
+
+    /// Returns the current world‑units‑per‑pixel ratio along the X axis.
+    #[must_use]
+    pub fn world_units_per_pixel_x(&self) -> f64 {
+        1.0 / self.zoom
+    }
+
+    /// Suggests a “nice” grid spacing in world units for the current zoom.
+    ///
+    /// The returned value is chosen so that grid lines appear roughly tens of
+    /// pixels apart (using a 1‑2‑5 ladder), with `base` treated as a lower
+    /// bound on the spacing in world units.
+    #[must_use]
+    pub fn suggest_grid_spacing(&self, base: f64) -> f64 {
+        let base = base.abs().max(f64::MIN_POSITIVE);
+        let target_px = 64.0_f64;
+        let wu_per_px = self.world_units_per_pixel_x().abs();
+        let mut desired = wu_per_px * target_px;
+        if desired < base {
+            desired = base;
+        }
+
+        let mut unit = 1.0_f64;
+        while unit * 10.0 <= desired {
+            unit *= 10.0;
+        }
+
+        loop {
+            for m in [1.0_f64, 2.0, 5.0, 10.0] {
+                let step = m * unit;
+                if step >= desired {
+                    return step;
+                }
+            }
+            unit *= 10.0;
+        }
+    }
+
+    /// Snapshot of the current 1D viewport state for debugging and inspection.
+    #[must_use]
+    pub fn debug_info(&self) -> Viewport1DDebugInfo {
+        Viewport1DDebugInfo {
+            view_span: self.view_span.clone(),
+            world_bounds: self.world_bounds.clone(),
+            visible_world_range: self.visible_world_range(),
+            zoom: self.zoom,
+            pan: self.pan,
+            min_zoom: self.min_zoom,
+            max_zoom: self.max_zoom,
+            clamp_mode: self.clamp_mode,
+            fit_mode: self.fit_mode,
+        }
+    }
+
+    fn world_bounds_is_eq(&self, other: &Option<Range<f64>>) -> bool {
+        match (&self.world_bounds, other) {
+            (None, None) => true,
+            (Some(a), Some(b)) => a.start == b.start && a.end == b.end,
+            _ => false,
+        }
+    }
+
+    fn clamp_to_bounds(&mut self) {
+        if self.clamp_mode == ClampMode::None {
+            return;
+        }
+        let bounds = match &self.world_bounds {
+            Some(b) if b.end > b.start => b,
+            _ => return,
+        };
+
+        let visible = self.visible_world_range();
+        if visible.end <= visible.start {
+            return;
+        }
+
+        let mut dx = 0.0;
+
+        if visible.end < bounds.start {
+            dx = bounds.start - visible.end;
+        } else if visible.start > bounds.end {
+            dx = bounds.end - visible.start;
+        }
+
+        if dx != 0.0 {
+            let delta_view = -dx * self.zoom;
+            self.pan += delta_view;
+        }
+    }
+}
+
+/// Debug snapshot of a [`Viewport1D`] state.
+#[derive(Clone, Debug)]
+pub struct Viewport1DDebugInfo {
+    /// Current view span in device coordinates.
+    pub view_span: Range<f64>,
+    /// Optional world bounds for clamping and fitting.
+    pub world_bounds: Option<Range<f64>>,
+    /// World‑space range currently visible through the view.
+    pub visible_world_range: Range<f64>,
+    /// Current uniform zoom factor.
+    pub zoom: f64,
+    /// Current pan offset in view coordinates.
+    pub pan: f64,
+    /// Minimum zoom factor.
+    pub min_zoom: f64,
+    /// Maximum zoom factor.
+    pub max_zoom: f64,
+    /// Clamp mode for panning relative to bounds.
+    pub clamp_mode: ClampMode,
+    /// Fit mode used by [`Viewport1D::fit_world`] / [`Viewport1D::fit_range`].
+    pub fit_mode: FitMode,
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ops::Range;
+
+    use kurbo::Point;
+
+    use super::{ClampMode, FitMode, Viewport1D};
+
+    #[test]
+    fn world_view_roundtrip_1d() {
+        let mut vp = Viewport1D::new(0.0..800.0);
+        vp.set_zoom(2.0);
+        vp.pan_by_view(10.0);
+
+        let world_x = 123.456;
+        let view_x = vp.world_to_view_x(world_x);
+        let back = vp.view_to_world_x(view_x);
+        assert!((back - world_x).abs() < 1e-9);
+    }
+
+    #[test]
+    fn zoom_about_anchor_keeps_anchor_fixed_1d() {
+        let vp_span = 0.0..800.0;
+        let mut vp = Viewport1D::new(vp_span.clone());
+
+        let anchor_view = (vp_span.start + vp_span.end) * 0.5;
+        let world_at_anchor_before = vp.view_to_world_x(anchor_view);
+
+        vp.zoom_about_view_point(anchor_view, 3.0);
+        let world_at_anchor_after = vp.view_to_world_x(anchor_view);
+
+        assert!((world_at_anchor_after - world_at_anchor_before).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fit_range_center_and_align_min() {
+        let view_span = 0.0..200.0;
+        let world_range = -50.0..150.0;
+        let mut vp = Viewport1D::new(view_span.clone());
+
+        // Center mode.
+        vp.set_fit_mode(FitMode::Center);
+        vp.fit_range(world_range.clone());
+        let world_center = (world_range.start + world_range.end) * 0.5;
+        let view_center = (view_span.start + view_span.end) * 0.5;
+        let mapped_center = vp.world_to_view_x(world_center);
+        assert!((mapped_center - view_center).abs() < 1e-6);
+
+        // AlignMin mode.
+        let mut vp = Viewport1D::new(view_span.clone());
+        vp.set_fit_mode(FitMode::AlignMin);
+        vp.fit_range(world_range.clone());
+        let mapped_min = vp.world_to_view_x(world_range.start);
+        assert!((mapped_min - view_span.start).abs() < 1e-6);
+    }
+
+    #[test]
+    fn clamp_keeps_some_world_visible_1d() {
+        let mut vp = Viewport1D::new(0.0..100.0);
+        vp.set_clamp_mode(ClampMode::KeepSomeVisible);
+        vp.set_world_bounds(Some(0.0..50.0));
+
+        vp.pan_by_view(10_000.0);
+        let vis = vp.visible_world_range();
+        assert!(vis.end >= 0.0 - 1e-6);
+    }
+
+    #[test]
+    fn suggest_grid_spacing_and_debug_info_1d() {
+        let mut vp = Viewport1D::new(0.0..800.0);
+        let base = 0.01;
+        let s0 = vp.suggest_grid_spacing(base);
+        assert!(s0 >= base);
+
+        vp.set_zoom(10.0);
+        let s1 = vp.suggest_grid_spacing(base);
+        assert!(s1 <= s0);
+
+        let info = vp.debug_info();
+        assert_eq!(
+            info.view_span,
+            Range {
+                start: 0.0,
+                end: 800.0
+            }
+        );
+        assert_eq!(info.clamp_mode, ClampMode::KeepSomeVisible);
+        assert_eq!(info.fit_mode, FitMode::Center);
+    }
+
+    #[test]
+    fn view_to_world_point_x_ignores_y_coordinate() {
+        let mut vp = Viewport1D::new(0.0..800.0);
+        vp.set_zoom(3.0);
+        vp.pan_by_view(5.0);
+
+        let world_from_y0 = vp.view_to_world_point_x(Point { x: 100.0, y: 0.0 });
+        let world_from_y1 = vp.view_to_world_point_x(Point {
+            x: 100.0,
+            y: 12345.0,
+        });
+        assert!((world_from_y0 - world_from_y1).abs() < 1e-9);
+    }
+}

--- a/understory_view2d/src/viewport2d.rs
+++ b/understory_view2d/src/viewport2d.rs
@@ -1,0 +1,552 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use kurbo::{Affine, Point, Rect, Vec2};
+
+use crate::modes::{ClampMode, FitMode};
+
+/// 2D viewport over a world‑space plane.
+///
+/// `Viewport2D` tracks a rectangular region in device/view space and a
+/// uniform pan+zoom transform mapping world coordinates into that region.
+/// It can be used to:
+/// - Convert points and rectangles between world and view coordinates.
+/// - Pan and zoom around a chosen anchor point.
+/// - Fit the entire world bounds (or a sub‑rect) into the view.
+#[derive(Clone, Debug)]
+pub struct Viewport2D {
+    view_rect: Rect,
+    world_bounds: Option<Rect>,
+    zoom: f64,
+    pan: Vec2,
+    min_zoom: f64,
+    max_zoom: f64,
+    clamp_mode: ClampMode,
+    fit_mode: FitMode,
+    world_to_view: Affine,
+    view_to_world: Affine,
+}
+
+impl Viewport2D {
+    /// Creates a new viewport covering `view_rect` with default zoom and clamping.
+    ///
+    /// - Initial zoom is `1.0`.
+    /// - Initial pan is zero (world origin maps to the view rect origin).
+    /// - Zoom is clamped to the range `[1e-3, 1e3]` by default.
+    #[must_use]
+    pub fn new(view_rect: Rect) -> Self {
+        let mut vp = Self {
+            view_rect,
+            world_bounds: None,
+            zoom: 1.0,
+            pan: Vec2::ZERO,
+            min_zoom: 1e-3,
+            max_zoom: 1e3,
+            clamp_mode: ClampMode::default(),
+            fit_mode: FitMode::default(),
+            world_to_view: Affine::IDENTITY,
+            view_to_world: Affine::IDENTITY,
+        };
+        vp.rebuild_transforms();
+        vp
+    }
+
+    /// Returns the current view rectangle in device coordinates.
+    #[must_use]
+    pub fn view_rect(&self) -> Rect {
+        self.view_rect
+    }
+
+    /// Sets the view rectangle in device coordinates.
+    ///
+    /// This does not change zoom or pan, but it may affect the visible world
+    /// region. Transforms are rebuilt to account for the new rect.
+    pub fn set_view_rect(&mut self, rect: Rect) {
+        if self.view_rect == rect {
+            return;
+        }
+        self.view_rect = rect;
+        self.rebuild_transforms();
+        self.clamp_to_bounds();
+    }
+
+    /// Sets optional world bounds used for clamping and view fitting.
+    pub fn set_world_bounds(&mut self, bounds: Option<Rect>) {
+        if self.world_bounds == bounds {
+            return;
+        }
+        self.world_bounds = bounds;
+        self.clamp_to_bounds();
+    }
+
+    /// Returns the current world bounds, if any.
+    #[must_use]
+    pub fn world_bounds(&self) -> Option<Rect> {
+        self.world_bounds
+    }
+
+    /// Returns the current uniform zoom factor.
+    #[must_use]
+    pub fn zoom(&self) -> f64 {
+        self.zoom
+    }
+
+    /// Sets the minimum and maximum zoom factors.
+    ///
+    /// The provided range is normalized so that `min_zoom <= max_zoom`. The
+    /// current zoom is clamped into the new range.
+    pub fn set_zoom_limits(&mut self, min_zoom: f64, max_zoom: f64) {
+        let (min_zoom, max_zoom) = if min_zoom <= max_zoom {
+            (min_zoom, max_zoom)
+        } else {
+            (max_zoom, min_zoom)
+        };
+        self.min_zoom = min_zoom;
+        self.max_zoom = max_zoom;
+        self.set_zoom(self.zoom);
+    }
+
+    /// Sets the clamp mode for panning relative to world bounds.
+    pub fn set_clamp_mode(&mut self, mode: ClampMode) {
+        if self.clamp_mode != mode {
+            self.clamp_mode = mode;
+            self.clamp_to_bounds();
+        }
+    }
+
+    /// Returns the current clamp mode.
+    #[must_use]
+    pub fn clamp_mode(&self) -> ClampMode {
+        self.clamp_mode
+    }
+
+    /// Sets how fitted content should be positioned inside the view rect.
+    pub fn set_fit_mode(&mut self, mode: FitMode) {
+        self.fit_mode = mode;
+    }
+
+    /// Returns the current fit mode.
+    #[must_use]
+    pub fn fit_mode(&self) -> FitMode {
+        self.fit_mode
+    }
+
+    /// Sets the zoom factor, clamping it into the configured zoom range.
+    pub fn set_zoom(&mut self, zoom: f64) {
+        let clamped = zoom.clamp(self.min_zoom, self.max_zoom);
+        if (self.zoom - clamped).abs() < f64::EPSILON {
+            return;
+        }
+        self.zoom = clamped;
+        self.rebuild_transforms();
+        self.clamp_to_bounds();
+    }
+
+    /// Pans the view by a delta in view/device space.
+    ///
+    /// This adjusts the pan offset and then applies clamping relative to world
+    /// bounds if configured.
+    pub fn pan_by_view(&mut self, delta: Vec2) {
+        if delta == Vec2::ZERO {
+            return;
+        }
+        self.pan += delta;
+        self.rebuild_transforms();
+        self.clamp_to_bounds();
+    }
+
+    /// Zooms around a given anchor point in view/device coordinates.
+    ///
+    /// The anchor point remains fixed in view space as much as possible under
+    /// the new zoom level.
+    pub fn zoom_about_view_point(&mut self, anchor_view: Point, factor: f64) {
+        if factor <= 0.0 {
+            return;
+        }
+        let old_zoom = self.zoom;
+        let new_zoom = (old_zoom * factor).clamp(self.min_zoom, self.max_zoom);
+        if (new_zoom - old_zoom).abs() < f64::EPSILON {
+            return;
+        }
+
+        let old_world = self.view_to_world_point(anchor_view);
+        self.zoom = new_zoom;
+        self.rebuild_transforms();
+        let new_anchor_view = self.world_to_view_point(old_world);
+        let delta_view = anchor_view - new_anchor_view;
+        self.pan_by_view(delta_view);
+    }
+
+    /// Fits the entire world bounds into the view, preserving aspect ratio.
+    ///
+    /// If no world bounds are set, this is a no‑op.
+    pub fn fit_world(&mut self) {
+        if let Some(bounds) = self.world_bounds {
+            self.fit_rect(bounds);
+        }
+    }
+
+    /// Fits the given world‑space rectangle into the view, preserving aspect ratio.
+    pub fn fit_rect(&mut self, rect: Rect) {
+        if rect.width() <= 0.0 || rect.height() <= 0.0 {
+            return;
+        }
+        let view_size = self.view_rect.size();
+        if view_size.width <= 0.0 || view_size.height <= 0.0 {
+            return;
+        }
+
+        let sx = view_size.width / rect.width().max(f64::MIN_POSITIVE);
+        let sy = view_size.height / rect.height().max(f64::MIN_POSITIVE);
+        let target_zoom = sx.min(sy);
+
+        let zoom = target_zoom.clamp(self.min_zoom, self.max_zoom);
+        self.zoom = zoom;
+
+        // Choose pan based on fit mode so that either the content is centered
+        // or its minimum corner aligns with the view origin.
+        let view_origin = self.view_rect.origin().to_vec2();
+        self.pan = match self.fit_mode {
+            FitMode::Center => {
+                let view_center = self.view_rect.center().to_vec2();
+                let world_center = rect.center().to_vec2();
+                view_center - view_origin - world_center * zoom
+            }
+            FitMode::AlignMin => {
+                let world_min = rect.origin().to_vec2();
+                -world_min * zoom
+            }
+        };
+
+        self.rebuild_transforms();
+        self.clamp_to_bounds();
+    }
+
+    /// Centers the view on the given world‑space point.
+    pub fn center_on(&mut self, world_pt: Point) {
+        let view_center = self.view_rect.center();
+        let world_in_view = self.world_to_view_point(world_pt);
+        let delta = view_center - world_in_view;
+        self.pan_by_view(delta);
+    }
+
+    /// Returns the visible world‑space rectangle.
+    #[must_use]
+    pub fn visible_world_rect(&self) -> Rect {
+        self.view_to_world_rect(self.view_rect)
+    }
+
+    /// Converts a world‑space point into view/device coordinates.
+    #[must_use]
+    pub fn world_to_view_point(&self, pt: Point) -> Point {
+        self.world_to_view * pt
+    }
+
+    /// Converts a view/device‑space point into world coordinates.
+    #[must_use]
+    pub fn view_to_world_point(&self, pt: Point) -> Point {
+        self.view_to_world * pt
+    }
+
+    /// Converts a world‑space rectangle into view/device coordinates.
+    #[must_use]
+    pub fn world_to_view_rect(&self, rect: Rect) -> Rect {
+        // Transform the four corners and take their bounding box. This is
+        // sufficient for the axis‑aligned, uniform zoom transform used here.
+        let p0 = rect.origin();
+        let p1 = Point::new(rect.max_x(), rect.y0);
+        let p2 = Point::new(rect.x0, rect.max_y());
+        let p3 = Point::new(rect.max_x(), rect.max_y());
+        let q0 = self.world_to_view * p0;
+        let q1 = self.world_to_view * p1;
+        let q2 = self.world_to_view * p2;
+        let q3 = self.world_to_view * p3;
+        let min_x = q0.x.min(q1.x).min(q2.x).min(q3.x);
+        let min_y = q0.y.min(q1.y).min(q2.y).min(q3.y);
+        let max_x = q0.x.max(q1.x).max(q2.x).max(q3.x);
+        let max_y = q0.y.max(q1.y).max(q2.y).max(q3.y);
+        Rect::new(min_x, min_y, max_x, max_y)
+    }
+
+    /// Converts a view/device‑space rectangle into world coordinates.
+    #[must_use]
+    pub fn view_to_world_rect(&self, rect: Rect) -> Rect {
+        let p0 = rect.origin();
+        let p1 = Point::new(rect.max_x(), rect.y0);
+        let p2 = Point::new(rect.x0, rect.max_y());
+        let p3 = Point::new(rect.max_x(), rect.max_y());
+        let q0 = self.view_to_world * p0;
+        let q1 = self.view_to_world * p1;
+        let q2 = self.view_to_world * p2;
+        let q3 = self.view_to_world * p3;
+        let min_x = q0.x.min(q1.x).min(q2.x).min(q3.x);
+        let min_y = q0.y.min(q1.y).min(q2.y).min(q3.y);
+        let max_x = q0.x.max(q1.x).max(q2.x).max(q3.x);
+        let max_y = q0.y.max(q1.y).max(q2.y).max(q3.y);
+        Rect::new(min_x, min_y, max_x, max_y)
+    }
+
+    /// Returns the current world‑units‑per‑pixel ratio at the view center.
+    ///
+    /// This is `1.0 / zoom` for the axis‑aligned, uniform zoom model used
+    /// by this crate and can be used to choose grid spacing or stroke
+    /// thickness in world units.
+    #[must_use]
+    pub fn world_units_per_pixel(&self) -> f64 {
+        1.0 / self.zoom
+    }
+
+    /// Returns the current world‑units‑per‑pixel ratio along the X axis.
+    ///
+    /// For the uniform zoom model used by this crate, this is identical
+    /// to [`Viewport2D::world_units_per_pixel`].
+    #[must_use]
+    pub fn world_units_per_pixel_x(&self) -> f64 {
+        self.world_units_per_pixel()
+    }
+
+    /// Returns the current world‑units‑per‑pixel ratio along the Y axis.
+    ///
+    /// For the uniform zoom model used by this crate, this is identical
+    /// to [`Viewport2D::world_units_per_pixel`].
+    #[must_use]
+    pub fn world_units_per_pixel_y(&self) -> f64 {
+        self.world_units_per_pixel()
+    }
+
+    /// Suggests a “nice” grid spacing in world units for the current zoom.
+    ///
+    /// The returned value is chosen so that grid lines appear roughly tens of
+    /// pixels apart (using a 1‑2‑5 ladder), with `base` treated as a lower
+    /// bound on the spacing in world units.
+    #[must_use]
+    pub fn suggest_grid_spacing(&self, base: f64) -> f64 {
+        let base = base.abs().max(f64::MIN_POSITIVE);
+        let target_px = 64.0_f64;
+        let wu_per_px = self.world_units_per_pixel_x().abs();
+        let mut desired = wu_per_px * target_px;
+        if desired < base {
+            desired = base;
+        }
+
+        let mut unit = 1.0_f64;
+        while unit * 10.0 <= desired {
+            unit *= 10.0;
+        }
+
+        loop {
+            for m in [1.0_f64, 2.0, 5.0, 10.0] {
+                let step = m * unit;
+                if step >= desired {
+                    return step;
+                }
+            }
+            unit *= 10.0;
+        }
+    }
+
+    /// Snapshot of the current viewport state for debugging and inspection.
+    #[must_use]
+    pub fn debug_info(&self) -> Viewport2DDebugInfo {
+        Viewport2DDebugInfo {
+            view_rect: self.view_rect,
+            world_bounds: self.world_bounds,
+            visible_world_rect: self.visible_world_rect(),
+            zoom: self.zoom,
+            pan: self.pan,
+            min_zoom: self.min_zoom,
+            max_zoom: self.max_zoom,
+            clamp_mode: self.clamp_mode,
+            fit_mode: self.fit_mode,
+        }
+    }
+
+    fn rebuild_transforms(&mut self) {
+        let view_origin = self.view_rect.origin().to_vec2();
+        let scale = self.zoom;
+        // World → view: translate by pan, then scale, then translate into view rect.
+        self.world_to_view = Affine::translate(view_origin + self.pan) * Affine::scale(scale);
+        self.view_to_world = self.world_to_view.inverse();
+    }
+
+    fn clamp_to_bounds(&mut self) {
+        if self.clamp_mode == ClampMode::None {
+            return;
+        }
+        let bounds = match self.world_bounds {
+            Some(b) if b.width() > 0.0 && b.height() > 0.0 => b,
+            _ => return,
+        };
+
+        // Current visible world rect; we will adjust pan to keep at least some
+        // overlap with `bounds`.
+        let visible = self.visible_world_rect();
+        if visible.width() <= 0.0 || visible.height() <= 0.0 {
+            return;
+        }
+
+        let mut dx = 0.0;
+        let mut dy = 0.0;
+
+        // Horizontal clamping: keep some overlap between visible rect and bounds.
+        if visible.max_x() < bounds.min_x() {
+            dx = bounds.min_x() - visible.max_x();
+        } else if visible.min_x() > bounds.max_x() {
+            dx = bounds.max_x() - visible.min_x();
+        }
+
+        // Vertical clamping.
+        if visible.max_y() < bounds.min_y() {
+            dy = bounds.min_y() - visible.max_y();
+        } else if visible.min_y() > bounds.max_y() {
+            dy = bounds.max_y() - visible.min_y();
+        }
+
+        if dx != 0.0 || dy != 0.0 {
+            // Adjust pan so that the visible world rect moves by `dx`/`dy`
+            // in world space. Increasing pan moves the world in the negative
+            // direction, so we need to negate.
+            let scale = self.zoom;
+            let delta_view = Vec2::new(-dx * scale, -dy * scale);
+            self.pan += delta_view;
+            self.rebuild_transforms();
+        }
+    }
+}
+
+/// Debug snapshot of a [`Viewport2D`] state.
+#[derive(Clone, Copy, Debug)]
+pub struct Viewport2DDebugInfo {
+    /// Current view rectangle in device coordinates.
+    pub view_rect: Rect,
+    /// Optional world bounds for clamping and fitting.
+    pub world_bounds: Option<Rect>,
+    /// World‑space rectangle currently visible through the view.
+    pub visible_world_rect: Rect,
+    /// Current uniform zoom factor.
+    pub zoom: f64,
+    /// Current pan offset in view coordinates.
+    pub pan: Vec2,
+    /// Minimum zoom factor.
+    pub min_zoom: f64,
+    /// Maximum zoom factor.
+    pub max_zoom: f64,
+    /// Clamp mode for panning relative to bounds.
+    pub clamp_mode: ClampMode,
+    /// Fit mode used by [`Viewport2D::fit_world`] / [`Viewport2D::fit_rect`].
+    pub fit_mode: FitMode,
+}
+
+#[cfg(test)]
+mod tests {
+    use kurbo::{Point, Rect};
+
+    use super::{ClampMode, FitMode, Viewport2D};
+
+    #[test]
+    fn basic_world_view_roundtrip() {
+        let view_rect = Rect::new(0.0, 0.0, 800.0, 600.0);
+        let vp = Viewport2D::new(view_rect);
+
+        let world_pt = Point::new(10.0, -5.0);
+        let view_pt = vp.world_to_view_point(world_pt);
+        let world_back = vp.view_to_world_point(view_pt);
+        assert!((world_back.x - world_pt.x).abs() < 1e-9);
+        assert!((world_back.y - world_pt.y).abs() < 1e-9);
+    }
+
+    #[test]
+    fn zoom_about_anchor_keeps_anchor_fixed() {
+        let view_rect = Rect::new(0.0, 0.0, 800.0, 600.0);
+        let mut vp = Viewport2D::new(view_rect);
+
+        // Choose an anchor at the center of the view.
+        let anchor_view = view_rect.center();
+        let world_at_anchor_before = vp.view_to_world_point(anchor_view);
+
+        vp.zoom_about_view_point(anchor_view, 2.0);
+        let world_at_anchor_after = vp.view_to_world_point(anchor_view);
+
+        assert!((world_at_anchor_after.x - world_at_anchor_before.x).abs() < 1e-9);
+        assert!((world_at_anchor_after.y - world_at_anchor_before.y).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fit_world_respects_bounds_and_aspect_ratio() {
+        let view_rect = Rect::new(0.0, 0.0, 200.0, 100.0);
+        let mut vp = Viewport2D::new(view_rect);
+
+        let world_bounds = Rect::new(-50.0, -25.0, 50.0, 25.0);
+        vp.set_world_bounds(Some(world_bounds));
+        vp.fit_world();
+
+        let visible = vp.visible_world_rect();
+        // The world bounds should be fully visible; allow tiny numeric slack.
+        assert!(visible.min_x() <= world_bounds.min_x() + 1e-9);
+        assert!(visible.max_x() >= world_bounds.max_x() - 1e-9);
+        assert!(visible.min_y() <= world_bounds.min_y() + 1e-9);
+        assert!(visible.max_y() >= world_bounds.max_y() - 1e-9);
+    }
+
+    #[test]
+    fn fit_mode_align_min_aligns_world_min_to_view_origin() {
+        let view_rect = Rect::new(0.0, 0.0, 200.0, 100.0);
+        let mut vp = Viewport2D::new(view_rect);
+        vp.set_fit_mode(FitMode::AlignMin);
+
+        let world_bounds = Rect::new(-50.0, -20.0, 150.0, 80.0);
+        vp.set_world_bounds(Some(world_bounds));
+        vp.fit_world();
+
+        // World min corner should map close to the view origin.
+        let view_origin_world = vp.world_to_view_point(world_bounds.origin());
+        let origin = view_rect.origin();
+        assert!((view_origin_world.x - origin.x).abs() < 1e-6);
+        assert!((view_origin_world.y - origin.y).abs() < 1e-6);
+    }
+
+    #[test]
+    fn extend_and_fit_preserve_anchor_and_clamp() {
+        let view_rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let mut vp = Viewport2D::new(view_rect);
+        vp.set_clamp_mode(ClampMode::KeepSomeVisible);
+
+        let bounds = Rect::new(0.0, 0.0, 50.0, 50.0);
+        vp.set_world_bounds(Some(bounds));
+        vp.fit_world();
+
+        // Attempt to pan far away; clamping should pull the view back so that
+        // the visible rect still overlaps the bounds.
+        vp.pan_by_view((1000.0, 1000.0).into());
+        let visible = vp.visible_world_rect();
+
+        assert!(visible.max_x() >= bounds.min_x() - 1e-6);
+        assert!(visible.max_y() >= bounds.min_y() - 1e-6);
+    }
+
+    #[test]
+    fn suggest_grid_spacing_and_debug_info_2d() {
+        let view_rect = Rect::new(0.0, 0.0, 400.0, 300.0);
+        let mut vp = Viewport2D::new(view_rect);
+
+        let base = 0.01;
+        let s0 = vp.suggest_grid_spacing(base);
+        assert!(s0 >= base);
+
+        // Zoom in: world units per pixel get smaller, so suggested spacing should
+        // also get smaller or stay the same.
+        vp.set_zoom(10.0);
+        let s1 = vp.suggest_grid_spacing(base);
+        assert!(s1 <= s0);
+
+        // Zoom out: suggested spacing should grow.
+        vp.set_zoom(0.1);
+        let s2 = vp.suggest_grid_spacing(base);
+        assert!(s2 >= s1);
+
+        let info = vp.debug_info();
+        assert_eq!(info.view_rect, view_rect);
+        assert_eq!(info.clamp_mode, ClampMode::KeepSomeVisible);
+        assert!(info.min_zoom <= info.max_zoom);
+    }
+}


### PR DESCRIPTION
This adds a new `understory_view2d` crate that provides reusable camera/viewport types:

- `Viewport2D` – 2D pan/zoom camera over a world-space plane:
  - Tracks a device-space `Rect`, uniform zoom and pan, optional world bounds.
  - Supports world↔view transforms, fitting a world rect into the view, and simple clamping via `ClampMode` and `FitMode`.
- `Viewport1D` – 1D pan/zoom camera for timelines/axes:
  - Tracks a device-space `Range<f64>`, uniform zoom and pan along a single axis, optional world bounds.
  - Supports world↔view conversions in X, fitting a world range into the span, and clamping with the same `ClampMode` / `FitMode`.