### PR TITLE
Change allowed lints to `expect`, remove one unfulfilled lint

### DIFF
--- a/benches/benches/ui_box_tree.rs
+++ b/benches/benches/ui_box_tree.rs
@@ -83,7 +83,7 @@ struct DumpNode {
     local_clip: Option<DumpRoundedRect>,
     local_transform: [f64; 6],
     children: Vec<DumpNode>,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     view_id: Option<String>,
 }
 
@@ -386,7 +386,7 @@ fn build_synthetic_ui_box_tree<B: Backend<f64>>(backend: B) -> (Tree<B>, Vec<Nod
     (tree, ids, stats)
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "Local helper to keep the synthetic tree construction readable."
 )]

--- a/understory_box_tree/src/tree.rs
+++ b/understory_box_tree/src/tree.rs
@@ -241,7 +241,7 @@ impl<B: Backend<f64>> Tree<B> {
             let generation = self.generations[idx].saturating_add(1);
             self.generations[idx] = generation;
             self.nodes[idx] = Some(Node::new(generation, local));
-            #[allow(
+            #[expect(
                 clippy::cast_possible_truncation,
                 reason = "NodeId uses 32-bit indices by design."
             )]
@@ -250,7 +250,7 @@ impl<B: Backend<f64>> Tree<B> {
             let generation = 1_u32;
             self.nodes.push(Some(Node::new(generation, local)));
             self.generations.push(generation);
-            #[allow(
+            #[expect(
                 clippy::cast_possible_truncation,
                 reason = "NodeId uses 32-bit indices by design."
             )]
@@ -421,7 +421,7 @@ impl<B: Backend<f64>> Tree<B> {
             .filter_map(|(i, n)| match n {
                 Some(n) if n.parent.is_none() =>
                 {
-                    #[allow(
+                    #[expect(
                         clippy::cast_possible_truncation,
                         reason = "NodeId uses 32-bit indices by design."
                     )]

--- a/understory_index/src/backends/grid.rs
+++ b/understory_index/src/backends/grid.rs
@@ -33,7 +33,7 @@ pub trait GridScalar: Scalar {
 }
 
 impl GridScalar for f32 {
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
         reason = "Grid cell indices are intentionally i32; out-of-range values are saturated."
     )]
@@ -56,7 +56,7 @@ impl GridScalar for f32 {
 }
 
 impl GridScalar for f64 {
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
         reason = "Grid cell indices are intentionally i32; out-of-range values are saturated."
     )]
@@ -79,7 +79,7 @@ impl GridScalar for f64 {
 }
 
 impl GridScalar for i64 {
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
         reason = "Grid cell indices are intentionally i32; out-of-range values are saturated."
     )]

--- a/understory_index/src/index.rs
+++ b/understory_index/src/index.rs
@@ -15,7 +15,7 @@ use crate::types::Aabb2D;
 pub struct Key(u32, u32);
 
 impl Key {
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
         reason = "Index keys are intentionally 32-bit; higher bits are truncated by design."
     )]

--- a/understory_responder/src/adapters/hit2d.rs
+++ b/understory_responder/src/adapters/hit2d.rs
@@ -38,7 +38,7 @@ where
         .map(|h| ResolvedHit {
             node: h.key,
             path: None,
-            #[allow(
+            #[expect(
                 clippy::cast_possible_truncation,
                 reason = "DepthKey uses f32; precision loss is acceptable for hit sorting."
             )]

--- a/understory_virtual_list/src/fixed.rs
+++ b/understory_virtual_list/src/fixed.rs
@@ -80,10 +80,6 @@ impl<S: Scalar> ExtentModel for FixedExtentModel<S> {
             return 0;
         }
         let ratio = offset / self.extent;
-        #[allow(
-            clippy::cast_possible_truncation,
-            reason = "Index is clamped to bounds immediately after the cast"
-        )]
         let i = ratio.floor_to_isize();
         i.clamp(0, self.len as isize - 1) as usize
     }

--- a/understory_virtual_list/src/scalar.rs
+++ b/understory_virtual_list/src/scalar.rs
@@ -82,7 +82,7 @@ impl Scalar for f32 {
     }
 
     fn floor_to_isize(self) -> isize {
-        #[allow(
+        #[expect(
             clippy::cast_possible_truncation,
             reason = "Used only for index approximation; result is clamped immediately after"
         )]
@@ -118,7 +118,7 @@ impl Scalar for f64 {
     }
 
     fn floor_to_isize(self) -> isize {
-        #[allow(
+        #[expect(
             clippy::cast_possible_truncation,
             reason = "Used only for index approximation; result is clamped immediately after"
         )]


### PR DESCRIPTION
`#[expect(...)]` auto-cleans by warning for unfulfilled expected lints.