### PR TITLE
Add new understory_event_state crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,18 +97,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libm"
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -467,9 +467,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -505,11 +505,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "understory_event_state"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+]
+
+[[package]]
 name = "understory_examples"
 version = "0.1.0"
 dependencies = [
  "kurbo",
  "understory_box_tree",
+ "understory_event_state",
  "understory_focus",
  "understory_index",
  "understory_precise_hit",
@@ -602,18 +610,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "understory_selection",
   "understory_view2d",
   "understory_virtual_list",
+  "understory_event_state",
   "benches",
   "examples",
 ]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Not a layout engine.
   - Upstream code (your layout system) decides sizes and positions and then updates this tree.
 
+- `understory_event_state`
+  - Common event state managers for UI interactions: hover enter/leave transitions, focus path changes, transform‑aware click recognition, and drag tracking.
+  - Each manager is a focused state machine that accepts pre‑computed information (root→target paths from `understory_responder`, pointer positions) and emits transition events.
+  - Designed to integrate with any event routing or spatial query system.
+  - Generic over node/widget ID types with no framework assumptions.
+
 - `understory_focus`
   - Focus navigation primitives: navigation intents, per‑node focus properties, and a spatial view of focusable candidates.
   - Provides pluggable policies for directional and ordered navigation, and an optional adapter for integrating with `understory_box_tree`.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,3 +15,4 @@ understory_box_tree = { path = "../understory_box_tree" }
 understory_focus = { path = "../understory_focus" }
 understory_index = { path = "../understory_index" }
 understory_precise_hit = { path = "../understory_precise_hit" }
+understory_event_state = { path = "../understory_event_state" }

--- a/examples/examples/responder_box_tree.rs
+++ b/examples/examples/responder_box_tree.rs
@@ -13,10 +13,10 @@ use std::collections::HashMap;
 
 use kurbo::{Affine, Point, Rect};
 use understory_box_tree::{ClipBehavior, LocalNode, NodeFlags, NodeId, QueryFilter, Tree};
+use understory_event_state::hover::HoverState;
 use understory_responder::adapters::box_tree::{hits_for_rect, top_hit_for_point};
 use understory_responder::dispatcher;
