### PR TITLE
box_tree: Make `Tree::update_world_recursive` use a loop

### DIFF
--- a/understory_box_tree/src/tree.rs
+++ b/understory_box_tree/src/tree.rs
@@ -760,7 +760,7 @@ impl<B: Backend<f64>> Tree<B> {
 
     fn update_world_recursive(
         &mut self,
-        id: NodeId,
+        root_id: NodeId,
         root_tf: Affine,
         root_clip: Option<Rect>,
         damage: &mut Damage,
@@ -772,7 +772,7 @@ impl<B: Backend<f64>> Tree<B> {
 
         // The world is updated by walking the tree depth-first, propagating transforms and clips
         // toward the leaves.
-        let mut stack = vec![(id, root_tf, root_clip)];
+        let mut stack = vec![(root_id, root_tf, root_clip)];
 
         while let Some((id, current_tf, current_clip)) = stack.pop() {
             let node = self.node_mut(id);


### PR DESCRIPTION
This will allow for bigger trees to be updated as we're not limited by stack size, but some of the other recursive methods may be slightly harder to rewrite.

If the allocation turns out to be a problem, we could introduce a reusable scratch buffer. There are some ways to do this without needing allocation (e.g., if we have a topological order of the tree, we can walk through the tree in that order, for each node knowing all its ancestors have already been updated).