### PR TITLE
understory_index: add grouped visit benchmarks

### DIFF
--- a/benches/benches/index_compare_backends.rs
+++ b/benches/benches/index_compare_backends.rs
@@ -110,7 +110,6 @@ fn gen_random_rects_in_world_f64(
 ) -> Vec<Aabb2D<f64>> {
     let mut rng = Rng::new(0x3C6E_F35F_4750_2932);
     (0..count)
-        .into_iter()
         .map(|_| {
             let center_x = rng.next_f64() * (world.max_x - world.min_x) + world.min_x;
             let center_y = rng.next_f64() * (world.max_y - world.min_y) + world.min_y;
@@ -134,7 +133,6 @@ fn gen_random_rects_in_world_f64(
 fn gen_random_points_in_world_f64(count: usize, world: Aabb2D<f64>) -> Vec<(f64, f64)> {
     let mut rng = Rng::new(0x81FD_BEE7_94F0_AF1A);
     (0..count)
-        .into_iter()
         .map(|_| {
             let x = rng.next_f64() * (world.max_x - world.min_x) + world.min_x;
             let y = rng.next_f64() * (world.max_y - world.min_y) + world.min_y;


### PR DESCRIPTION
These build the same indexes as the `insert_commit` benchmarks, and then measure the visit timings. Both visiting points and rectangles are measured.

The points and rectangles are generated randomly to be uniformly distributed. The rectangles have a uniformly random size.

![visit_point_grid](https://github.com/user-attachments/assets/b0d0df2a-953c-4497-93c5-4a1f184a3585)
![visit_point_overlap](https://github.com/user-attachments/assets/e2929dfe-3d65-4b94-9aa7-9eba24ee724f)
![visit_rect_grid](https://github.com/user-attachments/assets/be213b7e-d2dd-4ad2-8fcf-0bacbfc45c16)
![visit_rect_overlap](https://github.com/user-attachments/assets/a43b3db5-69cc-443f-b62e-64255adb3449)