-use understory_responder::hover::{HoverState, path_from_dispatch};
-use understory_responder::router::Router;
+use understory_responder::router::{Router, path_from_dispatch};
 use understory_responder::types::{Outcome, ResolvedHit, WidgetLookup};
 
 fn main() {

--- a/examples/examples/responder_focus.rs
+++ b/examples/examples/responder_focus.rs
@@ -9,7 +9,7 @@
 //! Run:
 //! - `cargo run -p understory_examples --example responder_focus`
 
-use understory_responder::focus::{FocusEvent, FocusState};
+use understory_event_state::focus::{FocusEvent, FocusState};
 use understory_responder::router::Router;
 use understory_responder::types::{ParentLookup, WidgetLookup};
 

--- a/examples/examples/responder_hover.rs
+++ b/examples/examples/responder_hover.rs
@@ -9,8 +9,8 @@
 //! Run:
 //! - `cargo run -p understory_examples --example responder_hover`
 
-use understory_responder::hover::{HoverEvent, HoverState, path_from_dispatch};
-use understory_responder::router::Router;
+use understory_event_state::hover::{HoverEvent, HoverState};
+use understory_responder::router::{Router, path_from_dispatch};
 use understory_responder::types::{DepthKey, Localizer, ParentLookup, ResolvedHit, WidgetLookup};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/understory_event_state/Cargo.toml
+++ b/understory_event_state/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "understory_event_state"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Common event state managers for UI."
+keywords = ["ui", "events", "state", "no_std", "understory"]
+categories = ["gui", "no-std"]
+
+[dependencies]
+kurbo = { workspace = true, default-features = false, optional = true }
+
+
+[lints]
+workspace = true
+
+[features]
+default = ["std", "drag", "click"]
+
+# This crate is `no_std` + `alloc` by default; `std` is only needed when
+# dependants prefer to compile with the standard library.
+# Forward our `std`/`libm` features to Kurbo. With workspace `kurbo` having
+# default-features = false, this fully controls Kurbo's std/no_std mode.
+std = ["kurbo?/std"]
+libm = ["kurbo?/libm"]
+click = ["dep:kurbo"]
+drag = ["dep:kurbo"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_event_state/LICENSE-APACHE
+++ b/understory_event_state/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/understory_event_state/LICENSE-MIT
+++ b/understory_event_state/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/understory_event_state/README.md
+++ b/understory_event_state/README.md
@@ -1,0 +1,183 @@
+<div align="center">
+
+# Understory Event State
+
+**Common event state managers for UIs**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_selection.svg)](https://crates.io/crates/understory_event_state)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_selection.svg)](https://docs.rs/understory_event_state)
+[![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license) \
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/endoli/understory/ci.yml?logo=github&label=CI)](https://github.com/endoli/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_event_state
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Understory Event State: Common event state managers for UI interactions.
+
+This crate provides small, focused state machines for common UI interactions that require stateful
+tracking across multiple events. Each module handles a specific interaction pattern:
+
+- [`hover`]: Track enter/leave transitions as the pointer moves across UI elements
+- [`focus`]: Manage keyboard focus state and focus transitions
+- [`click`]: Transform-aware click recognition with spatial/temporal tolerance
+- [`drag`]: Track drag operations with movement deltas and total offsets
+
+### Design Philosophy
+
+Each state manager is designed to be:
+
+- **Minimal and focused**: Each handles one specific interaction pattern
+- **Stateful but simple**: Track just enough state to compute transitions
+- **Integration-friendly**: Work with any event routing or spatial query system
+- **Generic**: Accept application-specific node/widget ID types
+
+The crate does not assume any particular UI framework, event system, or scene graph structure.
+Instead, these managers accept pre-computed information (like root→target paths from
+`understory_responder` or raw pointer positions) and produce transition events or state queries that
+applications can interpret.
+
+### Usage Patterns
+
+#### Hover Tracking
+
+Use [`hover::HoverState`] to compute enter/leave transitions when the pointer moves between UI
+elements:
+
+```rust
+use understory_event_state::hover::{HoverState, HoverEvent};
+
+let mut hover = HoverState::new();
+
+// Pointer enters a nested element: [root, parent, child]
+let events = hover.update_path(&[1, 2, 3]);
+assert_eq!(events, vec![
+    HoverEvent::Enter(1),
+    HoverEvent::Enter(2),
+    HoverEvent::Enter(3)
+]);
+
+// Pointer moves to sibling: [root, parent, sibling]
+let events = hover.update_path(&[1, 2, 4]);
+assert_eq!(events, vec![
+    HoverEvent::Leave(3),   // Leave child
+    HoverEvent::Enter(4)    // Enter sibling
+]);
+```
+
+#### Focus Management
+
+Use [`focus::FocusState`] to track which element has keyboard focus:
+
+```rust
+use understory_event_state::focus::{FocusState, FocusEvent};
+
+let mut focus = FocusState::new();
+
+// Focus an element
+let event = focus.set_focus(Some(42));
+assert_eq!(event, Some(FocusEvent::Gained(42)));
+
+// Change focus to another element
+let event = focus.set_focus(Some(100));
+assert_eq!(event, Some(FocusEvent::Changed { lost: 42, gained: 100 }));
+```
+
+#### Transform-Aware Click Recognition
+
+Use [`click::ClickState`] to recognize clicks even when elements transform during interaction:
+
+```rust
+use kurbo::Point;
+use understory_event_state::click::{ClickState, ClickResult};
+
+let mut clicks = ClickState::new();
+
+// Press down on element 42
+clicks.on_down(None, None, 42, Point::new(10.0, 20.0), 1000);
+
+// Element transforms, pointer up occurs on different element but within tolerance
+let result = clicks.on_up(None, None, &99, Point::new(13.0, 23.0), 1050);
+assert_eq!(result, ClickResult::Click(42)); // Still generates click on original target
+```
+
+#### Drag Operations
+
+Use [`drag::DragState`] to track pointer drag operations:
+
+```rust
+use kurbo::Point;
+use understory_event_state::drag::DragState;
+
+let mut drag = DragState::default();
+
+// Start drag at (10, 10)
+drag.start(Point::new(10.0, 10.0));
+
+// Move pointer, get delta since last position
+let delta = drag.update(Point::new(15.0, 12.0)).unwrap();
+// delta is (5.0, 2.0)
+
+// Get total offset from start
+let total = drag.total_offset(Point::new(15.0, 12.0)).unwrap();
+// total is (5.0, 2.0)
+```
+
+### Integration with Understory
+
+These state managers integrate naturally with other Understory crates:
+
+- Use `understory_responder` to route events and produce root→target paths
+- Feed those paths into [`hover::HoverState`] for enter/leave transitions
+- Use `understory_box_tree` hit testing to determine click/drag targets
+- Combine with `understory_selection` to handle selection interactions
+
+Each manager is designed to be a focused building block that handles one interaction pattern well,
+allowing applications to compose them as needed for their specific UI requirements.
+
+### Features
+
+- `click`: Enable transform-aware click recognition (requires `kurbo` dependency)
+- `drag`: Enable drag state tracking (requires `kurbo` dependency)
+
+This crate is `no_std` compatible (with `alloc`) for all modules.
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>), or
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>),
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the
+work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies. Please feel free to
+add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the
+work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any
+additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ../AUTHORS
+[LICENSE-APACHE]: LICENSE-APACHE
+[LICENSE-MIT]: LICENSE-MIT

