### PR TITLE
Add grid backend to `understory_index` (feature-gated)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,23 @@
+# See the configuration reference at
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+# Match Identifier - Case Sensitive
+[default.extend-identifiers]
+iy = "iy"
+iy0 = "iy0"
+iy1 = "iy1"
+
+# Match Inside a Word - Case Insensitive
+[default.extend-words]
+
+[files]
+# Include .github, .cargo, etc.
+ignore-hidden = false
+# /.git isn't in .gitignore, because git never tracks it.
+# Typos doesn't know that, though.
+extend-exclude = ["/.git"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "euclid"
 version = "0.22.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +192,12 @@ checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "half"
@@ -199,6 +217,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -536,6 +565,10 @@ dependencies = [
 [[package]]
 name = "understory_index"
 version = "0.0.1"
+dependencies = [
+ "hashbrown",
+ "smallvec",
+]
 
 [[package]]
 name = "understory_precise_hit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ repository = "https://github.com/endoli/understory"
 # let member crates opt into `std` or `libm` explicitly via their own features.
 kurbo = { version = "0.12.0", default-features = false }
 bitflags = "2.10.0"
+hashbrown = "0.16.1"
+smallvec = { version = "1.13.2", default-features = false }
 
 [workspace.lints]
 # LINEBENDER LINT SET - Cargo.toml - v7

--- a/understory_box_tree/README.md
+++ b/understory_box_tree/README.md
@@ -54,12 +54,13 @@ code is expected to introduce groups, stacking semantics, and paint order if nee
 ## Integration with Understory Index
 
 This crate uses [`understory_index`] for spatial queries. You can choose the backend and scalar to
-fit your workload (flat vector, R-tree or BVH). Float inputs are
+fit your workload (flat vector, grid, R-tree, or BVH). Float inputs are
 assumed to be finite (no NaNs). AABBs are loose for non-axis-aligned transforms and rounded
 clips: we store an axis-aligned box that fully contains what is drawn, but it is not
 guaranteed to be tight.
 
 See [`understory_index::Index`],
+[`understory_index::backends::GridF32`]/[`understory_index::backends::GridF64`]/[`understory_index::backends::GridI64`],
 [`understory_index::backends::RTreeF32`]/[`understory_index::backends::RTreeF64`]/[`understory_index::backends::RTreeI64`],
 and
 [`understory_index::backends::BvhF32`]/[`understory_index::backends::BvhF64`]/[`understory_index::backends::BvhI64`]

--- a/understory_box_tree/src/lib.rs
+++ b/understory_box_tree/src/lib.rs
@@ -37,12 +37,13 @@
 //! ## Integration with Understory Index
 //!
 //! This crate uses [`understory_index`] for spatial queries. You can choose the backend and scalar to
-//! fit your workload (flat vector, R-tree or BVH). Float inputs are
+//! fit your workload (flat vector, grid, R-tree, or BVH). Float inputs are
 //! assumed to be finite (no NaNs). AABBs are loose for non-axis-aligned transforms and rounded
 //! clips: we store an axis-aligned box that fully contains what is drawn, but it is not
 //! guaranteed to be tight.
 //!
 //! See [`understory_index::Index`],
+//! [`understory_index::backends::GridF32`]/[`understory_index::backends::GridF64`]/[`understory_index::backends::GridI64`],
 //! [`understory_index::backends::RTreeF32`]/[`understory_index::backends::RTreeF64`]/[`understory_index::backends::RTreeI64`],
 //! and
 //! [`understory_index::backends::BvhF32`]/[`understory_index::backends::BvhF64`]/[`understory_index::backends::BvhI64`]

--- a/understory_index/Cargo.toml
+++ b/understory_index/Cargo.toml
@@ -8,7 +8,13 @@ repository = "https://github.com/endoli/understory"
 keywords = ["spatial", "aabb", "index", "rtree", "bvh"]
 categories = ["data-structures", "graphics", "no-std"]
 
+[features]
+default = ["backend_grid"]
+backend_grid = ["dep:hashbrown", "dep:smallvec"]
+
 [dependencies]
+hashbrown = { workspace = true, optional = true }
+smallvec = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/understory_index/README.md
+++ b/understory_index/README.md
@@ -31,8 +31,14 @@ It is generic over the scalar type `T` and does not depend on any geometry crate
 Higher layers (like a scene or region tree) can compute world-space AABBs and feed them here.
 
 Backends are pluggable via a simple trait so you can swap the spatial strategy without API churn.
-The default backend is a flat vector (linear scan).
-R-tree and BVH backends are generic over the scalar and use widened accumulator types (f32→f64, f64→f64, i64→i128) for SAH-like splits.
+The default backend is a flat vector (linear scan). Additional backends include a uniform grid
+(feature `backend_grid`), and R-tree/BVH implementations with widened accumulator types
+(f32→f64, f64→f64, i64→i128) for SAH-like splits.
+
+## Features
+
+- `backend_grid` *(default)*: enables a uniform grid backend backed by `hashbrown`. Disable
+  this feature to avoid the `hashbrown` dependency and grid types.
 
 # Example
 
@@ -71,10 +77,27 @@ let hits: Vec<_> = idx.query_point(10.0, 10.0).collect();
 assert_eq!(hits.len(), 1);
 ```
 
+With the `backend_grid` feature enabled (default), you can also use a uniform grid backend:
+
+```rust
+use understory_index::{Index, Aabb2D};
+
+// Use a grid backend (f32) with a 64-unit cell size.
+let mut idx = Index::<f32, u32>::with_grid(64.0);
+let _k = idx.insert(Aabb2D::new(0.0, 0.0, 10.0, 10.0), 1);
+let _ = idx.commit();
+
+let hits: Vec<_> = idx.query_point(5.0, 5.0).collect();
+assert_eq!(hits.len(), 1);
+```
+
 ## Choosing a backend
 
 - `FlatVec` (default): simplest and smallest, linear scans. Good for very small sets
   or when inserts/updates vastly outnumber queries.
+- `GridF32`/`GridF64`/`GridI64` *(feature `backend_grid`)*: uniform grid with configurable
+  cell size. A good fit for viewports and UI hit-testing where objects are roughly uniformly
+  distributed in screen space and query rectangles are small compared to the world extent.
 - `RTreeF32`/`RTreeF64`/`RTreeI64`: R-tree with SAH-like splits and widened metrics; good
   general-purpose index when distribution is irregular and updates are frequent.
   See the [`backends`] docs for a brief SAH overview.

--- a/understory_index/src/backends/grid.rs
+++ b/understory_index/src/backends/grid.rs
@@ -1,0 +1,403 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Uniform grid backend for 2D AABBs.
+//!
+//! This backend buckets AABBs into fixed-size grid cells and answers queries
+//! by touching only the cells overlapping the query primitive. It is intended
+//! for workloads with:
+//! - moderately uniform spatial density (e.g., viewports, UI hit-testing),
+//! - dynamic updates, and
+//! - query rectangles that are small compared to the full world extent.
+
+use alloc::vec::Vec;
+use core::fmt::Debug;
+
+use hashbrown::{HashMap, HashSet};
+use smallvec::SmallVec;
+
+use crate::backend::Backend;
+use crate::types::{Aabb2D, Scalar};
+
+/// Scalar types supported by the grid backend.
+///
+/// This is kept separate from [`Scalar`] so that the grid implementation can
+/// use type-specific logic (e.g., Euclidean division for integers).
+pub trait GridScalar: Scalar {
+    /// Map a scalar coordinate to a grid coordinate along one axis.
+    ///
+    /// The mapping is based on an origin and uniform cell size. Implementations
+    /// are expected to be monotonic in `value` for fixed `origin` and
+    /// `cell_size`.
+    fn cell_coord(value: Self, origin: Self, cell_size: Self) -> i32;
+}
+
+impl GridScalar for f32 {
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "Grid cell indices are intentionally i32; higher bits are truncated by design."
+    )]
+    #[inline]
+    fn cell_coord(value: Self, origin: Self, cell_size: Self) -> i32 {
+        debug_assert!(
+            cell_size > 0.0,
+            "grid cell_size must be strictly positive (f32)"
+        );
+        let t = (value - origin) / cell_size;
+        if t >= 0.0 {
+            t as i32
+        } else {
+            let ti = t as i32;
+            if (ti as Self) == t { ti } else { ti - 1 }
+        }
+    }
+}
+
+impl GridScalar for f64 {
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "Grid cell indices are intentionally i32; higher bits are truncated by design."
+    )]
+    #[inline]
+    fn cell_coord(value: Self, origin: Self, cell_size: Self) -> i32 {
+        debug_assert!(
+            cell_size > 0.0,
+            "grid cell_size must be strictly positive (f64)"
+        );
+        let t = (value - origin) / cell_size;
+        if t >= 0.0 {
+            t as i32
+        } else {
+            let ti = t as i32;
+            if (ti as Self) == t { ti } else { ti - 1 }
+        }
+    }
+}
+
+impl GridScalar for i64 {
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "Grid cell indices are intentionally i32; higher bits are truncated by design."
+    )]
+    #[inline]
+    fn cell_coord(value: Self, origin: Self, cell_size: Self) -> i32 {
+        debug_assert!(
+            cell_size > 0,
+            "grid cell_size must be strictly positive (i64)"
+        );
+        let rel = value - origin;
+        // Euclidean division rounds toward -∞, which matches floor for all
+        // integer values.
+        (rel.div_euclid(cell_size)) as i32
+    }
+}
+
+/// Uniform grid backend with fixed cell size.
+pub struct Grid<T: GridScalar> {
+    cell_size: T,
+    origin_x: T,
+    origin_y: T,
+    cells: HashMap<(i32, i32), Cell>,
+    slots: Vec<Option<SlotEntry<T>>>,
+}
+
+#[derive(Clone, Debug)]
+struct SlotEntry<T: GridScalar> {
+    aabb: Aabb2D<T>,
+    // Cells currently containing this AABB.
+    cells: SmallVec<[(i32, i32); 4]>,
+}
+
+#[derive(Default)]
+struct Cell {
+    slots: SmallVec<[usize; 8]>,
+}
+
+impl<T: GridScalar> Debug for Grid<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let total_slots = self.slots.len();
+        let live_slots = self.slots.iter().filter(|s| s.is_some()).count();
+        let num_cells = self.cells.len();
+        f.debug_struct("Grid")
+            .field("cell_size", &self.cell_size)
+            .field("origin_x", &self.origin_x)
+            .field("origin_y", &self.origin_y)
+            .field("total_slots", &total_slots)
+            .field("live_slots", &live_slots)
+            .field("cells", &num_cells)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T: GridScalar> Grid<T> {
+    /// Create a new grid backend with the given cell size and origin at (0, 0).
+    pub fn new(cell_size: T) -> Self {
+        debug_assert!(cell_size > T::zero(), "cell_size must be strictly positive");
+        Self {
+            cell_size,
+            origin_x: T::zero(),
+            origin_y: T::zero(),
+            cells: HashMap::new(),
+            slots: Vec::new(),
+        }
+    }
+
+    /// Create a new grid backend with the given cell size and origin.
+    pub fn with_origin(cell_size: T, origin_x: T, origin_y: T) -> Self {
+        debug_assert!(cell_size > T::zero(), "cell_size must be strictly positive");
+        Self {
+            cell_size,
+            origin_x,
+            origin_y,
+            cells: HashMap::new(),
+            slots: Vec::new(),
+        }
+    }
+
+    fn ensure_slot(&mut self, slot: usize) {
+        if self.slots.len() <= slot {
+            self.slots.resize_with(slot + 1, || None);
+        }
+    }
+
+    fn slot_entry(&self, slot: usize) -> &SlotEntry<T> {
+        self.slots
+            .get(slot)
+            .expect("grid invariant violated: cell references out-of-bounds slot")
+            .as_ref()
+            .expect("grid invariant violated: cell references vacant slot")
+    }
+
+    fn remove_from_cells(&mut self, slot: usize, cells: &[(i32, i32)]) {
+        for &(ix, iy) in cells {
+            let cell = self
+                .cells
+                .get_mut(&(ix, iy))
+                .expect("grid invariant violated: missing cell while removing slot");
+
+            let pos = cell
+                .slots
+                .iter()
+                .position(|&s| s == slot)
+                .expect("grid invariant violated: slot not found in expected cell");
+            cell.slots.swap_remove(pos);
+
+            if cell.slots.is_empty() {
+                // Dropping empty cells keeps the map compact for sparse grids.
+                self.cells.remove(&(ix, iy));
+            }
+        }
+    }
+
+    fn cell_range(&self, min: T, max: T, origin: T) -> (i32, i32) {
+        let c0 = T::cell_coord(min, origin, self.cell_size);
+        let c1 = T::cell_coord(max, origin, self.cell_size);
+        if c0 <= c1 { (c0, c1) } else { (c1, c0) }
+    }
+
+    fn covered_cells(&self, aabb: &Aabb2D<T>) -> SmallVec<[(i32, i32); 4]> {
+        let (ix0, ix1) = self.cell_range(aabb.min_x, aabb.max_x, self.origin_x);
+        let (iy0, iy1) = self.cell_range(aabb.min_y, aabb.max_y, self.origin_y);
+        let mut out: SmallVec<[(i32, i32); 4]> = SmallVec::new();
+        for ix in ix0..=ix1 {
+            for iy in iy0..=iy1 {
+                out.push((ix, iy));
+            }
+        }
+        out
+    }
+}
+
+impl<T: GridScalar> Backend<T> for Grid<T> {
+    fn insert(&mut self, slot: usize, aabb: Aabb2D<T>) {
+        self.ensure_slot(slot);
+
+        // If this slot was previously used, clean up its old cell memberships.
+        if let Some(old) = self.slots[slot].take() {
+            self.remove_from_cells(slot, &old.cells);
+        }
+
+        let cells = self.covered_cells(&aabb);
+        for &(ix, iy) in &cells {
+            self.cells.entry((ix, iy)).or_default().slots.push(slot);
+        }
+        self.slots[slot] = Some(SlotEntry { aabb, cells });
+    }
+
+    fn update(&mut self, slot: usize, aabb: Aabb2D<T>) {
+        // Take the current entry out to avoid aliasing `self` while mutating
+        // grid cells.
+        let current = if let Some(slot_ref) = self.slots.get_mut(slot) {
+            slot_ref.take()
+        } else {
+            None
+        };
+
+        let Some(mut entry) = current else {
+            // If the slot does not exist, treat this as an insert.
+            self.insert(slot, aabb);
+            return;
+        };
+
+        // If the AABB is unchanged, restore the entry and skip work.
+        if entry.aabb == aabb {
+            self.slots[slot] = Some(entry);
+            return;
+        }
+
+        // Remove from old cells.
+        self.remove_from_cells(slot, &entry.cells);
+
+        // Insert into new cells.
+        let cells = self.covered_cells(&aabb);
+        for &(ix, iy) in &cells {
+            self.cells.entry((ix, iy)).or_default().slots.push(slot);
+        }
+        entry.aabb = aabb;
+        entry.cells = cells;
+        self.slots[slot] = Some(entry);
+    }
+
+    fn remove(&mut self, slot: usize) {
+        if slot >= self.slots.len() {
+            return;
+        }
+        if let Some(entry) = self.slots[slot].take() {
+            self.remove_from_cells(slot, &entry.cells);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.cells.clear();
+        self.slots.clear();
+    }
+
+    fn visit_point<F: FnMut(usize)>(&self, x: T, y: T, mut f: F) {
+        let ix = T::cell_coord(x, self.origin_x, self.cell_size);
+        let iy = T::cell_coord(y, self.origin_y, self.cell_size);
+        if let Some(cell) = self.cells.get(&(ix, iy)) {
+            for &slot in &cell.slots {
+                let entry = self.slot_entry(slot);
+                if entry.aabb.contains_point(x, y) {
+                    f(slot);
+                }
+            }
+        }
+    }
+
+    fn visit_rect<F: FnMut(usize)>(&self, rect: Aabb2D<T>, mut f: F) {
+        let (ix0, ix1) = self.cell_range(rect.min_x, rect.max_x, self.origin_x);
+        let (iy0, iy1) = self.cell_range(rect.min_y, rect.max_y, self.origin_y);
+
+        let mut seen: HashSet<usize> = HashSet::new();
+
+        for ix in ix0..=ix1 {
+            for iy in iy0..=iy1 {
+                if let Some(cell) = self.cells.get(&(ix, iy)) {
+                    for &slot in &cell.slots {
+                        if !seen.insert(slot) {
+                            continue;
+                        }
+                        let entry = self.slot_entry(slot);
+                        if entry.aabb.overlaps(&rect) {
+                            f(slot);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Grid backend over `f32` coordinates.
+pub type GridF32 = Grid<f32>;
+/// Grid backend over `f64` coordinates.
+pub type GridF64 = Grid<f64>;
+/// Grid backend over `i64` coordinates.
+pub type GridI64 = Grid<i64>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn insert_update_remove_roundtrip_f32() {
+        let mut grid: GridF32 = GridF32::new(10.0);
+
+        let a = Aabb2D::new(0.0, 0.0, 10.0, 10.0);
+        grid.insert(0, a);
+
+        // Point in the AABB should hit slot 0.
+        let mut hits = Vec::new();
+        grid.visit_point(5.0, 5.0, |s| hits.push(s));
+        assert_eq!(hits, vec![0]);
+
+        // Move the AABB; point should follow.
+        let b = Aabb2D::new(20.0, 20.0, 30.0, 30.0);
+        grid.update(0, b);
+
+        hits.clear();
+        grid.visit_point(5.0, 5.0, |s| hits.push(s));
+        assert!(hits.is_empty());
+
+        hits.clear();
+        grid.visit_point(25.0, 25.0, |s| hits.push(s));
+        assert_eq!(hits, vec![0]);
+
+        // Remove and ensure no hits.
+        grid.remove(0);
+        hits.clear();
+        grid.visit_point(25.0, 25.0, |s| hits.push(s));
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn rect_query_deduplicates_slots() {
+        let mut grid: GridF32 = GridF32::new(5.0);
+
+        // This AABB spans multiple cells.
+        let a = Aabb2D::new(0.0, 0.0, 20.0, 20.0);
+        grid.insert(1, a);
+
+        let rect = Aabb2D::new(2.0, 2.0, 18.0, 18.0);
+        let mut hits = Vec::new();
+        grid.visit_rect(rect, |s| hits.push(s));
+
+        // Slot 1 should be reported exactly once.
+        assert_eq!(hits, vec![1]);
+    }
+
+    #[test]
+    fn update_missing_slot_inserts() {
+        let mut grid: GridF32 = GridF32::new(10.0);
+
+        // Updating an unused slot should behave like insert.
+        let a = Aabb2D::new(0.0, 0.0, 10.0, 10.0);
+        grid.update(5, a);
+
+        let mut hits = Vec::new();
+        grid.visit_point(5.0, 5.0, |s| hits.push(s));
+        assert_eq!(hits, vec![5]);
+    }
+
+    #[test]
+    fn basic_f64_and_i64_grids() {
+        // f64 grid with negative coordinates.
+        let mut g64: GridF64 = GridF64::new(10.0);
+        let a = Aabb2D::new(-25.0, -25.0, -5.0, -5.0);
+        g64.insert(0, a);
+        let mut hits = Vec::new();
+        g64.visit_point(-10.0, -10.0, |s| hits.push(s));
+        assert_eq!(hits, vec![0]);
+
+        // i64 grid with negative coordinates.
+        let mut g_i64: GridI64 = GridI64::new(10);
+        let b = Aabb2D::new(-30, -30, -10, -10);
+        g_i64.insert(3, b);
+        hits.clear();
+        g_i64.visit_point(-20, -20, |s| hits.push(s));
+        assert_eq!(hits, vec![3]);
+    }
+}

--- a/understory_index/src/backends/mod.rs
+++ b/understory_index/src/backends/mod.rs
@@ -6,6 +6,7 @@
 //! - `flatvec`: flat vector with linear scans (small, simple).
 //! - `rtree`: generic R-tree (`T: Scalar`) with SAH-like split (aliases: `RTreeI64`, `RTreeF32`, `RTreeF64`).
 //! - `bvh`: generic BVH (`T: Scalar`) with SAH-like split (aliases: `BvhF32`, `BvhF64`, `BvhI64`).
+//! - `grid` (feature `backend_grid`): uniform grid with configurable cell size.
 //!
 //! SAH note
 //! --------
@@ -21,8 +22,12 @@
 
 pub(crate) mod bvh;
 pub(crate) mod flatvec;
+#[cfg(feature = "backend_grid")]
+pub(crate) mod grid;
 pub(crate) mod rtree;
 
 pub use bvh::{Bvh, BvhF32, BvhF64, BvhI64};
 pub use flatvec::FlatVec;
+#[cfg(feature = "backend_grid")]
+pub use grid::{Grid, GridF32, GridF64, GridI64, GridScalar};
 pub use rtree::{RTree, RTreeF32, RTreeF64, RTreeI64};

--- a/understory_index/src/lib.rs
+++ b/understory_index/src/lib.rs
@@ -16,8 +16,14 @@
 //! Higher layers (like a scene or region tree) can compute world-space AABBs and feed them here.
 //!
 //! Backends are pluggable via a simple trait so you can swap the spatial strategy without API churn.
-//! The default backend is a flat vector (linear scan).
-//! R-tree and BVH backends are generic over the scalar and use widened accumulator types (f32→f64, f64→f64, i64→i128) for SAH-like splits.
+//! The default backend is a flat vector (linear scan). Additional backends include a uniform grid
+//! (feature `backend_grid`), and R-tree/BVH implementations with widened accumulator types
+//! (f32→f64, f64→f64, i64→i128) for SAH-like splits.
+//!
+//! ## Features
+//!
+//! - `backend_grid` *(default)*: enables a uniform grid backend backed by `hashbrown`. Disable
+//!   this feature to avoid the `hashbrown` dependency and grid types.
 //!
 //! # Example
 //!
@@ -56,10 +62,30 @@
 //! assert_eq!(hits.len(), 1);
 //! ```
 //!
+//! With the `backend_grid` feature enabled (default), you can also use a uniform grid backend:
+//!
+//! ```rust
+//! # #[cfg(feature = "backend_grid")]
+//! # {
+//! use understory_index::{Index, Aabb2D};
+//!
+//! // Use a grid backend (f32) with a 64-unit cell size.
+//! let mut idx = Index::<f32, u32>::with_grid(64.0);
+//! let _k = idx.insert(Aabb2D::new(0.0, 0.0, 10.0, 10.0), 1);
+//! let _ = idx.commit();
+//!
+//! let hits: Vec<_> = idx.query_point(5.0, 5.0).collect();
+//! assert_eq!(hits.len(), 1);
+//! # }
+//! ```
+//!
 //! ## Choosing a backend
 //!
 //! - `FlatVec` (default): simplest and smallest, linear scans. Good for very small sets
 //!   or when inserts/updates vastly outnumber queries.
+//! - `GridF32`/`GridF64`/`GridI64` *(feature `backend_grid`)*: uniform grid with configurable
+//!   cell size. A good fit for viewports and UI hit-testing where objects are roughly uniformly
+//!   distributed in screen space and query rectangles are small compared to the world extent.
 //! - `RTreeF32`/`RTreeF64`/`RTreeI64`: R-tree with SAH-like splits and widened metrics; good
 //!   general-purpose index when distribution is irregular and updates are frequent.
 //!   See the [`backends`] docs for a brief SAH overview.


### PR DESCRIPTION
This adds a uniform grid backend to `understory_index`, wires it up behind a feature flag, and updates understory_box_tree and the benchmark crate to exercise and compare it against existing backends.