### PR TITLE
index: Write benchmark against `Backend`, reuse and regroup

### DIFF
--- a/benches/benches/index_compare_backends.rs
+++ b/benches/benches/index_compare_backends.rs
@@ -139,7 +139,7 @@ fn bench_insert_commit_rect_grid_f64(c: &mut Criterion) {
         I: IndexOpsF64U32 + 'static,
     {
         b.iter_batched(
-            || make_index(),
+            make_index,
             |mut idx| {
                 for (i, r) in rects.iter().copied().enumerate() {
                     idx.insert_box(r, i as u32);


### PR DESCRIPTION
This suggests writing the usage patterns we're benchmarking against `Backend` generically, and running them for all the backends. This ensures we compare the same workload across backends.

This also suggests grouping the benchmark results under the usage pattern first, and backend second, which allows comparing the backends directly for each usage pattern.

I've only done this for the `insert_commit` one for now, but I think this makes the idea clear.

The report then starts to look like this, with especially the line chart now being useful (comparing all the backends for one specific workload under different sizes of that workload, with backends grouped to allow Criterion to draw a linear interpolation line).

<img width="967" height="5592" alt="Screenshot 2025-12-15 at 12-51-27 insert_commit_rect_grid_f64 Summary - Criterion rs" src="https://github.com/user-attachments/assets/638e95cd-fd65-4bac-9350-fe29b7eecdb7" />
