### PR TITLE
box_tree: remove unused `Dirty::z_index` flag

### DIFF
--- a/understory_box_tree/src/tree.rs
+++ b/understory_box_tree/src/tree.rs
@@ -149,7 +149,6 @@ struct Dirty {
     layout: bool,
     transform: bool,
     clip: bool,
-    z: bool,
     index: bool,
 }
 
@@ -176,7 +175,6 @@ impl Node {
                 layout: true,
                 transform: true,
                 clip: true,
-                z: true,
                 index: true,
             },
             index_key: None,
@@ -222,7 +220,6 @@ impl<B: Backend<f64>> Tree<B> {
             n.dirty.layout |= flags.layout;
             n.dirty.transform |= flags.transform;
             n.dirty.clip |= flags.clip;
-            n.dirty.z |= flags.z;
             n.dirty.index |= flags.index;
             n.children.clone()
         };
@@ -305,7 +302,6 @@ impl<B: Backend<f64>> Tree<B> {
                 layout: true,
                 transform: true,
                 clip: true,
-                z: true,
                 index: true,
             },
         );
@@ -339,7 +335,6 @@ impl<B: Backend<f64>> Tree<B> {
             && n.local.z_index != z
         {
             n.local.z_index = z;
-            n.dirty.z = true;
         }
     }
 


### PR DESCRIPTION
Currently `z` takes effect immediately, and it does not affect geometry, so it doesn't cause nodes to be dirty. (Also see somewhat related docs changes in https://github.com/endoli/understory/pull/102.)

The other flags currently also aren't really used, but we could! (Not tonight.)