### PR TITLE
box_tree: Change default clip behavior to `Inherit`

### DIFF
--- a/understory_box_tree/src/types.rs
+++ b/understory_box_tree/src/types.rs
@@ -11,9 +11,9 @@ pub enum ClipBehavior {
     /// Do not apply any clip (ignore local clip and ancestor clip).
     None,
     /// Use the local clip if present; otherwise inherit any ancestor clip.
-    #[default]
     PreferLocal,
     /// Apply parent clip if present; if both local and parent clips exist, intersect them.
+    #[default]
     Inherit,
 }
 
@@ -109,8 +109,8 @@ pub struct LocalNode {
     /// - Points outside `local_clip` (once transformed) cannot hit this node or any descendant.
     ///   Backends may still apply more precise clipping during rendering.
     pub local_clip: Option<RoundedRect>,
-    /// How to compose local and ancestor clips for this node (defaults to [`ClipBehavior::PreferLocal`],
-    /// which falls back to the parent clip when no local clip is set).
+    /// How to compose local and ancestor clips for this node (defaults to
+    /// [`ClipBehavior::Inherit`], which intersects the local clip, if any, with the parent clip).
     pub clip_behavior: ClipBehavior,
     /// Z-order within the parent stacking context.
     ///


### PR DESCRIPTION
If a node has a clip, likely the most expected behavior is for no children of that node to spill outside the clip (also if any children have their own clips).

When `ClipBehavior` was introduced in
https://github.com/endoli/understory/pull/28, the default was set to the old behavior of children with clips ignoring their parents' clips.