### PR TITLE
box_tree: Improve `LocalNode::z_index` docs

### DIFF
--- a/understory_box_tree/src/types.rs
+++ b/understory_box_tree/src/types.rs
@@ -97,10 +97,12 @@ pub struct LocalNode {
     /// - Points outside `local_clip` (once transformed) cannot hit this node or any descendant.
     ///   Backends may still apply more precise clipping during rendering.
     pub local_clip: Option<RoundedRect>,
-    /// Z-order within the parent stacking context.
+    /// The node's z-order within the [`Tree`](crate::Tree).
     ///
-    /// - Higher values are drawn on top of siblings with lower values.
-    /// - Hit testing also compares `z_index` across different parents when nodes overlap;
+    /// This does not model stacking contexts.
+    ///
+    /// - Nodes with higher values are drawn on top of nodes with lower values.
+    /// - Hit testing compares `z_index` when nodes within the tree overlap;
     ///   depth in the tree and insertion order are used as secondary tie-breakers.
     pub z_index: i32,
     /// Visibility and interaction flags.


### PR DESCRIPTION
Takes the "does not model stacking contexts" wording from crate-level docs:

https://github.com/endoli/understory/blob/fdbfceaf8b3bd75d4c8eb5d72c757545b0140dff/understory_box_tree/src/lib.rs#L33-L35