### PR TITLE
Add `GridTrackModel` adapter for grid virtualization

### DIFF
--- a/understory_virtual_list/README.md
+++ b/understory_virtual_list/README.md
@@ -40,6 +40,8 @@ The core concepts are:
   scroll state, viewport extent, and overscan, and caches the most recent
   [`VisibleStrip`]. It also provides index-based scrolling via [`ScrollAlign`]
   and convenience methods for visibility queries and scroll clamping.
+- [`GridTrackModel`]: an adapter that maps a per-track [`ExtentModel`] onto a
+  per-cell view for grid-like layouts (tracks × cells).
 
 This crate deliberately does **not** know about widgets, display trees, or any
 particular UI framework. Host frameworks are responsible for:
@@ -83,6 +85,31 @@ extents back into it after layout. A typical pattern is:
 
 All extents and offsets live in a caller-chosen 1D coordinate space
 (typically logical pixels) and are expected to be finite and non-negative.
+
+## Grid-like example with tracks and cells
+
+For grids, use [`GridTrackModel`] to adapt a per-track model to per-cell
+indices. In a vertical grid, tracks typically correspond to rows and cells
+to columns:
+
+```rust
+use core::num::NonZeroUsize;
+use understory_virtual_list::{FixedExtentModel, GridTrackModel, VirtualList};
+
+// Four tracks (rows), each 20 logical pixels tall.
+let row_model = FixedExtentModel::new(4, 20.0);
+// A 3-column grid over 12 cells (4 rows × 3 columns).
+let columns = NonZeroUsize::new(3).unwrap();
+let grid_model = GridTrackModel::new(row_model, columns, 12);
+let mut list = VirtualList::new(grid_model, 40.0, 0.0);
+
+let strip = list.visible_strip();
+assert!(strip.start < strip.end);
+// Host code can map each visible cell index `i` to:
+//   let track = list.model().track_of_cell(i);
+//   let cell_in_track = list.model().cell_in_track(i);
+```
+
 This crate is `no_std` and uses `alloc`.
 
 <!-- cargo-rdme end -->

--- a/understory_virtual_list/src/fixed.rs
+++ b/understory_virtual_list/src/fixed.rs
@@ -3,7 +3,7 @@
 
 //! A simple extent model with uniform per-item extent.
 
-use crate::{ExtentModel, Scalar};
+use crate::{ExtentModel, ResizableExtentModel, Scalar};
 
 /// An [`ExtentModel`] where all items share the same extent.
 #[derive(Debug, Clone, Copy)]
@@ -86,6 +86,12 @@ impl<S: Scalar> ExtentModel for FixedExtentModel<S> {
         )]
         let i = ratio.floor_to_isize();
         i.clamp(0, self.len as isize - 1) as usize
+    }
+}
+
+impl<S: Scalar> ResizableExtentModel for FixedExtentModel<S> {
+    fn set_len(&mut self, len: usize) {
+        self.set_len(len);
     }
 }
 

