### PR TITLE
Downgrade `kurbo` to v0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,9 +248,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "kurbo"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
 dependencies = [
  "arrayvec",
  "euclid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ repository = "https://github.com/endoli/understory"
 [workspace.dependencies]
 # Kurbo supports no_std via its `libm` feature. Disable default features here and
 # let member crates opt into `std` or `libm` explicitly via their own features.
-kurbo = { version = "0.13.0", default-features = false }
+kurbo = { version = "0.12.0", default-features = false }
 bitflags = "2.10.0"
 
 [workspace.lints]


### PR DESCRIPTION
This reverts https://github.com/endoli/understory/pull/72 as `vello` cannot entirely straightforwardly be bumped to the same `kurbo` version due to some potential layer/clip issues in `peniko`/`vello` (and `vello` gets `kurbo` through `peniko`): https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/Mix.3A.3AClip.20optimisation.3A.20Interaction.20with.20layers/with/537093339.

This has potential to make changes in https://github.com/endoli/understory/pull/73 somewhat slower (as Kurbo v0.13 optimized the `nearest` method used there). That will get automatically fixed once the entire stack has been bumped.