--- a/understory_event_state/src/click.rs
+++ b/understory_event_state/src/click.rs
@@ -25,7 +25,7 @@
 //!
 //! Basic click detection:
 //! ```
-//! use understory_responder::click::{ClickState, ClickResult};
+//! use understory_event_state::click::{ClickState, ClickResult};
 //! use kurbo::Point;
 //!
 //! let mut state: ClickState<u32> = ClickState::new();
@@ -40,7 +40,7 @@
 //!
 //! Transform-tolerant click detection with movement tracking:
 //! ```
-//! # use understory_responder::click::{ClickState, ClickResult};
+//! # use understory_event_state::click::{ClickState, ClickResult};
 //! # use kurbo::Point;
 //! // Configure spatial tolerance of 10px and temporal tolerance of 500ms
 //! let mut state: ClickState<u32> = ClickState::with_thresholds(Some(10.0), Some(500));
@@ -87,7 +87,7 @@
 //!
 //! Each pointer is tracked independently:
 //! ```
-//! # use understory_responder::click::{ClickState, ClickResult, PointerId};
+//! # use understory_event_state::click::{ClickState, ClickResult, PointerId};
 //! # use core::num::NonZeroU64;
 //! # use kurbo::Point;
 //! let mut state: ClickState<u32> = ClickState::new();