--- a/understory_virtual_list/src/grid_track.rs
+++ b/understory_virtual_list/src/grid_track.rs
@@ -1,0 +1,252 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! An [`ExtentModel`] adapter that maps a per-track model onto per-cell indices.
+//!
+//! This is useful for grid-like layouts where the scroll axis operates over
+//! *tracks* (for example, rows in a vertical grid or columns in a horizontal
+//! grid) while the backing data is indexed as a flat sequence of *cells*.
+//!
+//! A [`GridTrackModel`] wraps another [`ExtentModel`] that describes per-track
+//! extents in the scroll direction and exposes an [`ExtentModel`] view over a
+//! dense strip of `0..len` cells:
+//!
+//! - Each track contains a fixed number of cells (`cells_per_track`).
+//! - The extent and offset of a cell are those of its containing track.
+//! - [`ExtentModel::index_at_offset`] resolves to the first cell in the track
+//!   whose start is at or before the given offset.
+//!
+//! Hosts are expected to interpret track/cell as either row/column or
+//! column/row depending on scroll direction.
+
+use core::num::NonZeroUsize;
+
+use crate::{ExtentModel, ResizableExtentModel, Scalar};
+
+/// Adapts a per-track [`ExtentModel`] into a per-cell model for grid layouts.
+#[derive(Debug, Clone)]
+pub struct GridTrackModel<M: ResizableExtentModel> {
+    track_model: M,
+    cells_per_track: NonZeroUsize,
+    len: usize,
+}
+
+impl<M: ResizableExtentModel> GridTrackModel<M> {
+    /// Creates a new [`GridTrackModel`].
+    ///
+    /// - `track_model` describes the extent and offset of each track.
+    /// - `cells_per_track` is the number of cells in each track (must be > 0).
+    /// - `len` is the total number of cells in the flattened grid.
+    ///
+    /// Tracks are consumed in order, so the number of logical tracks is
+    /// `tracks = ceil(len / cells_per_track)`. Any trailing cells in the last
+    /// (partially filled) track share that track's extent.
+    ///
+    /// `cells_per_track` must be non-zero.
+    #[must_use]
+    pub fn new(track_model: M, cells_per_track: NonZeroUsize, len: usize) -> Self {
+        let mut track_model = track_model;
+        let track_count = if len == 0 {
+            0
+        } else {
+            len.div_ceil(cells_per_track.get())
+        };
+        track_model.set_len(track_count);
+
+        Self {
+            track_model,
+            cells_per_track,
+            len,
+        }
+    }
+
+    /// Returns a shared reference to the underlying track model.
+    #[must_use]
+    pub fn track_model(&self) -> &M {
+        &self.track_model
+    }
+
+    /// Returns a mutable reference to the underlying track model.
+    pub fn track_model_mut(&mut self) -> &mut M {
+        &mut self.track_model
+    }
+
+    /// Returns the number of cells per track.
+    #[must_use]
+    pub const fn cells_per_track(&self) -> usize {
+        self.cells_per_track.get()
+    }
+
+    /// Sets the number of cells per track.
+    ///
+    /// This does not modify the underlying track model; it only affects how
+    /// the flat cell indices are mapped onto tracks.
+    ///
+    /// `cells_per_track` must be non-zero.
+    pub fn set_cells_per_track(&mut self, cells_per_track: NonZeroUsize) {
+        self.cells_per_track = cells_per_track;
+        let track_count = self.track_count();
+        self.track_model.set_len(track_count);
+    }
+
+    /// Returns the total number of cells in the grid.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Sets the total number of cells in the grid.
+    ///
+    /// This does not modify the underlying track model; callers are expected
+    /// to keep the number of tracks in the model consistent with their usage.
+    pub fn set_len(&mut self, len: usize) {
+        self.len = len;
+        let track_count = self.track_count();
+        self.track_model.set_len(track_count);
+    }
+
+    /// Returns `true` if there are no cells in this grid.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the track index containing `cell_index`.
+    ///
+    /// The result is `cell_index / cells_per_track`.
+    #[must_use]
+    pub const fn track_of_cell(&self, cell_index: usize) -> usize {
+        cell_index / self.cells_per_track.get()
+    }
+
+    /// Returns the zero-based position of `cell_index` within its track.
+    ///
+    /// The result is `cell_index % cells_per_track`.
+    #[must_use]
+    pub const fn cell_in_track(&self, cell_index: usize) -> usize {
+        cell_index % self.cells_per_track.get()
+    }
+
+    /// Returns the number of tracks needed to represent `len` cells.
+    ///
+    /// This is `ceil(len / cells_per_track)` and may exceed the backing track
+    /// count if the underlying model is not sized consistently.
+    #[must_use]
+    pub const fn track_count(&self) -> usize {
+        if self.len == 0 {
+            return 0;
+        }
+        self.len.div_ceil(self.cells_per_track.get())
+    }
+}
+
+impl<M: ResizableExtentModel> ExtentModel for GridTrackModel<M> {
+    type Scalar = M::Scalar;
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn total_extent(&mut self) -> Self::Scalar {
+        self.track_model.total_extent()
+    }
+
+    fn extent_of(&mut self, index: usize) -> Self::Scalar {
+        if self.len == 0 {
+            return M::Scalar::zero();
+        }
+        let clamped = index.min(self.len.saturating_sub(1));
+        let track = self.track_of_cell(clamped);
+        debug_assert!(
+            track < self.track_model.len(),
+            "GridTrackModel track index out of bounds: track={track}, len={}",
+            self.track_model.len()
+        );
+        self.track_model.extent_of(track)
+    }
+
+    fn offset_of(&mut self, index: usize) -> Self::Scalar {
+        if self.len == 0 {
+            return M::Scalar::zero();
+        }
+        let clamped = index.min(self.len.saturating_sub(1));
+        let track = self.track_of_cell(clamped);
+        debug_assert!(
+            track < self.track_model.len(),
+            "GridTrackModel track index out of bounds: track={track}, len={}",
+            self.track_model.len()
+        );
+        self.track_model.offset_of(track)
+    }
+
+    fn index_at_offset(&mut self, offset: Self::Scalar) -> usize {
+        if self.len == 0 {
+            return 0;
+        }
+        let track = self.track_model.index_at_offset(offset);
+        track
+            .saturating_mul(self.cells_per_track.get())
+            .min(self.len.saturating_sub(1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GridTrackModel;
+    use crate::{ExtentModel, FixedExtentModel};
+    use core::num::NonZeroUsize;
+
+    #[test]
+    fn basic_cell_to_track_mapping() {
+        let track_model = FixedExtentModel::new(3, 10.0_f32);
+        let grid = GridTrackModel::new(track_model, NonZeroUsize::new(4).unwrap(), 10);
+
+        assert_eq!(grid.track_count(), 3);
+        assert_eq!(grid.track_of_cell(0), 0);
+        assert_eq!(grid.track_of_cell(3), 0);
+        assert_eq!(grid.track_of_cell(4), 1);
+        assert_eq!(grid.cell_in_track(4), 0);
+        assert_eq!(grid.cell_in_track(7), 3);
+    }
+
+    #[test]
+    fn extent_and_offsets_come_from_tracks() {
+        let track_model = FixedExtentModel::new(3, 10.0_f32);
+        let mut grid = GridTrackModel::new(track_model, NonZeroUsize::new(4).unwrap(), 10);
+
+        // Three tracks of extent 10 → total 30.
+        assert_eq!(grid.total_extent(), 30.0);
+
+        // All cells in track 0 share offset 0 and extent 10.
+        assert_eq!(grid.offset_of(0), 0.0);
+        assert_eq!(grid.offset_of(3), 0.0);
+        assert_eq!(grid.extent_of(0), 10.0);
+        assert_eq!(grid.extent_of(3), 10.0);
+
+        // Cells in track 1: offset 10.
+        assert_eq!(grid.offset_of(4), 10.0);
+        assert_eq!(grid.offset_of(7), 10.0);
+
+        // Cells in track 2: offset 20 (partial track).
+        assert_eq!(grid.offset_of(8), 20.0);
+        assert_eq!(grid.offset_of(9), 20.0);
+    }
+
+    #[test]
+    fn index_at_offset_resolves_to_first_cell_in_track() {
+        let track_model = FixedExtentModel::new(3, 10.0_f32);
+        let mut grid = GridTrackModel::new(track_model, NonZeroUsize::new(4).unwrap(), 10);
+
+        // Offsets within first track map to first cell (0).
+        assert_eq!(grid.index_at_offset(0.0), 0);
+        assert_eq!(grid.index_at_offset(5.0), 0);
+
+        // Offsets in second track map to first cell of that track (4).
+        assert_eq!(grid.index_at_offset(10.0), 4);
+        assert_eq!(grid.index_at_offset(19.9), 4);
+
+        // Offsets in third track map to first cell of that track (8).
+        assert_eq!(grid.index_at_offset(20.0), 8);
+        assert_eq!(grid.index_at_offset(100.0), 8);
+    }
+}

--- a/understory_virtual_list/src/lib.rs
+++ b/understory_virtual_list/src/lib.rs
@@ -23,6 +23,8 @@
 //!   scroll state, viewport extent, and overscan, and caches the most recent
 //!   [`VisibleStrip`]. It also provides index-based scrolling via [`ScrollAlign`]
 //!   and convenience methods for visibility queries and scroll clamping.
+//! - [`GridTrackModel`]: an adapter that maps a per-track [`ExtentModel`] onto a
+//!   per-cell view for grid-like layouts (tracks × cells).
 //!
 //! This crate deliberately does **not** know about widgets, display trees, or any
 //! particular UI framework. Host frameworks are responsible for:
@@ -66,6 +68,31 @@
 //!
 //! All extents and offsets live in a caller-chosen 1D coordinate space
 //! (typically logical pixels) and are expected to be finite and non-negative.
+//!
+//! ## Grid-like example with tracks and cells
+//!
+//! For grids, use [`GridTrackModel`] to adapt a per-track model to per-cell
+//! indices. In a vertical grid, tracks typically correspond to rows and cells
+//! to columns:
+//!
+//! ```rust
+//! use core::num::NonZeroUsize;
+//! use understory_virtual_list::{FixedExtentModel, GridTrackModel, VirtualList};
+//!
+//! // Four tracks (rows), each 20 logical pixels tall.
+//! let row_model = FixedExtentModel::new(4, 20.0);
+//! // A 3-column grid over 12 cells (4 rows × 3 columns).
+//! let columns = NonZeroUsize::new(3).unwrap();
+//! let grid_model = GridTrackModel::new(row_model, columns, 12);
+//! let mut list = VirtualList::new(grid_model, 40.0, 0.0);
+//!
+//! let strip = list.visible_strip();
+//! assert!(strip.start < strip.end);
+//! // Host code can map each visible cell index `i` to:
+//! //   let track = list.model().track_of_cell(i);
+//! //   let cell_in_track = list.model().cell_in_track(i);
+//! ```
+//!
 //! This crate is `no_std` and uses `alloc`.
 
 #![no_std]
@@ -73,13 +100,15 @@
 extern crate alloc;
 
 mod fixed;
+mod grid_track;
 mod model;
 mod prefix_sum;
 mod scalar;
 mod virtual_list;
 
 pub use fixed::FixedExtentModel;
-pub use model::{ExtentModel, VisibleStrip, compute_visible_strip};
+pub use grid_track::GridTrackModel;
+pub use model::{ExtentModel, ResizableExtentModel, VisibleStrip, compute_visible_strip};
 pub use prefix_sum::PrefixSumExtentModel;
 pub use scalar::Scalar;
 pub use virtual_list::{ScrollAlign, VirtualList};

--- a/understory_virtual_list/src/model.rs
+++ b/understory_virtual_list/src/model.rs
@@ -76,6 +76,18 @@ pub trait ExtentModel {
     fn index_at_offset(&mut self, offset: Self::Scalar) -> usize;
 }
 
+/// An [`ExtentModel`] whose logical length can be resized.
+///
+/// Implementations are expected to ensure storage for `len` items and treat
+/// any newly added items as having extent `0.0` until explicitly updated.
+pub trait ResizableExtentModel: ExtentModel {
+    /// Ensures that the model can represent `len` items.
+    ///
+    /// Implementations typically grow internal storage and treat new items as
+    /// zero-sized until their extents are set by the caller.
+    fn set_len(&mut self, len: usize);
+}
+
 /// Compute the visible slice of a strip, given scroll position, viewport size, and overscan.
 ///
 /// - `scroll_offset`: top of the viewport in strip coordinates (`>= 0`).

--- a/understory_virtual_list/src/prefix_sum.rs
+++ b/understory_virtual_list/src/prefix_sum.rs
@@ -5,7 +5,7 @@
 
 use alloc::vec::Vec;
 
-use crate::{ExtentModel, Scalar};
+use crate::{ExtentModel, ResizableExtentModel, Scalar};
 
 /// An [`ExtentModel`] backed by per-item extents and a lazily-maintained prefix-sum cache.
 ///
@@ -217,6 +217,12 @@ impl<S: Scalar> ExtentModel for PrefixSumExtentModel<S> {
     fn index_at_offset(&mut self, offset: S) -> usize {
         let len = self.extents.len();
         self.index_at_offset_for_len(offset, len)
+    }
+}
+
+impl<S: Scalar> ResizableExtentModel for PrefixSumExtentModel<S> {
+    fn set_len(&mut self, len: usize) {
+        self.set_len(len);
     }
 }
 


### PR DESCRIPTION
This also adds a new `ResizableExtentModel` trait used by the grid track model.