### PR TITLE
index: define `Grid`'s `GridScalar::cell_coord` to be saturating

### DIFF
--- a/understory_index/src/backends/grid.rs
+++ b/understory_index/src/backends/grid.rs
@@ -95,9 +95,9 @@ impl GridScalar for i64 {
         let coord = rel.div_euclid(cell_size);
 
         // Saturate values out of `i32` range.
-        if coord >= i64::from(i32::MAX) {
+        if coord >= Self::from(i32::MAX) {
             i32::MAX
-        } else if coord <= i64::from(i32::MIN) {
+        } else if coord <= Self::from(i32::MIN) {
             i32::MIN
         } else {
             coord as i32


### PR DESCRIPTION
If an `f64`, `f32` or `i64` coordinate is such that it is out of range of cells representable by an `i32`, the grid cell coordinate is saturated to `i32::MIN` or `i32::MAX`). Negative fractional coordinates are still rounded toward negative infinity.

This is probably enough for https://github.com/endoli/understory/pull/91, but that requires a bit more thought.