--- a/understory_event_state/src/drag.rs
+++ b/understory_event_state/src/drag.rs
@@ -1,0 +1,295 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Drag state helper: compute movement deltas and total offsets from position changes.
+//!
+//! ## Usage
+//!
+//! 1) Start a drag operation by calling [`DragState::start`] with the initial position.
+//! 2) On each move event, call [`DragState::update`] to get the movement delta since the last update.
+//! 3) Optionally call [`DragState::total_offset`] to get the cumulative offset from the start position.
+//! 4) End the drag operation with [`DragState::end`] to reset state.
+//!
+//! ## Minimal example
+//!
+//! ```
+//! use kurbo::Point;
+//! use understory_event_state::drag::DragState;
+//!
+//! let mut drag = DragState::default();
+//!
+//! // Start dragging at (10, 20)
+//! drag.start(Point::new(10.0, 20.0));
+//! assert!(drag.is_dragging());
+//!
+//! // Move to (15, 25) - delta is (5, 5)
+//! let delta = drag.update(Point::new(15.0, 25.0)).unwrap();
+//! assert_eq!(delta.x, 5.0);
+//! assert_eq!(delta.y, 5.0);
+//!
+//! // Total offset from start is also (5, 5)
+//! let total = drag.total_offset(Point::new(15.0, 25.0)).unwrap();
+//! assert_eq!(total.x, 5.0);
+//! assert_eq!(total.y, 5.0);
+//! ```
+
+use kurbo::{Point, Vec2};
+
+/// Tracks drag state for move event processing
+#[derive(Debug, Clone, Default, Copy)]
+pub struct DragState {
+    /// Start position of the drag operation
+    pub start_pos: Option<Point>,
+    /// Last recorded pointer position during drag
+    pub last_pos: Option<Point>,
+}
+
+impl DragState {
+    /// Start tracking a new drag operation from the given position.
+    pub fn start(&mut self, pos: Point) {
+        self.start_pos = Some(pos);
+        self.last_pos = Some(pos);
+    }
+
+    /// Update the drag state with a new position, returning the movement delta since last update.
+    pub fn update(&mut self, pos: Point) -> Option<Vec2> {
+        if self.start_pos.is_some() {
+            if let Some(last_pos) = self.last_pos {
+                let delta = pos - last_pos;
+                self.last_pos = Some(pos);
+                Some(delta)
+            } else {
+                self.last_pos = Some(pos);
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Get total offset from drag start position.
+    pub fn total_offset(&self, current_pos: Point) -> Option<Vec2> {
+        if self.start_pos.is_some() {
+            self.start_pos.map(|start_pos| current_pos - start_pos)
+        } else {
+            None
+        }
+    }
+
+    /// End the current drag operation and reset state.
+    pub fn end(&mut self) {
+        self.start_pos = None;
+        self.last_pos = None;
+    }
+
+    /// Returns `true` while a drag operation is active
+    pub fn is_dragging(&self) -> bool {
+        self.start_pos.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_drag_state_is_not_dragging() {
+        let drag = DragState::default();
+        assert!(drag.start_pos.is_none());
+        assert!(drag.start_pos.is_some() == drag.last_pos.is_some());
+    }
+
+    #[test]
+    fn start_sets_dragging_state() {
+        let mut drag = DragState::default();
+        let start = Point::new(10.0, 20.0);
+
+        drag.start(start);
+
+        assert_eq!(drag.start_pos, Some(start));
+        assert_eq!(drag.start_pos, drag.last_pos);
+    }
+
+    #[test]
+    fn update_returns_delta_when_dragging() {
+        let mut drag = DragState::default();
+        drag.start(Point::new(10.0, 20.0));
+
+        let new_pos = Point::new(15.0, 25.0);
+        let delta = drag.update(new_pos);
+
+        assert_eq!(delta, Some(Vec2::new(5.0, 5.0)));
+        assert_eq!(drag.last_pos, Some(new_pos));
+    }
+
+    #[test]
+    fn update_returns_none_when_not_dragging() {
+        let mut drag = DragState::default();
+
+        let delta = drag.update(Point::new(15.0, 25.0));
+
+        assert_eq!(delta, None);
+        assert!(drag.last_pos.is_none());
+    }
+
+    #[test]
+    fn update_with_no_last_position_returns_none() {
+        let mut drag = DragState {
+            start_pos: Some(Point::new(10.0, 20.0)),
+            last_pos: None,
+        };
+
+        let new_pos = Point::new(15.0, 25.0);
+        let delta = drag.update(new_pos);
+
+        assert_eq!(delta, None);
+        assert_eq!(drag.last_pos, Some(new_pos));
+    }
+
+    #[test]
+    fn multiple_updates_track_incremental_deltas() {
+        let mut drag = DragState::default();
+        drag.start(Point::new(0.0, 0.0));
+
+        // First move
+        let delta1 = drag.update(Point::new(5.0, 3.0));
+        assert_eq!(delta1, Some(Vec2::new(5.0, 3.0)));
+
+        // Second move from new position
+        let delta2 = drag.update(Point::new(8.0, 7.0));
+        assert_eq!(delta2, Some(Vec2::new(3.0, 4.0)));
+
+        // Third move
+        let delta3 = drag.update(Point::new(10.0, 10.0));
+        assert_eq!(delta3, Some(Vec2::new(2.0, 3.0)));
+    }
+
+    #[test]
+    fn total_offset_calculates_from_start() {
+        let mut drag = DragState::default();
+        let start = Point::new(10.0, 20.0);
+        drag.start(start);
+
+        // Move to intermediate position
+        drag.update(Point::new(15.0, 25.0));
+
+        // Total offset from start to current position
+        let current = Point::new(20.0, 35.0);
+        let total = drag.total_offset(current);
+
+        assert_eq!(total, Some(Vec2::new(10.0, 15.0)));
+    }
+
+    #[test]
+    fn total_offset_returns_none_when_not_dragging() {
+        let drag = DragState::default();
+
+        let total = drag.total_offset(Point::new(100.0, 200.0));
+
+        assert_eq!(total, None);
+    }
+
+    #[test]
+    fn total_offset_with_no_start_position_returns_none() {
+        let drag = DragState {
+            start_pos: None,
+            last_pos: Some(Point::new(10.0, 20.0)),
+        };
+
+        let total = drag.total_offset(Point::new(15.0, 25.0));
+
+        assert_eq!(total, None);
+    }
+
+    #[test]
+    fn end_resets_drag_state() {
+        let mut drag = DragState::default();
+        drag.start(Point::new(10.0, 20.0));
+        drag.update(Point::new(15.0, 25.0));
+
+        drag.end();
+
+        assert!(drag.start_pos.is_none());
+        assert!(drag.last_pos.is_none());
+    }
+
+    #[test]
+    fn end_on_fresh_state_is_safe() {
+        let mut drag = DragState::default();
+
+        drag.end();
+
+        assert!(drag.start_pos.is_none());
+        assert!(drag.start_pos.is_some() == drag.last_pos.is_some());
+    }
+
+    #[test]
+    fn negative_movement_deltas() {
+        let mut drag = DragState::default();
+        drag.start(Point::new(100.0, 100.0));
+
+        // Move to smaller coordinates
+        let delta = drag.update(Point::new(90.0, 85.0));
+
+        assert_eq!(delta, Some(Vec2::new(-10.0, -15.0)));
+    }
+
+    #[test]
+    fn zero_movement_delta() {
+        let mut drag = DragState::default();
+        let start = Point::new(50.0, 50.0);
+        drag.start(start);
+
+        // Update to same position
+        let delta = drag.update(start);
+
+        assert_eq!(delta, Some(Vec2::new(0.0, 0.0)));
+    }
+
+    #[test]
+    fn fractional_coordinates() {
+        let mut drag = DragState::default();
+        drag.start(Point::new(1.5, 2.7));
+
+        let delta = drag.update(Point::new(3.2, 4.1));
+
+        // Use approximate equality for floating point comparison
+        let expected_delta = Vec2::new(1.7, 1.4);
+        assert!((delta.unwrap().x - expected_delta.x).abs() < f64::EPSILON * 10.0);
+        assert!((delta.unwrap().y - expected_delta.y).abs() < f64::EPSILON * 10.0);
+
+        let total = drag.total_offset(Point::new(3.2, 4.1));
+        assert!((total.unwrap().x - expected_delta.x).abs() < f64::EPSILON * 10.0);
+        assert!((total.unwrap().y - expected_delta.y).abs() < f64::EPSILON * 10.0);
+    }
+
+    #[test]
+    fn start_overwrites_previous_drag() {
+        let mut drag = DragState::default();
+
+        // First drag session
+        drag.start(Point::new(0.0, 0.0));
+        drag.update(Point::new(10.0, 10.0));
+
+        // Start new drag session from different position
+        let new_start = Point::new(50.0, 60.0);
+        drag.start(new_start);
+
+        assert_eq!(drag.start_pos, Some(new_start));
+        assert_eq!(drag.start_pos, drag.last_pos);
+
+        // Total offset should be from new start position
+        let total = drag.total_offset(Point::new(55.0, 65.0));
+        assert_eq!(total, Some(Vec2::new(5.0, 5.0)));
+    }
+
+    #[test]
+    fn large_coordinate_values() {
+        let mut drag = DragState::default();
+        drag.start(Point::new(1000000.0, 2000000.0));
+
+        let delta = drag.update(Point::new(1000001.0, 2000002.0));
+
+        assert_eq!(delta, Some(Vec2::new(1.0, 2.0)));
+    }
+}

--- a/understory_event_state/src/focus.rs
+++ b/understory_event_state/src/focus.rs
@@ -10,7 +10,7 @@
 //!
 //! ## Minimal example
 //! ```
-//! use understory_responder::focus::{FocusState, FocusEvent};
+//! use understory_event_state::focus::{FocusState, FocusEvent};
 //! let mut f: FocusState<u32> = FocusState::new();
 //! assert_eq!(f.update_path(&[1, 2]), vec![FocusEvent::Enter(1), FocusEvent::Enter(2)]);
 //! assert_eq!(f.update_path(&[1, 3]), vec![FocusEvent::Leave(2), FocusEvent::Enter(3)]);
@@ -23,7 +23,7 @@
 //!
 //! ```ignore
 //! use understory_focus::{DefaultPolicy, FocusEntry, FocusPolicy, FocusSpace, Navigation, WrapMode};
-//! use understory_responder::focus::{FocusEvent, FocusState};
+//! use understory_event_state::focus::{FocusEvent, FocusState};
 //!
 //! # type NodeId = u32;
 //! # let root: NodeId = 1;

--- a/understory_event_state/src/lib.rs
+++ b/understory_event_state/src/lib.rs
@@ -1,0 +1,160 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=understory_event_state --heading-base-level=0
+
+//! Understory Event State: Common event state managers for UI interactions.
+//!
+//! This crate provides small, focused state machines for common UI interactions
+//! that require stateful tracking across multiple events. Each module handles a
+//! specific interaction pattern:
+//!
+//! - [`hover`]: Track enter/leave transitions as the pointer moves across UI elements
+//! - [`focus`]: Manage keyboard focus state and focus transitions
+//! - [`click`]: Transform-aware click recognition with spatial/temporal tolerance
+//! - [`drag`]: Track drag operations with movement deltas and total offsets
+//!
+//! ## Design Philosophy
+//!
+//! Each state manager is designed to be:
+//!
+//! - **Minimal and focused**: Each handles one specific interaction pattern
+//! - **Stateful but simple**: Track just enough state to compute transitions
+//! - **Integration-friendly**: Work with any event routing or spatial query system
+//! - **Generic**: Accept application-specific node/widget ID types
+//!
+//! The crate does not assume any particular UI framework, event system, or scene
+//! graph structure. Instead, these managers accept pre-computed information (like
+//! root→target paths from `understory_responder` or raw pointer positions) and
+//! produce transition events or state queries that applications can interpret.
+//!
+//! ## Usage Patterns
+//!
+//! ### Hover Tracking
+//!
+//! Use [`hover::HoverState`] to compute enter/leave transitions when the pointer
+//! moves between UI elements:
+//!
+//! ```rust
+//! use understory_event_state::hover::{HoverState, HoverEvent};
+//!
+//! let mut hover = HoverState::new();
+//!
+//! // Pointer enters a nested element: [root, parent, child]
+//! let events = hover.update_path(&[1, 2, 3]);
+//! assert_eq!(events, vec![
+//!     HoverEvent::Enter(1),
+//!     HoverEvent::Enter(2),
+//!     HoverEvent::Enter(3)
+//! ]);
+//!
+//! // Pointer moves to sibling: [root, parent, sibling]
+//! let events = hover.update_path(&[1, 2, 4]);
+//! assert_eq!(events, vec![
+//!     HoverEvent::Leave(3),   // Leave child
+//!     HoverEvent::Enter(4)    // Enter sibling
+//! ]);
+//! ```
+//!
+//! ### Focus Management
+//!
+//! Use [`focus::FocusState`] to track keyboard focus transitions:
+//!
+//! ```rust
+//! use understory_event_state::focus::{FocusState, FocusEvent};
+//!
+//! let mut focus = FocusState::new();
+//!
+//! // Focus moves to element 42 (with path from root)
+//! let events = focus.update_path(&[1, 42]);
+//! assert_eq!(events, vec![
+//!     FocusEvent::Enter(1),
+//!     FocusEvent::Enter(42)
+//! ]);
+//!
+//! // Focus moves to different element 100 (different branch)
+//! let events = focus.update_path(&[1, 100]);
+//! assert_eq!(events, vec![
+//!     FocusEvent::Leave(42),
+//!     FocusEvent::Enter(100)
+//! ]);
+//! ```
+//!
+//! ### Transform-Aware Click Recognition
+//!
+//! Use [`click::ClickState`] to recognize clicks even when elements transform during interaction:
+//!
+//! ```rust
+//! # #[cfg(feature = "click")]
+//! # fn example() {
+//! use kurbo::Point;
+//! use understory_event_state::click::{ClickState, ClickResult};
+//!
+//! let mut clicks = ClickState::new();
+//!
+//! // Press down on element 42
+//! clicks.on_down(None, None, 42, Point::new(10.0, 20.0), 1000);
+//!
+//! // Element transforms, pointer up occurs on different element but within tolerance
+//! let result = clicks.on_up(None, None, &99, Point::new(13.0, 23.0), 1050);
+//! assert_eq!(result, ClickResult::Click(42)); // Still generates click on original target
+//! # }
+//! ```
+//!
+//! ### Drag Operations
+//!
+//! Use [`drag::DragState`] to track pointer drag operations:
+//!
+//! ```rust
+//! # #[cfg(feature = "drag")]
+//! # fn example() {
+//! use kurbo::Point;
+//! use understory_event_state::drag::DragState;
+//!
+//! let mut drag = DragState::default();
+//!
+//! // Start drag at (10, 10)
+//! drag.start(Point::new(10.0, 10.0));
+//!
+//! // Move pointer, get delta since last position
+//! let delta = drag.update(Point::new(15.0, 12.0)).unwrap();
+//! // delta is (5.0, 2.0)
+//!
+//! // Get total offset from start
+//! let total = drag.total_offset(Point::new(15.0, 12.0)).unwrap();
+//! // total is (5.0, 2.0)
+//! # }
+//! ```
+//!
+//! ## Integration with Understory
+//!
+//! These state managers integrate naturally with other Understory crates:
+//!
+//! - Use `understory_responder` to route events and produce root→target paths
+//! - Feed those paths into [`hover::HoverState`] for enter/leave transitions
+//! - Use `understory_box_tree` hit testing to determine click/drag targets
+//! - Combine with `understory_selection` to handle selection interactions
+//!
+//! Each manager is designed to be a focused building block that handles one
+//! interaction pattern well, allowing applications to compose them as needed
+//! for their specific UI requirements.
+//!
+//! ## Features
+//!
+//! - `click`: Enable transform-aware click recognition (requires `kurbo` dependency)
+//! - `drag`: Enable drag state tracking (requires `kurbo` dependency)
+//!
+//! This crate is `no_std` compatible (with `alloc`) for all modules.
+
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "click")]
+pub mod click;
+
+#[cfg(feature = "drag")]
+pub mod drag;
+pub mod focus;
+pub mod hover;

--- a/understory_responder/README.md
+++ b/understory_responder/README.md
@@ -61,21 +61,21 @@ The router only computes the traversal order. A higher‑level dispatcher can ex
    - Overlapping siblings: only the topmost/nearest candidate is selected; siblings do not receive the target.
    - Equal‑depth ties: deterministic and stable; the last candidate wins unless you pre‑order your hits or set a policy.
    - Pointer capture: overrides selection until released.
-3) Hover — derive the path from the dispatch via [`path_from_dispatch`](https://docs.rs/understory_responder/latest/understory_responder/hover/fn.path_from_dispatch.html)
-   and feed it to [`HoverState`](https://docs.rs/understory_responder/latest/understory_responder/hover/struct.HoverState.html). `HoverState` emits leave (inner→outer)
-   and enter (outer→inner) events for the minimal transition between old and new paths.
-4) Click — use [`ClickState`](https://docs.rs/understory_responder/latest/understory_responder/click/struct.ClickState.html) to determine when pointer up events
-   should generate click events. Handles cases where elements transform between down and up,
-   applying configurable spatial and temporal tolerance to preserve user intent.
 
-## Focus
+## Integration with Event State
+
+The router produces dispatch sequences that integrate with `understory_event_state` for stateful interactions:
+
+- Extract root→target paths using [`path_from_dispatch`](https://docs.rs/understory_responder/latest/understory_responder/router/fn.path_from_dispatch.html)
+- Feed paths to hover, focus, click, and drag state managers as needed
+- See `understory_event_state` documentation for details on each state manager
+
+## Focus Routing
 
 Focus routing is separate from pointer routing.
-Use [`Router::dispatch_for`](router::Router::dispatch_for) to emit a capture → target → bubble sequence for the focused node.
+Use [`Router::dispatch_for`](router::Router::dispatch_for) to emit a capture → target → bubble sequence for a focused node.
 The router reconstructs the root→target path via [`ParentLookup`](https://docs.rs/understory_responder/latest/understory_responder/types/trait.ParentLookup.html) or falls back to a singleton path.
-Use [`FocusState`](https://docs.rs/understory_responder/latest/understory_responder/focus/struct.FocusState.html) to compute `Enter(..)` and `Leave(..)` transitions between old and new focus paths.
 Keyboard and IME events typically route to focus and may bypass scope filters by policy at a higher layer.
-Click‑to‑focus can be implemented by setting focus after a pointer route and then routing subsequent key input via `dispatch_for`.
 
 ## Dispatcher
 

--- a/understory_responder/src/lib.rs
+++ b/understory_responder/src/lib.rs
@@ -44,21 +44,21 @@
 //!    - Overlapping siblings: only the topmost/nearest candidate is selected; siblings do not receive the target.
 //!    - Equal‑depth ties: deterministic and stable; the last candidate wins unless you pre‑order your hits or set a policy.
 //!    - Pointer capture: overrides selection until released.
-//! 3) Hover — derive the path from the dispatch via [`path_from_dispatch`](crate::hover::path_from_dispatch)
-//!    and feed it to [`HoverState`](crate::hover::HoverState). `HoverState` emits leave (inner→outer)
-//!    and enter (outer→inner) events for the minimal transition between old and new paths.
-//! 4) Click — use [`ClickState`](crate::click::ClickState) to determine when pointer up events
-//!    should generate click events. Handles cases where elements transform between down and up,
-//!    applying configurable spatial and temporal tolerance to preserve user intent.
 //!
-//! ## Focus
+//! ## Integration with Event State
+//!
+//! The router produces dispatch sequences that integrate with `understory_event_state` for stateful interactions:
+//!
+//! - Extract root→target paths using [`path_from_dispatch`](crate::router::path_from_dispatch)
+//! - Feed paths to hover, focus, click, and drag state managers as needed
+//! - See `understory_event_state` documentation for details on each state manager
+//!
+//! ## Focus Routing
 //!
 //! Focus routing is separate from pointer routing.
-//! Use [`Router::dispatch_for`](router::Router::dispatch_for) to emit a capture → target → bubble sequence for the focused node.
+//! Use [`Router::dispatch_for`](router::Router::dispatch_for) to emit a capture → target → bubble sequence for a focused node.
 //! The router reconstructs the root→target path via [`ParentLookup`](crate::types::ParentLookup) or falls back to a singleton path.
-//! Use [`FocusState`](crate::focus::FocusState) to compute `Enter(..)` and `Leave(..)` transitions between old and new focus paths.
 //! Keyboard and IME events typically route to focus and may bypass scope filters by policy at a higher layer.
-//! Click‑to‑focus can be implemented by setting focus after a pointer route and then routing subsequent key input via `dispatch_for`.
 //!
 //! ## Dispatcher
 //!
@@ -100,9 +100,6 @@
 extern crate alloc;
 
 pub mod adapters;
-pub mod click;
 pub mod dispatcher;
-pub mod focus;
-pub mod hover;
 pub mod router;
 pub mod types;


### PR DESCRIPTION
This extracts the state managers from the responder crate into a separate crate and adds a new drag state. 

This change is in line with the understory ethos of creating independent, reusable ui components. Each of these event states has an independent benefit and shouldn't be tied to the `understory_responder` crate. Combining these independent pieces together in a single additional crate is an organizational choice but because each of the pieces is small it doesn't cause any concern for compiles times and for this same reason there are not cfg flags for every state (there are cfg flags that enabled by default for the event states that depend on kurbo) 