### PR TITLE
responder: avoid cloning hit paths; add borrowed hit support

### DIFF
--- a/understory_responder/README.md
+++ b/understory_responder/README.md
@@ -31,9 +31,12 @@ Instead, feed it [`ResolvedHit`](https://docs.rs/understory_responder/latest/und
 
 ## Inputs
 
-Provide one or more [`ResolvedHit`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.ResolvedHit.html) values for candidate targets.
-A [`ResolvedHit`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.ResolvedHit.html) contains the node key, an optional root→target `path`, a [`DepthKey`](https://docs.rs/understory_responder/latest/understory_responder/types/enum.DepthKey.html) used for ordering,
+Provide one or more hit candidates for targets.
+The simplest is [`ResolvedHit`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.ResolvedHit.html), which contains the node key, an optional owned root→target `path`, a [`DepthKey`](https://docs.rs/understory_responder/latest/understory_responder/types/enum.DepthKey.html) used for ordering,
 a [`Localizer`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.Localizer.html) for coordinate conversion, and an optional `meta` payload (e.g., text or ray‑hit details).
+
+If your picker caches full paths (for example in an `Rc<[K]>`), you can avoid rebuilding a `Vec<K>` by using [`ResolvedHitRef`](https://docs.rs/understory_responder/latest/understory_responder/types/struct.ResolvedHitRef.html),
+which borrows a `&[K]` path, or by implementing [`Hit`](https://docs.rs/understory_responder/latest/understory_responder/types/trait.Hit.html) for your own hit type.
 You may also provide a [`ParentLookup`](https://docs.rs/understory_responder/latest/understory_responder/types/trait.ParentLookup.html) source to reconstruct a path when `path` is absent.
 
 ## Ordering

--- a/understory_responder/src/lib.rs
+++ b/understory_responder/src/lib.rs
@@ -14,9 +14,12 @@
 //!
 //! ## Inputs
 //!
-//! Provide one or more [`ResolvedHit`](crate::types::ResolvedHit) values for candidate targets.
-//! A [`ResolvedHit`](crate::types::ResolvedHit) contains the node key, an optional root→target `path`, a [`DepthKey`](crate::types::DepthKey) used for ordering,
+//! Provide one or more hit candidates for targets.
+//! The simplest is [`ResolvedHit`](crate::types::ResolvedHit), which contains the node key, an optional owned root→target `path`, a [`DepthKey`](crate::types::DepthKey) used for ordering,
 //! a [`Localizer`](crate::types::Localizer) for coordinate conversion, and an optional `meta` payload (e.g., text or ray‑hit details).
+//!
+//! If your picker caches full paths (for example in an `Rc<[K]>`), you can avoid rebuilding a `Vec<K>` by using [`ResolvedHitRef`](crate::types::ResolvedHitRef),
+//! which borrows a `&[K]` path, or by implementing [`Hit`](crate::types::Hit) for your own hit type.
 //! You may also provide a [`ParentLookup`](crate::types::ParentLookup) source to reconstruct a path when `path` is absent.
 //!
 //! ## Ordering


### PR DESCRIPTION
* `Router::handle_with_hits` now accepts any `Hit` (incl. `ResolvedHitRef`) so cached root→target paths can be routed without rebuilding `Vec`s.
* Also routes from `&[K]` internally, adds a test exercising borrowed paths, and tightens small const/inline helpers.