### PR TITLE
understory_dirty: add no_std dirty-tracking primitives (graph + dirty…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: check understory_box_tree README
         run: cargo rdme --workspace-project=understory_box_tree --heading-base-level=0 --check
 
+      - name: check understory_dirty README
+        run: cargo rdme --workspace-project=understory_dirty --heading-base-level=0 --check
+
       - name: check understory_precise_hit README
         run: cargo rdme --workspace-project=understory_precise_hit --heading-base-level=0 --check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "serde",
  "serde_json",
  "understory_box_tree",
+ "understory_dirty",
  "understory_index",
 ]
 
@@ -521,6 +522,13 @@ dependencies = [
  "bitflags",
  "kurbo",
  "understory_index",
+]
+
+[[package]]
+name = "understory_dirty"
+version = "0.1.0"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "understory_index",
   "understory_box_tree",
+  "understory_dirty",
   "understory_focus",
   "understory_precise_hit",
   "understory_responder",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,6 +8,7 @@ autobenches = false
 [dependencies]
 understory_index = { path = "../understory_index" }
 understory_box_tree = { path = "../understory_box_tree" }
+understory_dirty = { path = "../understory_dirty" }
 kurbo.workspace = true
 rstar = { version = "0.11", optional = true }
 
@@ -32,4 +33,8 @@ required-features = ["compare_rstar"]
 
 [[bench]]
 name = "ui_box_tree"
+harness = false
+
+[[bench]]
+name = "dirty"
 harness = false

--- a/benches/benches/dirty.rs
+++ b/benches/benches/dirty.rs
@@ -1,0 +1,265 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use understory_dirty::{
+    Channel, DirtyGraph, DirtyTracker, EagerPolicy, LazyPolicy, TraversalScratch,
+};
+
+const LAYOUT: Channel = Channel::new(0);
+
+#[derive(Clone)]
+struct Lcg(u64);
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        // Numerical Recipes LCG parameters.
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (self.0 >> 32) as u32
+    }
+
+    fn gen_range_usize(&mut self, upper_exclusive: usize) -> usize {
+        if upper_exclusive == 0 {
+            return 0;
+        }
+        (self.next_u32() as usize) % upper_exclusive
+    }
+}
+
+fn build_dag_graph(n: u32, edges_per_node: u32, seed: u64) -> DirtyGraph<u32> {
+    let mut graph = DirtyGraph::new();
+    let mut rng = Lcg::new(seed);
+
+    // Ensure a DAG by only adding edges `from -> to` where `to < from`.
+    for from in 0..n {
+        if from == 0 {
+            continue;
+        }
+        let out = edges_per_node.min(from);
+        for _ in 0..out {
+            let to = rng.gen_range_usize(from as usize) as u32;
+            let _ = graph
+                .add_dependency(from, to, LAYOUT, understory_dirty::CycleHandling::Allow)
+                .expect("CycleHandling::Allow never errors");
+        }
+    }
+
+    graph
+}
+
+fn build_dag_tracker(n: u32, edges_per_node: u32, seed: u64) -> DirtyTracker<u32> {
+    let graph = build_dag_graph(n, edges_per_node, seed);
+    let mut tracker = DirtyTracker::new();
+    *tracker.graph_mut() = graph;
+    tracker
+}
+
+fn roots_repeating(unique_roots: u32, marks: u32) -> impl Iterator<Item = u32> {
+    (0..marks).map(move |i| i % unique_roots)
+}
+
+fn bench_dirty(c: &mut Criterion) {
+    let mut group = c.benchmark_group("understory_dirty");
+    group.sample_size(50);
+
+    for &(n, edges_per_node) in &[
+        (256_u32, 1_u32),
+        (256_u32, 4_u32),
+        (4_096_u32, 1_u32),
+        (4_096_u32, 4_u32),
+    ] {
+        group.bench_function(format!("eager_mark(n={n},e={edges_per_node})"), |b| {
+            b.iter_batched(
+                || build_dag_tracker(n, edges_per_node, 0xD1A7_0000_0000_0001),
+                |mut tracker| {
+                    tracker.mark_with(0, LAYOUT, &EagerPolicy);
+                    black_box(tracker);
+                },
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_function(
+            format!("eager_mark_with_scratch(n={n},e={edges_per_node})"),
+            |b| {
+                b.iter_batched(
+                    || build_dag_graph(n, edges_per_node, 0xD1A7_0000_0000_0005),
+                    |graph| {
+                        let mut dirty = understory_dirty::DirtySet::new();
+                        let mut scratch = TraversalScratch::with_capacity(n as usize / 2);
+                        EagerPolicy.propagate_with_scratch(
+                            0,
+                            LAYOUT,
+                            &graph,
+                            &mut dirty,
+                            &mut scratch,
+                        );
+                        black_box(dirty);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        group.bench_function(
+            format!("eager_mark_and_drain(n={n},e={edges_per_node})"),
+            |b| {
+                b.iter_batched(
+                    || build_dag_tracker(n, edges_per_node, 0xD1A7_0000_0000_0002),
+                    |mut tracker| {
+                        tracker.mark_with(0, LAYOUT, &EagerPolicy);
+                        let sum: u64 = tracker
+                            .drain_sorted(LAYOUT)
+                            .fold(0_u64, |acc, k| acc + u64::from(k));
+                        black_box(sum);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        group.bench_function(
+            format!("lazy_mark_and_drain_affected(n={n},e={edges_per_node})"),
+            |b| {
+                b.iter_batched(
+                    || build_dag_tracker(n, edges_per_node, 0xD1A7_0000_0000_0003),
+                    |mut tracker| {
+                        tracker.mark_with(0, LAYOUT, &LazyPolicy);
+                        let sum: u64 = tracker
+                            .drain_affected_sorted(LAYOUT)
+                            .fold(0_u64, |acc, k| acc + u64::from(k));
+                        black_box(sum);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        group.bench_function(
+            format!("drain_sorted_all_dirty(n={n},e={edges_per_node})"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let mut tracker =
+                            build_dag_tracker(n, edges_per_node, 0xD1A7_0000_0000_0004);
+                        for k in 0..n {
+                            tracker.mark(k, LAYOUT);
+                        }
+                        tracker
+                    },
+                    |mut tracker| {
+                        let sum: u64 = tracker
+                            .drain_sorted(LAYOUT)
+                            .fold(0_u64, |acc, k| acc + u64::from(k));
+                        black_box(sum);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        // Measures the non-draining sorted view of dirty keys.
+        group.bench_function(
+            format!("peek_sorted_all_dirty_sum(n={n},e={edges_per_node})"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let mut tracker =
+                            build_dag_tracker(n, edges_per_node, 0xD1A7_0000_0000_0007);
+                        for k in 0..n {
+                            tracker.mark(k, LAYOUT);
+                        }
+                        tracker
+                    },
+                    |tracker| {
+                        let sum: u64 = tracker
+                            .peek_sorted(LAYOUT)
+                            .fold(0_u64, |acc, k| acc + u64::from(k));
+                        black_box(sum);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    // Demonstrate the "many marks, few drains" workload where LazyPolicy can win:
+    // repeated marks against a small set of roots should not repeatedly traverse dependents.
+    for &(n, edges_per_node, marks, unique_roots) in &[
+        (4_096_u32, 4_u32, 1_024_u32, 1_u32),
+        (4_096_u32, 4_u32, 1_024_u32, 8_u32),
+    ] {
+        group.bench_function(
+            format!("redundant_marks_then_drain_eager(n={n},e={edges_per_node},marks={marks},roots={unique_roots})"),
+            |b| {
+                b.iter_batched(
+                    || build_dag_tracker(n, edges_per_node, 0xD1A7_0000_0000_0010),
+                    |mut tracker| {
+                        for root in roots_repeating(unique_roots, marks) {
+                            tracker.mark_with(root, LAYOUT, &EagerPolicy);
+                        }
+                        let sum: u64 = tracker
+                            .drain_sorted(LAYOUT)
+                            .fold(0_u64, |acc, k| acc + u64::from(k));
+                        black_box(sum);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        group.bench_function(
+            format!("redundant_marks_then_drain_eager_with_scratch(n={n},e={edges_per_node},marks={marks},roots={unique_roots})"),
+            |b| {
+                b.iter_batched(
+                    || build_dag_graph(n, edges_per_node, 0xD1A7_0000_0000_0030),
+                    |graph| {
+                        let mut dirty = understory_dirty::DirtySet::new();
+                        let mut scratch = TraversalScratch::with_capacity(n as usize / 2);
+                        for root in roots_repeating(unique_roots, marks) {
+                            EagerPolicy.propagate_with_scratch(
+                                root,
+                                LAYOUT,
+                                &graph,
+                                &mut dirty,
+                                &mut scratch,
+                            );
+                        }
+                        let sum: u64 = understory_dirty::drain_sorted(&mut dirty, &graph, LAYOUT)
+                            .fold(0_u64, |acc, k| acc + u64::from(k));
+                        black_box(sum);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        group.bench_function(
+            format!("redundant_marks_then_drain_lazy(n={n},e={edges_per_node},marks={marks},roots={unique_roots})"),
+            |b| {
+                b.iter_batched(
+                    || build_dag_tracker(n, edges_per_node, 0xD1A7_0000_0000_0020),
+                    |mut tracker| {
+                        for root in roots_repeating(unique_roots, marks) {
+                            tracker.mark_with(root, LAYOUT, &LazyPolicy);
+                        }
+                        let sum: u64 = tracker
+                            .drain_affected_sorted(LAYOUT)
+                            .fold(0_u64, |acc, k| acc + u64::from(k));
+                        black_box(sum);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_dirty);
+criterion_main!(benches);

--- a/understory_dirty/Cargo.toml
+++ b/understory_dirty/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "understory_dirty"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Generic dirty-tracking and invalidation primitives"
+keywords = ["dirty", "invalidation", "incremental", "no_std", "understory"]
+categories = ["data-structures"]
+
+[dependencies]
+hashbrown.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = []
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_dirty/README.md
+++ b/understory_dirty/README.md
@@ -1,0 +1,160 @@
+<div align="center">
+
+# Understory Dirty
+
+**Generic dirty-tracking and invalidation primitives**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_dirty.svg)](https://crates.io/crates/understory_dirty)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_dirty.svg)](https://docs.rs/understory_dirty)
+[![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/endoli/understory/ci.yml?logo=github&label=CI)](https://github.com/endoli/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_dirty
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Understory Dirty: generic dirty-tracking and invalidation primitives.
+
+This crate provides building blocks for incremental computation systems
+where changes to upstream data must propagate to downstream consumers.
+It models invalidation as a combination of:
+
+- **Channels** ([`Channel`], [`ChannelSet`]): Named domains for dirty tracking
+  (e.g., layout, paint, accessibility).
+- **Dependency graphs** ([`DirtyGraph`]): DAG of "A depends on B" edges,
+  with cycle detection and bidirectional traversal.
+- **Dirty sets** ([`DirtySet`]): Accumulated dirty keys per channel with
+  generation tracking for stale-computation detection.
+- **Propagation policies** ([`PropagationPolicy`], [`EagerPolicy`], [`LazyPolicy`]):
+  Pluggable strategies for how dirty marks spread through the graph.
+- **Topological drain** ([`DrainSorted`]): Kahn's algorithm to yield dirty keys
+  in dependency order.
+- **Scratch buffers** ([`TraversalScratch`]): Reusable traversal state for
+  tight loops (many marks per frame) to avoid repeated allocations.
+
+## Quick Start
+
+```rust
+use understory_dirty::{Channel, DirtyTracker, EagerPolicy};
+
+const LAYOUT: Channel = Channel::new(0);
+const PAINT: Channel = Channel::new(1);
+
+let mut tracker = DirtyTracker::<u32>::new();
+
+// Build dependency graph: 3 depends on 2, 2 depends on 1
+tracker.add_dependency(2, 1, LAYOUT).unwrap();
+tracker.add_dependency(3, 2, LAYOUT).unwrap();
+
+// Mark with eager propagation (marks 1, 2, 3)
+tracker.mark_with(1, LAYOUT, &EagerPolicy);
+
+// Or mark manually without propagation
+tracker.mark(1, PAINT);
+
+// Drain in topological order: 1, 2, 3
+for key in tracker.drain_sorted(LAYOUT) {
+    // recompute_layout(key);
+}
+```
+
+## Using Components Separately
+
+While [`DirtyTracker`] provides a convenient combined API, you can also
+use the underlying types directly for more control:
+
+```rust
+use understory_dirty::{
+    Channel, CycleHandling, DirtyGraph, DirtySet, EagerPolicy, PropagationPolicy,
+};
+
+const LAYOUT: Channel = Channel::new(0);
+
+// Build the dependency graph
+let mut graph = DirtyGraph::<u32>::new();
+graph.add_dependency(2, 1, LAYOUT, CycleHandling::Error).unwrap();
+graph.add_dependency(3, 2, LAYOUT, CycleHandling::Error).unwrap();
+
+// Maintain dirty state separately
+let mut dirty = DirtySet::new();
+let eager = EagerPolicy;
+
+// Propagate dirty marks
+eager.propagate(1, LAYOUT, &graph, &mut dirty);
+
+assert!(dirty.is_dirty(1, LAYOUT));
+assert!(dirty.is_dirty(2, LAYOUT));
+assert!(dirty.is_dirty(3, LAYOUT));
+```
+
+## Propagation Policies
+
+The crate provides two built-in policies:
+
+- [`EagerPolicy`]: Immediately marks all transitive dependents when a key
+  is marked dirty. Use this when you need to know the full dirty set
+  immediately after marking. Use with [`DirtyTracker::drain_sorted`].
+
+- [`LazyPolicy`]: Only marks the key itself at mark-time; no propagation
+  occurs. Use [`DirtyTracker::drain_affected_sorted`] to expand and process
+  all affected keys (marked roots + their transitive dependents) at drain
+  time. This avoids redundant traversals when many marks happen in succession.
+
+You can implement [`PropagationPolicy`] for custom strategies (e.g.,
+depth-limited propagation, priority-based marking).
+
+## Performance Notes
+
+For eager propagation in hot loops, consider reusing a [`TraversalScratch`]
+and calling [`EagerPolicy::propagate_with_scratch`] to avoid per-mark
+allocation during graph traversal.
+
+## Choosing a Drain Function
+
+- [`drain_sorted`] / [`DirtyTracker::drain_sorted`]: Drains exactly the keys
+  that are currently marked dirty, in topological order. Use with [`EagerPolicy`]
+  or when you only want to process explicitly marked keys.
+
+- [`drain_affected_sorted`] / [`DirtyTracker::drain_affected_sorted`]: Expands
+  the dirty set to include all transitive dependents before draining. Use with
+  [`LazyPolicy`] to get the "lazy at mark-time, eager at drain-time" workflow.
+
+## Cycle Detection
+
+[`DirtyGraph::add_dependency`] supports configurable cycle handling via
+[`CycleHandling`]:
+
+- `DebugAssert` (default): Panics in debug builds, ignores in release.
+- `Error`: Returns `Err(CycleError)` if a cycle would be created.
+- `Ignore`: Silently ignores the dependency.
+- `Allow`: Skips cycle detection entirely (useful when cycles are intentional).
+
+## `no_std` Support
+
+This crate is `no_std` and uses `alloc`. It does not depend on `std`.
+
+## Features
+
+This crate currently has no optional features. All functionality is always
+available.
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under the Apache License, Version 2.0 ([LICENSE] or <http://www.apache.org/licenses/LICENSE-2.0>)
+
+<!-- Needs to be defined here for rustdoc's benefit -->
+[LICENSE]: LICENSE

--- a/understory_dirty/src/channel.rs
+++ b/understory_dirty/src/channel.rs
@@ -1,0 +1,319 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Channel and channel set types for identifying dirty domains.
+
+use core::fmt;
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
+
+/// Identifies a dirty domain (layout, paint, accessibility, etc.).
+///
+/// A channel is a lightweight handle (a single `u8`) that represents a specific
+/// invalidation domain. Dependencies and dirty state are tracked per-channel,
+/// allowing independent invalidation of different concerns.
+///
+/// # Example
+///
+/// ```
+/// use understory_dirty::Channel;
+///
+/// // Define your own channels as constants
+/// const LAYOUT: Channel = Channel::new(0);
+/// const PAINT: Channel = Channel::new(1);
+/// const A11Y: Channel = Channel::new(2);
+/// const STYLE: Channel = Channel::new(3);
+/// ```
+///
+/// # See Also
+///
+/// - [`ChannelSet`]: A compact set of channels.
+/// - [`DirtySet`](crate::DirtySet): Tracks dirty keys per channel.
+/// - [`DirtyGraph`](crate::DirtyGraph): Stores dependencies per channel.
+/// - [`DirtyTracker`](crate::DirtyTracker): Convenience wrapper combining graph + set.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Channel(u8);
+
+impl Channel {
+    /// Creates a new channel with the given index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= 64`, as [`ChannelSet`] only supports 64 channels.
+    #[must_use]
+    pub const fn new(index: u8) -> Self {
+        assert!(index < 64, "Channel index must be less than 64");
+        Self(index)
+    }
+
+    /// Returns the index of this channel.
+    #[must_use]
+    pub const fn index(self) -> u8 {
+        self.0
+    }
+
+    /// Converts this channel into a single-element [`ChannelSet`].
+    #[must_use]
+    pub const fn into_set(self) -> ChannelSet {
+        ChannelSet(1_u64 << self.0)
+    }
+}
+
+impl fmt::Debug for Channel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Channel").field(&self.0).finish()
+    }
+}
+
+/// A compact bitfield representing a set of up to 64 channels.
+///
+/// `ChannelSet` is useful for operations that affect multiple channels at once,
+/// such as marking a node dirty in several domains simultaneously.
+///
+/// # Example
+///
+/// ```
+/// use understory_dirty::{Channel, ChannelSet};
+///
+/// const LAYOUT: Channel = Channel::new(0);
+/// const PAINT: Channel = Channel::new(1);
+/// const A11Y: Channel = Channel::new(2);
+///
+/// let mut set = ChannelSet::empty();
+/// set.insert(LAYOUT);
+/// set.insert(PAINT);
+///
+/// assert!(set.contains(LAYOUT));
+/// assert!(set.contains(PAINT));
+/// assert!(!set.contains(A11Y));
+///
+/// // Combine sets with bitwise OR
+/// let combined = LAYOUT.into_set() | A11Y.into_set();
+/// assert!(combined.contains(LAYOUT));
+/// assert!(combined.contains(A11Y));
+/// ```
+///
+/// # See Also
+///
+/// - [`Channel`]: The single-channel identifier stored in this set.
+/// - [`DirtySet`](crate::DirtySet): Uses channels to partition dirty keys.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
+pub struct ChannelSet(u64);
+
+impl ChannelSet {
+    /// An empty channel set.
+    pub const EMPTY: Self = Self(0);
+
+    /// A channel set containing all 64 possible channels.
+    pub const ALL: Self = Self(u64::MAX);
+
+    /// Creates an empty channel set.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self::EMPTY
+    }
+
+    /// Creates a channel set containing all 64 possible channels.
+    #[must_use]
+    pub const fn all() -> Self {
+        Self::ALL
+    }
+
+    /// Returns `true` if this set contains no channels.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Returns `true` if this set contains the given channel.
+    #[must_use]
+    pub const fn contains(self, channel: Channel) -> bool {
+        (self.0 & (1_u64 << channel.0)) != 0
+    }
+
+    /// Inserts a channel into the set.
+    pub fn insert(&mut self, channel: Channel) {
+        self.0 |= 1_u64 << channel.0;
+    }
+
+    /// Removes a channel from the set.
+    pub fn remove(&mut self, channel: Channel) {
+        self.0 &= !(1_u64 << channel.0);
+    }
+
+    /// Returns the number of channels in the set.
+    #[must_use]
+    pub const fn len(self) -> u32 {
+        self.0.count_ones()
+    }
+
+    /// Returns an iterator over the channels in this set.
+    #[must_use]
+    pub const fn iter(self) -> ChannelSetIter {
+        ChannelSetIter { bits: self.0 }
+    }
+}
+
+impl fmt::Debug for ChannelSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+impl BitOr for ChannelSet {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for ChannelSet {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl BitAnd for ChannelSet {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl BitAndAssign for ChannelSet {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
+impl Not for ChannelSet {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Self(!self.0)
+    }
+}
+
+impl From<Channel> for ChannelSet {
+    fn from(channel: Channel) -> Self {
+        channel.into_set()
+    }
+}
+
+impl IntoIterator for ChannelSet {
+    type Item = Channel;
+    type IntoIter = ChannelSetIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// An iterator over the channels in a [`ChannelSet`].
+#[derive(Clone, Debug)]
+pub struct ChannelSetIter {
+    bits: u64,
+}
+
+impl Iterator for ChannelSetIter {
+    type Item = Channel;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.bits == 0 {
+            return None;
+        }
+        // SAFETY: trailing_zeros of a u64 is at most 63, which fits in u8.
+        #[expect(clippy::cast_possible_truncation, reason = "trailing_zeros <= 63")]
+        let index = self.bits.trailing_zeros() as u8;
+        self.bits &= self.bits - 1; // Clear the lowest set bit
+        Some(Channel(index))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let count = self.bits.count_ones() as usize;
+        (count, Some(count))
+    }
+}
+
+impl ExactSizeIterator for ChannelSetIter {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    const LAYOUT: Channel = Channel::new(0);
+    const PAINT: Channel = Channel::new(1);
+    const A11Y: Channel = Channel::new(2);
+
+    #[test]
+    fn channel_new_valid() {
+        let ch = Channel::new(42);
+        assert_eq!(ch.index(), 42);
+    }
+
+    #[test]
+    #[should_panic(expected = "Channel index must be less than 64")]
+    fn channel_new_invalid() {
+        let _ = Channel::new(64);
+    }
+
+    #[test]
+    fn channel_set_operations() {
+        let mut set = ChannelSet::empty();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+
+        set.insert(LAYOUT);
+        assert!(!set.is_empty());
+        assert!(set.contains(LAYOUT));
+        assert!(!set.contains(PAINT));
+        assert_eq!(set.len(), 1);
+
+        set.insert(PAINT);
+        assert!(set.contains(PAINT));
+        assert_eq!(set.len(), 2);
+
+        set.remove(LAYOUT);
+        assert!(!set.contains(LAYOUT));
+        assert!(set.contains(PAINT));
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn channel_set_bitwise() {
+        let a = LAYOUT.into_set();
+        let b = PAINT.into_set();
+        let c = a | b;
+
+        assert!(c.contains(LAYOUT));
+        assert!(c.contains(PAINT));
+        assert!(!c.contains(A11Y));
+
+        let d = c & a;
+        assert!(d.contains(LAYOUT));
+        assert!(!d.contains(PAINT));
+
+        let e = !a;
+        assert!(!e.contains(LAYOUT));
+        assert!(e.contains(PAINT));
+    }
+
+    #[test]
+    fn channel_set_iter() {
+        let set = LAYOUT.into_set() | A11Y.into_set();
+        let channels: Vec<_> = set.iter().collect();
+
+        assert_eq!(channels.len(), 2);
+        assert!(channels.contains(&LAYOUT));
+        assert!(channels.contains(&A11Y));
+    }
+
+    #[test]
+    fn channel_set_iter_exact_size() {
+        let set = LAYOUT.into_set() | PAINT.into_set() | A11Y.into_set();
+        let iter = set.iter();
+        assert_eq!(iter.len(), 3);
+    }
+}

--- a/understory_dirty/src/graph.rs
+++ b/understory_dirty/src/graph.rs
@@ -1,0 +1,764 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Dependency graph for dirty tracking.
+
+use alloc::vec::Vec;
+use core::fmt;
+use core::hash::Hash;
+
+use hashbrown::{HashMap, HashSet};
+
+use crate::channel::{Channel, ChannelSet};
+use crate::scratch::TraversalScratch;
+
+/// Error returned when a cycle would be created by adding a dependency.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CycleError<K> {
+    /// The key that would depend on another.
+    pub from: K,
+    /// The key that would be depended upon.
+    pub to: K,
+    /// The channel where the cycle would occur.
+    pub channel: Channel,
+}
+
+impl<K: fmt::Debug> fmt::Debug for CycleError<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CycleError {{ from: {:?}, to: {:?}, channel: {:?} }}",
+            self.from, self.to, self.channel
+        )
+    }
+}
+
+impl<K: fmt::Debug> fmt::Display for CycleError<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "adding dependency {:?} -> {:?} in {:?} would create a cycle",
+            self.from, self.to, self.channel
+        )
+    }
+}
+
+impl<K: fmt::Debug> core::error::Error for CycleError<K> {}
+
+/// How to handle cycle detection when adding dependencies.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub enum CycleHandling {
+    /// Panic in debug builds, silently ignore in release builds.
+    ///
+    /// This is the default behavior: catches bugs during development with
+    /// zero cost in release builds.
+    #[default]
+    DebugAssert,
+    /// Return an error if a cycle would be created.
+    Error,
+    /// Silently ignore the dependency if it would create a cycle.
+    Ignore,
+    /// Allow cycles (skip cycle detection entirely).
+    ///
+    /// This is useful when the caller guarantees no cycles, or when cycles
+    /// are intentionally allowed. This has a small performance benefit as
+    /// no reachability check is performed.
+    Allow,
+}
+
+/// Dependency graph: "A depends on B" edges per channel.
+///
+/// `DirtyGraph` stores bidirectional dependency edges, allowing O(1) queries
+/// for both "what does A depend on?" and "what depends on A?". Dependencies
+/// are stored per-channel, so layout dependencies can be independent of
+/// paint dependencies.
+///
+/// # Type Parameters
+///
+/// - `K`: The key type, typically a node identifier. Must be `Copy + Eq + Hash`.
+///
+/// # Example
+///
+/// ```
+/// use understory_dirty::{Channel, CycleHandling, DirtyGraph};
+///
+/// const LAYOUT: Channel = Channel::new(0);
+///
+/// let mut graph = DirtyGraph::<u32>::new();
+///
+/// // Node 2 depends on node 1 for layout
+/// graph.add_dependency(2, 1, LAYOUT, CycleHandling::Error).unwrap();
+/// // Node 3 depends on node 2 for layout
+/// graph.add_dependency(3, 2, LAYOUT, CycleHandling::Error).unwrap();
+///
+/// // Query dependencies
+/// assert!(graph.dependencies(2, LAYOUT).any(|k| k == 1));
+/// assert!(graph.dependents(1, LAYOUT).any(|k| k == 2));
+///
+/// // Transitive dependents of node 1: [2, 3]
+/// let transitive: Vec<_> = graph.transitive_dependents(1, LAYOUT).collect();
+/// assert!(transitive.contains(&2));
+/// assert!(transitive.contains(&3));
+/// ```
+///
+/// # See Also
+///
+/// - [`DirtyTracker`](crate::DirtyTracker): Convenience wrapper combining graph + set.
+/// - [`CycleHandling`]: Cycle policy used by [`add_dependency`](Self::add_dependency).
+/// - [`DrainSorted`](crate::DrainSorted) / [`DrainSortedOwned`](crate::DrainSortedOwned): Drains dirty keys in dependency order.
+#[derive(Debug, Clone)]
+pub struct DirtyGraph<K>
+where
+    K: Copy + Eq + Hash,
+{
+    /// Forward edges: (from, channel) -> set of keys `from` depends on.
+    forward: HashMap<(K, Channel), HashSet<K>>,
+    /// Reverse edges: (to, channel) -> set of keys that depend on `to`.
+    reverse: HashMap<(K, Channel), HashSet<K>>,
+    /// Cached channels where `key` has any dependencies.
+    forward_channels: HashMap<K, ChannelSet>,
+    /// Cached channels where `key` has any dependents.
+    reverse_channels: HashMap<K, ChannelSet>,
+}
+
+impl<K> Default for DirtyGraph<K>
+where
+    K: Copy + Eq + Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K> DirtyGraph<K>
+where
+    K: Copy + Eq + Hash,
+{
+    /// Creates a new empty dependency graph.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            forward: HashMap::new(),
+            reverse: HashMap::new(),
+            forward_channels: HashMap::new(),
+            reverse_channels: HashMap::new(),
+        }
+    }
+
+    /// Returns `true` if the graph has no dependencies.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.forward.is_empty()
+    }
+
+    /// Adds a dependency: `from` depends on `to` in the given channel.
+    ///
+    /// When `to` becomes dirty, `from` should be recomputed (in that channel).
+    ///
+    /// # Cycle Handling
+    ///
+    /// The `handling` parameter controls behavior when adding this dependency
+    /// would create a cycle:
+    ///
+    /// - [`CycleHandling::DebugAssert`]: Panics in debug builds, ignores in release.
+    /// - [`CycleHandling::Error`]: Returns `Err(CycleError)`.
+    /// - [`CycleHandling::Ignore`]: Silently ignores the dependency.
+    /// - [`CycleHandling::Allow`]: Skips cycle detection entirely.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if the dependency was newly added.
+    /// - `Ok(false)` if the dependency already existed.
+    /// - `Err(CycleError)` if a cycle would be created and `handling` is `Error`.
+    ///
+    /// # See Also
+    ///
+    /// - [`CycleHandling`]: How cycles are treated.
+    /// - [`CycleError`]: Returned when `handling` is [`CycleHandling::Error`].
+    pub fn add_dependency(
+        &mut self,
+        from: K,
+        to: K,
+        channel: Channel,
+        handling: CycleHandling,
+    ) -> Result<bool, CycleError<K>> {
+        // Self-dependency is a trivial cycle
+        if from == to {
+            return self.handle_cycle(from, to, channel, handling);
+        }
+
+        // Check for cycles unless explicitly allowed
+        if handling != CycleHandling::Allow && self.would_create_cycle(from, to, channel) {
+            return self.handle_cycle(from, to, channel, handling);
+        }
+
+        // Add forward edge: (from, channel) -> to
+        let inserted = self.forward.entry((from, channel)).or_default().insert(to);
+
+        if inserted {
+            // Add reverse edge: (to, channel) <- from
+            self.reverse.entry((to, channel)).or_default().insert(from);
+
+            self.forward_channels
+                .entry(from)
+                .and_modify(|set| set.insert(channel))
+                .or_insert_with(|| channel.into_set());
+            self.reverse_channels
+                .entry(to)
+                .and_modify(|set| set.insert(channel))
+                .or_insert_with(|| channel.into_set());
+        }
+
+        Ok(inserted)
+    }
+
+    fn handle_cycle(
+        &self,
+        from: K,
+        to: K,
+        channel: Channel,
+        handling: CycleHandling,
+    ) -> Result<bool, CycleError<K>> {
+        match handling {
+            CycleHandling::DebugAssert => {
+                debug_assert!(false, "adding dependency would create a cycle");
+                Ok(false)
+            }
+            CycleHandling::Error => Err(CycleError { from, to, channel }),
+            CycleHandling::Ignore | CycleHandling::Allow => Ok(false),
+        }
+    }
+
+    /// Checks whether adding `from -> to` would create a cycle.
+    ///
+    /// This performs a DFS from `to` to see if `from` is reachable.
+    fn would_create_cycle(&self, from: K, to: K, channel: Channel) -> bool {
+        // A cycle would be created if `from` is reachable from `to`
+        // (i.e., `to` already transitively depends on `from`)
+        let mut visited = HashSet::new();
+        let mut stack = Vec::new();
+        stack.push(to);
+
+        while let Some(current) = stack.pop() {
+            if current == from {
+                return true;
+            }
+            if !visited.insert(current) {
+                continue;
+            }
+
+            // Follow forward edges from current
+            if let Some(deps) = self.forward.get(&(current, channel)) {
+                stack.extend(deps.iter().copied());
+            }
+        }
+
+        false
+    }
+
+    /// Removes a dependency: `from` no longer depends on `to` in the given channel.
+    ///
+    /// Returns `true` if the dependency existed and was removed.
+    pub fn remove_dependency(&mut self, from: K, to: K, channel: Channel) -> bool {
+        let mut removed = false;
+        let mut removed_forward_entry = false;
+        if let Some(deps) = self.forward.get_mut(&(from, channel)) {
+            removed = deps.remove(&to);
+            if removed && deps.is_empty() {
+                self.forward.remove(&(from, channel));
+                removed_forward_entry = true;
+            }
+        }
+
+        if !removed {
+            return false;
+        }
+
+        let mut removed_reverse_entry = false;
+        if let Some(dependents) = self.reverse.get_mut(&(to, channel)) {
+            dependents.remove(&from);
+            if dependents.is_empty() {
+                self.reverse.remove(&(to, channel));
+                removed_reverse_entry = true;
+            }
+        }
+
+        if removed_forward_entry && let Some(set) = self.forward_channels.get_mut(&from) {
+            set.remove(channel);
+            if set.is_empty() {
+                self.forward_channels.remove(&from);
+            }
+        }
+        if removed_reverse_entry && let Some(set) = self.reverse_channels.get_mut(&to) {
+            set.remove(channel);
+            if set.is_empty() {
+                self.reverse_channels.remove(&to);
+            }
+        }
+
+        true
+    }
+
+    /// Removes a key entirely from the graph.
+    ///
+    /// This removes all dependencies involving `key`, both as a dependent
+    /// and as a dependency.
+    pub fn remove_key(&mut self, key: K) {
+        // Remove forward edges: (key, channel) -> deps
+        if let Some(channels) = self.forward_channels.remove(&key) {
+            for channel in channels {
+                if let Some(deps) = self.forward.remove(&(key, channel)) {
+                    for dep in deps {
+                        let Some(dependents) = self.reverse.get_mut(&(dep, channel)) else {
+                            continue;
+                        };
+                        dependents.remove(&key);
+                        if dependents.is_empty() {
+                            self.reverse.remove(&(dep, channel));
+                            if let Some(set) = self.reverse_channels.get_mut(&dep) {
+                                set.remove(channel);
+                                if set.is_empty() {
+                                    self.reverse_channels.remove(&dep);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Remove reverse edges: (key, channel) <- dependents
+        if let Some(channels) = self.reverse_channels.remove(&key) {
+            for channel in channels {
+                if let Some(dependents) = self.reverse.remove(&(key, channel)) {
+                    for dependent in dependents {
+                        let Some(deps) = self.forward.get_mut(&(dependent, channel)) else {
+                            continue;
+                        };
+                        deps.remove(&key);
+                        if deps.is_empty() {
+                            self.forward.remove(&(dependent, channel));
+                            if let Some(set) = self.forward_channels.get_mut(&dependent) {
+                                set.remove(channel);
+                                if set.is_empty() {
+                                    self.forward_channels.remove(&dependent);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns an iterator over the direct dependencies of `key` in the given channel.
+    ///
+    /// These are the keys that `key` depends on (i.e., if they become dirty,
+    /// `key` should be recomputed).
+    ///
+    /// The iteration order is not specified and may vary across runs or platforms.
+    pub fn dependencies(&self, key: K, channel: Channel) -> impl Iterator<Item = K> + '_ {
+        self.forward
+            .get(&(key, channel))
+            .into_iter()
+            .flat_map(|deps| deps.iter().copied())
+    }
+
+    /// Returns an iterator over the direct dependents of `key` in the given channel.
+    ///
+    /// These are the keys that depend on `key` (i.e., if `key` becomes dirty,
+    /// they should be recomputed).
+    ///
+    /// The iteration order is not specified and may vary across runs or platforms.
+    pub fn dependents(&self, key: K, channel: Channel) -> impl Iterator<Item = K> + '_ {
+        self.reverse
+            .get(&(key, channel))
+            .into_iter()
+            .flat_map(|deps| deps.iter().copied())
+    }
+
+    /// Returns an iterator over all transitive dependents of `key` in the given channel.
+    ///
+    /// This performs a DFS traversal and yields all keys that directly or
+    /// indirectly depend on `key`.
+    ///
+    /// The iteration order is not specified and may vary across runs or platforms.
+    pub fn transitive_dependents(&self, key: K, channel: Channel) -> impl Iterator<Item = K> + '_ {
+        TransitiveDependentsIter::new(self, key, channel)
+    }
+
+    /// Calls `f` for each transitive dependent of `key`, using reusable scratch buffers.
+    ///
+    /// This is equivalent to iterating [`transitive_dependents`](Self::transitive_dependents),
+    /// but allows the caller to reuse allocations across traversals.
+    ///
+    /// The iteration order is not specified and may vary across runs or platforms.
+    ///
+    /// # See Also
+    ///
+    /// - [`TraversalScratch`]: Reusable storage for this traversal.
+    /// - [`EagerPolicy::propagate_with_scratch`](crate::EagerPolicy::propagate_with_scratch): Uses this helper.
+    pub fn for_each_transitive_dependent(
+        &self,
+        key: K,
+        channel: Channel,
+        scratch: &mut TraversalScratch<K>,
+        mut f: impl FnMut(K),
+    ) {
+        scratch.reset();
+        scratch.stack.extend(self.dependents(key, channel));
+
+        while let Some(next) = scratch.stack.pop() {
+            if scratch.visited.insert(next) {
+                f(next);
+                scratch.stack.extend(self.dependents(next, channel));
+            }
+        }
+    }
+
+    /// Returns the set of channels in which `key` has any dependencies.
+    #[must_use]
+    pub fn dependency_channels(&self, key: K) -> ChannelSet {
+        self.forward_channels
+            .get(&key)
+            .copied()
+            .unwrap_or(ChannelSet::EMPTY)
+    }
+
+    /// Returns the set of channels in which `key` has any dependents.
+    #[must_use]
+    pub fn dependent_channels(&self, key: K) -> ChannelSet {
+        self.reverse_channels
+            .get(&key)
+            .copied()
+            .unwrap_or(ChannelSet::EMPTY)
+    }
+
+    /// Returns `true` if `key` has any dependencies in the given channel.
+    #[must_use]
+    pub fn has_dependencies(&self, key: K, channel: Channel) -> bool {
+        self.forward
+            .get(&(key, channel))
+            .is_some_and(|deps| !deps.is_empty())
+    }
+
+    /// Returns `true` if `key` has any dependents in the given channel.
+    #[must_use]
+    pub fn has_dependents(&self, key: K, channel: Channel) -> bool {
+        self.reverse
+            .get(&(key, channel))
+            .is_some_and(|deps| !deps.is_empty())
+    }
+
+    /// Returns the in-degree of `key` in the given channel.
+    ///
+    /// The in-degree is the number of keys that `key` depends on.
+    #[must_use]
+    pub fn in_degree(&self, key: K, channel: Channel) -> usize {
+        self.forward
+            .get(&(key, channel))
+            .map(HashSet::len)
+            .unwrap_or(0)
+    }
+
+    /// Returns the out-degree of `key` in the given channel.
+    ///
+    /// The out-degree is the number of keys that depend on `key`.
+    #[must_use]
+    pub fn out_degree(&self, key: K, channel: Channel) -> usize {
+        self.reverse
+            .get(&(key, channel))
+            .map(HashSet::len)
+            .unwrap_or(0)
+    }
+
+    /// Returns an iterator over all unique keys that have dependencies or dependents.
+    ///
+    /// Each key is yielded at most once, even if it appears in both the forward
+    /// and reverse edge maps.
+    ///
+    /// The iteration order is not specified and may vary across runs or platforms.
+    pub fn keys(&self) -> impl Iterator<Item = K> + '_ {
+        // Use a HashSet to deduplicate keys that appear in both maps.
+        let mut seen = HashSet::new();
+        self.forward_channels
+            .keys()
+            .chain(self.reverse_channels.keys())
+            .copied()
+            .filter(move |&k| seen.insert(k))
+    }
+
+    /// Collects [`keys`](Self::keys) into a `Vec`.
+    ///
+    /// The order is not specified and may vary across runs or platforms.
+    #[must_use]
+    pub fn keys_vec(&self) -> Vec<K> {
+        self.keys().collect()
+    }
+}
+
+/// Iterator over transitive dependents using DFS.
+struct TransitiveDependentsIter<'a, K>
+where
+    K: Copy + Eq + Hash,
+{
+    graph: &'a DirtyGraph<K>,
+    channel: Channel,
+    visited: HashSet<K>,
+    stack: Vec<K>,
+}
+
+impl<'a, K> TransitiveDependentsIter<'a, K>
+where
+    K: Copy + Eq + Hash,
+{
+    fn new(graph: &'a DirtyGraph<K>, start: K, channel: Channel) -> Self {
+        let mut iter = Self {
+            graph,
+            channel,
+            visited: HashSet::new(),
+            stack: Vec::new(),
+        };
+        // Initialize with direct dependents
+        iter.stack.extend(graph.dependents(start, channel));
+        iter
+    }
+}
+
+impl<K> Iterator for TransitiveDependentsIter<'_, K>
+where
+    K: Copy + Eq + Hash,
+{
+    type Item = K;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(key) = self.stack.pop() {
+            if self.visited.insert(key) {
+                // Push dependents of this key
+                self.stack.extend(self.graph.dependents(key, self.channel));
+                return Some(key);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    const LAYOUT: Channel = Channel::new(0);
+    const PAINT: Channel = Channel::new(1);
+    const A11Y: Channel = Channel::new(2);
+
+    #[test]
+    fn add_and_query_dependencies() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(3, 2, LAYOUT, CycleHandling::Error)
+            .unwrap();
+
+        // Node 2 depends on node 1
+        assert!(graph.dependencies(2, LAYOUT).any(|k| k == 1));
+        // Node 1 has dependent node 2
+        assert!(graph.dependents(1, LAYOUT).any(|k| k == 2));
+        // Node 2 has dependent node 3
+        assert!(graph.dependents(2, LAYOUT).any(|k| k == 3));
+    }
+
+    #[test]
+    fn cycle_detection_error() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(3, 2, LAYOUT, CycleHandling::Error)
+            .unwrap();
+
+        // Adding 1 -> 3 would create a cycle: 1 -> 3 -> 2 -> 1
+        let result = graph.add_dependency(1, 3, LAYOUT, CycleHandling::Error);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.from, 1);
+        assert_eq!(err.to, 3);
+    }
+
+    #[test]
+    fn self_dependency_is_cycle() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        let result = graph.add_dependency(1, 1, LAYOUT, CycleHandling::Error);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cycle_ignore() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Ignore)
+            .unwrap();
+
+        // Self-cycle is silently ignored
+        let result = graph.add_dependency(1, 1, LAYOUT, CycleHandling::Ignore);
+        assert!(result.is_ok());
+        assert!(!result.unwrap()); // Returns false because nothing was added
+    }
+
+    #[test]
+    fn cycle_allow() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Allow)
+            .unwrap();
+        graph
+            .add_dependency(3, 2, LAYOUT, CycleHandling::Allow)
+            .unwrap();
+
+        // Cycle is allowed
+        let result = graph.add_dependency(1, 3, LAYOUT, CycleHandling::Allow);
+        assert!(result.is_ok());
+        assert!(result.unwrap()); // Edge was added
+    }
+
+    #[test]
+    fn remove_dependency() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        assert!(graph.dependencies(2, LAYOUT).any(|k| k == 1));
+
+        let removed = graph.remove_dependency(2, 1, LAYOUT);
+        assert!(removed);
+        assert!(!graph.dependencies(2, LAYOUT).any(|k| k == 1));
+
+        // Removing again returns false
+        assert!(!graph.remove_dependency(2, 1, LAYOUT));
+    }
+
+    #[test]
+    fn remove_key() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(3, 2, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(2, 1, PAINT, CycleHandling::Error)
+            .unwrap();
+
+        graph.remove_key(2);
+
+        // Node 2's dependencies are gone
+        assert!(!graph.dependencies(2, LAYOUT).any(|_| true));
+        // Node 1's dependents are gone
+        assert!(!graph.dependents(1, LAYOUT).any(|_| true));
+        // Node 3's dependencies are gone
+        assert!(!graph.dependencies(3, LAYOUT).any(|_| true));
+    }
+
+    #[test]
+    fn transitive_dependents() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        // 1 <- 2 <- 3
+        //      ^
+        //      |
+        //      4
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(3, 2, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(4, 2, LAYOUT, CycleHandling::Error)
+            .unwrap();
+
+        let transitive: Vec<_> = graph.transitive_dependents(1, LAYOUT).collect();
+        assert_eq!(transitive.len(), 3);
+        assert!(transitive.contains(&2));
+        assert!(transitive.contains(&3));
+        assert!(transitive.contains(&4));
+    }
+
+    #[test]
+    fn channel_independence() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+
+        assert!(graph.has_dependencies(2, LAYOUT));
+        assert!(!graph.has_dependencies(2, PAINT));
+        assert!(graph.has_dependents(1, LAYOUT));
+        assert!(!graph.has_dependents(1, PAINT));
+    }
+
+    #[test]
+    fn in_out_degree() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        // 3 depends on 1 and 2
+        graph
+            .add_dependency(3, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(3, 2, LAYOUT, CycleHandling::Error)
+            .unwrap();
+
+        // Node 3 has in-degree 2 (depends on 2 nodes)
+        assert_eq!(graph.in_degree(3, LAYOUT), 2);
+        // Node 1 has out-degree 1 (1 node depends on it)
+        assert_eq!(graph.out_degree(1, LAYOUT), 1);
+    }
+
+    #[test]
+    fn dependency_channels() {
+        let mut graph = DirtyGraph::<u32>::new();
+
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(2, 1, PAINT, CycleHandling::Error)
+            .unwrap();
+
+        let channels = graph.dependency_channels(2);
+        assert!(channels.contains(LAYOUT));
+        assert!(channels.contains(PAINT));
+        assert!(!channels.contains(A11Y));
+    }
+
+    #[test]
+    fn keys_and_keys_vec_are_unique() {
+        let mut graph = DirtyGraph::<u32>::new();
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+
+        let keys: Vec<_> = graph.keys().collect();
+        assert_eq!(keys.len(), 2);
+        assert!(keys.contains(&1));
+        assert!(keys.contains(&2));
+
+        let keys_vec = graph.keys_vec();
+        assert_eq!(keys_vec.len(), 2);
+        assert!(keys_vec.contains(&1));
+        assert!(keys_vec.contains(&2));
+    }
+}

--- a/understory_dirty/src/lib.rs
+++ b/understory_dirty/src/lib.rs
@@ -1,0 +1,149 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Understory Dirty: generic dirty-tracking and invalidation primitives.
+//!
+//! This crate provides building blocks for incremental computation systems
+//! where changes to upstream data must propagate to downstream consumers.
+//! It models invalidation as a combination of:
+//!
+//! - **Channels** ([`Channel`], [`ChannelSet`]): Named domains for dirty tracking
+//!   (e.g., layout, paint, accessibility).
+//! - **Dependency graphs** ([`DirtyGraph`]): DAG of "A depends on B" edges,
+//!   with cycle detection and bidirectional traversal.
+//! - **Dirty sets** ([`DirtySet`]): Accumulated dirty keys per channel with
+//!   generation tracking for stale-computation detection.
+//! - **Propagation policies** ([`PropagationPolicy`], [`EagerPolicy`], [`LazyPolicy`]):
+//!   Pluggable strategies for how dirty marks spread through the graph.
+//! - **Topological drain** ([`DrainSorted`]): Kahn's algorithm to yield dirty keys
+//!   in dependency order.
+//! - **Scratch buffers** ([`TraversalScratch`]): Reusable traversal state for
+//!   tight loops (many marks per frame) to avoid repeated allocations.
+//!
+//! ## Quick Start
+//!
+//! ```rust
+//! use understory_dirty::{Channel, DirtyTracker, EagerPolicy};
+//!
+//! const LAYOUT: Channel = Channel::new(0);
+//! const PAINT: Channel = Channel::new(1);
+//!
+//! let mut tracker = DirtyTracker::<u32>::new();
+//!
+//! // Build dependency graph: 3 depends on 2, 2 depends on 1
+//! tracker.add_dependency(2, 1, LAYOUT).unwrap();
+//! tracker.add_dependency(3, 2, LAYOUT).unwrap();
+//!
+//! // Mark with eager propagation (marks 1, 2, 3)
+//! tracker.mark_with(1, LAYOUT, &EagerPolicy);
+//!
+//! // Or mark manually without propagation
+//! tracker.mark(1, PAINT);
+//!
+//! // Drain in topological order: 1, 2, 3
+//! for key in tracker.drain_sorted(LAYOUT) {
+//!     // recompute_layout(key);
+//! }
+//! ```
+//!
+//! ## Using Components Separately
+//!
+//! While [`DirtyTracker`] provides a convenient combined API, you can also
+//! use the underlying types directly for more control:
+//!
+//! ```rust
+//! use understory_dirty::{
+//!     Channel, CycleHandling, DirtyGraph, DirtySet, EagerPolicy, PropagationPolicy,
+//! };
+//!
+//! const LAYOUT: Channel = Channel::new(0);
+//!
+//! // Build the dependency graph
+//! let mut graph = DirtyGraph::<u32>::new();
+//! graph.add_dependency(2, 1, LAYOUT, CycleHandling::Error).unwrap();
+//! graph.add_dependency(3, 2, LAYOUT, CycleHandling::Error).unwrap();
+//!
+//! // Maintain dirty state separately
+//! let mut dirty = DirtySet::new();
+//! let eager = EagerPolicy;
+//!
+//! // Propagate dirty marks
+//! eager.propagate(1, LAYOUT, &graph, &mut dirty);
+//!
+//! assert!(dirty.is_dirty(1, LAYOUT));
+//! assert!(dirty.is_dirty(2, LAYOUT));
+//! assert!(dirty.is_dirty(3, LAYOUT));
+//! ```
+//!
+//! ## Propagation Policies
+//!
+//! The crate provides two built-in policies:
+//!
+//! - [`EagerPolicy`]: Immediately marks all transitive dependents when a key
+//!   is marked dirty. Use this when you need to know the full dirty set
+//!   immediately after marking. Use with [`DirtyTracker::drain_sorted`].
+//!
+//! - [`LazyPolicy`]: Only marks the key itself at mark-time; no propagation
+//!   occurs. Use [`DirtyTracker::drain_affected_sorted`] to expand and process
+//!   all affected keys (marked roots + their transitive dependents) at drain
+//!   time. This avoids redundant traversals when many marks happen in succession.
+//!
+//! You can implement [`PropagationPolicy`] for custom strategies (e.g.,
+//! depth-limited propagation, priority-based marking).
+//!
+//! ## Performance Notes
+//!
+//! For eager propagation in hot loops, consider reusing a [`TraversalScratch`]
+//! and calling [`EagerPolicy::propagate_with_scratch`] to avoid per-mark
+//! allocation during graph traversal.
+//!
+//! ## Choosing a Drain Function
+//!
+//! - [`drain_sorted`] / [`DirtyTracker::drain_sorted`]: Drains exactly the keys
+//!   that are currently marked dirty, in topological order. Use with [`EagerPolicy`]
+//!   or when you only want to process explicitly marked keys.
+//!
+//! - [`drain_affected_sorted`] / [`DirtyTracker::drain_affected_sorted`]: Expands
+//!   the dirty set to include all transitive dependents before draining. Use with
+//!   [`LazyPolicy`] to get the "lazy at mark-time, eager at drain-time" workflow.
+//!
+//! ## Cycle Detection
+//!
+//! [`DirtyGraph::add_dependency`] supports configurable cycle handling via
+//! [`CycleHandling`]:
+//!
+//! - `DebugAssert` (default): Panics in debug builds, ignores in release.
+//! - `Error`: Returns `Err(CycleError)` if a cycle would be created.
+//! - `Ignore`: Silently ignores the dependency.
+//! - `Allow`: Skips cycle detection entirely (useful when cycles are intentional).
+//!
+//! ## `no_std` Support
+//!
+//! This crate is `no_std` and uses `alloc`. It does not depend on `std`.
+//!
+//! ## Features
+//!
+//! This crate currently has no optional features. All functionality is always
+//! available.
+
+#![no_std]
+
+extern crate alloc;
+
+mod channel;
+mod drain;
+mod graph;
+mod policy;
+mod scratch;
+mod set;
+mod tracker;
+
+pub use channel::{Channel, ChannelSet, ChannelSetIter};
+pub use drain::{
+    DrainCompletion, DrainSorted, DrainSortedOwned, drain_affected_sorted, drain_sorted,
+};
+pub use graph::{CycleError, CycleHandling, DirtyGraph};
+pub use policy::{EagerPolicy, LazyPolicy, PropagationPolicy};
+pub use scratch::TraversalScratch;
+pub use set::DirtySet;
+pub use tracker::DirtyTracker;

--- a/understory_dirty/src/policy.rs
+++ b/understory_dirty/src/policy.rs
@@ -1,0 +1,320 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Propagation policies for dirty marking.
+
+use core::hash::Hash;
+
+use crate::channel::Channel;
+use crate::graph::DirtyGraph;
+use crate::scratch::TraversalScratch;
+use crate::set::DirtySet;
+
+/// Trait for dirty propagation policies.
+///
+/// A propagation policy determines how dirty marks spread through the
+/// dependency graph. When a key is marked dirty, the policy can choose
+/// to immediately propagate to all dependents (eager), defer propagation
+/// (lazy), or implement custom strategies.
+///
+/// # Example
+///
+/// ```
+/// use understory_dirty::{
+///     Channel, CycleHandling, DirtyGraph, DirtySet, EagerPolicy, PropagationPolicy,
+/// };
+///
+/// const LAYOUT: Channel = Channel::new(0);
+///
+/// let mut graph = DirtyGraph::<u32>::new();
+/// graph.add_dependency(2, 1, LAYOUT, CycleHandling::Error).unwrap();
+/// graph.add_dependency(3, 2, LAYOUT, CycleHandling::Error).unwrap();
+///
+/// let mut dirty = DirtySet::new();
+/// let eager = EagerPolicy;
+///
+/// // Mark node 1 dirty with eager propagation
+/// eager.propagate(1, LAYOUT, &graph, &mut dirty);
+///
+/// // All transitive dependents are now dirty
+/// assert!(dirty.is_dirty(1, LAYOUT));
+/// assert!(dirty.is_dirty(2, LAYOUT));
+/// assert!(dirty.is_dirty(3, LAYOUT));
+/// ```
+pub trait PropagationPolicy<K>
+where
+    K: Copy + Eq + Hash,
+{
+    /// Propagates dirty marks from `key` through the dependency graph.
+    ///
+    /// This method is called after `key` has been marked dirty. The policy
+    /// should mark any additional keys that should become dirty as a result.
+    ///
+    /// # Parameters
+    ///
+    /// - `key`: The key that was just marked dirty.
+    /// - `channel`: The channel in which the key is dirty.
+    /// - `graph`: The dependency graph (read-only).
+    /// - `dirty`: The dirty set to mark additional keys in.
+    fn propagate(&self, key: K, channel: Channel, graph: &DirtyGraph<K>, dirty: &mut DirtySet<K>);
+}
+
+/// Eager propagation policy: immediately mark all transitive dependents.
+///
+/// When a key is marked dirty, `EagerPolicy` performs a DFS traversal of
+/// the dependency graph and marks all transitive dependents as dirty.
+///
+/// This is useful when you want to know the full dirty set immediately
+/// after marking, without waiting for drain time.
+///
+/// # Example
+///
+/// ```
+/// use understory_dirty::{
+///     Channel, CycleHandling, DirtyGraph, DirtySet, EagerPolicy, PropagationPolicy,
+/// };
+///
+/// const LAYOUT: Channel = Channel::new(0);
+///
+/// let mut graph = DirtyGraph::<u32>::new();
+/// // Chain: 1 <- 2 <- 3
+/// graph.add_dependency(2, 1, LAYOUT, CycleHandling::Error).unwrap();
+/// graph.add_dependency(3, 2, LAYOUT, CycleHandling::Error).unwrap();
+///
+/// let mut dirty = DirtySet::new();
+/// let eager = EagerPolicy;
+///
+/// // Mark node 1, propagates to 2 and 3
+/// eager.propagate(1, LAYOUT, &graph, &mut dirty);
+///
+/// assert!(dirty.is_dirty(1, LAYOUT));
+/// assert!(dirty.is_dirty(2, LAYOUT));
+/// assert!(dirty.is_dirty(3, LAYOUT));
+/// ```
+#[derive(Copy, Clone, Debug, Default)]
+pub struct EagerPolicy;
+
+impl<K> PropagationPolicy<K> for EagerPolicy
+where
+    K: Copy + Eq + Hash,
+{
+    fn propagate(&self, key: K, channel: Channel, graph: &DirtyGraph<K>, dirty: &mut DirtySet<K>) {
+        // Mark the key itself
+        dirty.mark(key, channel);
+
+        // DFS to mark all transitive dependents
+        for dependent in graph.transitive_dependents(key, channel) {
+            dirty.mark(dependent, channel);
+        }
+    }
+}
+
+impl EagerPolicy {
+    /// Propagates using reusable scratch buffers.
+    ///
+    /// This is equivalent to calling [`PropagationPolicy::propagate`] for
+    /// [`EagerPolicy`], but avoids per-call allocations by reusing `scratch`.
+    ///
+    /// # See Also
+    ///
+    /// - [`TraversalScratch`]: Reusable traversal storage.
+    /// - [`DirtyGraph::for_each_transitive_dependent`]: Scratch-powered traversal.
+    pub fn propagate_with_scratch<K>(
+        &self,
+        key: K,
+        channel: Channel,
+        graph: &DirtyGraph<K>,
+        dirty: &mut DirtySet<K>,
+        scratch: &mut TraversalScratch<K>,
+    ) where
+        K: Copy + Eq + Hash,
+    {
+        dirty.mark(key, channel);
+        graph.for_each_transitive_dependent(key, channel, scratch, |dependent| {
+            dirty.mark(dependent, channel);
+        });
+    }
+}
+
+/// Lazy propagation policy: only marks the key itself, no propagation.
+///
+/// `LazyPolicy` does not propagate dirty marks at mark time. Only the
+/// explicitly marked key is added to the dirty set. To process all affected
+/// keys (marked roots + their transitive dependents), use
+/// [`drain_affected_sorted`](crate::drain_affected_sorted) or
+/// [`DirtyTracker::drain_affected_sorted`](crate::DirtyTracker::drain_affected_sorted)
+/// at drain time.
+///
+/// This is useful when many marks happen in succession and you want to
+/// avoid redundant traversals. The tradeoff is that [`DirtySet::is_dirty`]
+/// will not reflect transitive dirty state; only the explicitly marked
+/// roots are in the dirty set.
+///
+/// # Important
+///
+/// - Use [`drain_affected_sorted`](crate::drain_affected_sorted) (not `drain_sorted`)
+///   to correctly process all affected keys when using `LazyPolicy`.
+/// - Using `drain_sorted` with `LazyPolicy` will only process the marked roots,
+///   not their dependents.
+///
+/// # Example
+///
+/// ```
+/// use understory_dirty::{
+///     Channel, CycleHandling, DirtyGraph, DirtySet, LazyPolicy, PropagationPolicy,
+///     drain_affected_sorted,
+/// };
+///
+/// const LAYOUT: Channel = Channel::new(0);
+///
+/// let mut graph = DirtyGraph::<u32>::new();
+/// graph.add_dependency(2, 1, LAYOUT, CycleHandling::Error).unwrap();
+/// graph.add_dependency(3, 2, LAYOUT, CycleHandling::Error).unwrap();
+///
+/// let mut dirty = DirtySet::new();
+/// let lazy = LazyPolicy;
+///
+/// // Mark node 1 with lazy policy
+/// lazy.propagate(1, LAYOUT, &graph, &mut dirty);
+///
+/// // Only node 1 is marked (dependents not marked yet)
+/// assert!(dirty.is_dirty(1, LAYOUT));
+/// assert!(!dirty.is_dirty(2, LAYOUT));
+///
+/// // Use drain_affected_sorted to expand and process all affected keys
+/// let affected: Vec<_> = drain_affected_sorted(&mut dirty, &graph, LAYOUT).collect();
+/// assert_eq!(affected, vec![1, 2, 3]); // All affected keys in topological order
+/// ```
+#[derive(Copy, Clone, Debug, Default)]
+pub struct LazyPolicy;
+
+impl<K> PropagationPolicy<K> for LazyPolicy
+where
+    K: Copy + Eq + Hash,
+{
+    fn propagate(&self, key: K, channel: Channel, _graph: &DirtyGraph<K>, dirty: &mut DirtySet<K>) {
+        // Just mark the key, no propagation
+        dirty.mark(key, channel);
+    }
+}
+
+/// Blanket implementation for boxed policies.
+impl<K, P> PropagationPolicy<K> for &P
+where
+    K: Copy + Eq + Hash,
+    P: PropagationPolicy<K> + ?Sized,
+{
+    fn propagate(&self, key: K, channel: Channel, graph: &DirtyGraph<K>, dirty: &mut DirtySet<K>) {
+        (*self).propagate(key, channel, graph, dirty);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    use crate::graph::CycleHandling;
+
+    const LAYOUT: Channel = Channel::new(0);
+
+    fn setup_chain_graph() -> DirtyGraph<u32> {
+        let mut graph = DirtyGraph::new();
+        // Chain: 1 <- 2 <- 3 <- 4
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(3, 2, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(4, 3, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+    }
+
+    #[test]
+    fn eager_policy_marks_all_dependents() {
+        let graph = setup_chain_graph();
+        let mut dirty = DirtySet::new();
+        let eager = EagerPolicy;
+
+        eager.propagate(1, LAYOUT, &graph, &mut dirty);
+
+        assert!(dirty.is_dirty(1, LAYOUT));
+        assert!(dirty.is_dirty(2, LAYOUT));
+        assert!(dirty.is_dirty(3, LAYOUT));
+        assert!(dirty.is_dirty(4, LAYOUT));
+    }
+
+    #[test]
+    fn eager_policy_from_middle() {
+        let graph = setup_chain_graph();
+        let mut dirty = DirtySet::new();
+        let eager = EagerPolicy;
+
+        eager.propagate(2, LAYOUT, &graph, &mut dirty);
+
+        // Node 1 is NOT dirty (not a dependent)
+        assert!(!dirty.is_dirty(1, LAYOUT));
+        // Nodes 2, 3, 4 are dirty
+        assert!(dirty.is_dirty(2, LAYOUT));
+        assert!(dirty.is_dirty(3, LAYOUT));
+        assert!(dirty.is_dirty(4, LAYOUT));
+    }
+
+    #[test]
+    fn lazy_policy_only_marks_key() {
+        let graph = setup_chain_graph();
+        let mut dirty = DirtySet::new();
+        let lazy = LazyPolicy;
+
+        lazy.propagate(1, LAYOUT, &graph, &mut dirty);
+
+        assert!(dirty.is_dirty(1, LAYOUT));
+        assert!(!dirty.is_dirty(2, LAYOUT));
+        assert!(!dirty.is_dirty(3, LAYOUT));
+        assert!(!dirty.is_dirty(4, LAYOUT));
+    }
+
+    #[test]
+    fn policy_through_reference() {
+        let graph = setup_chain_graph();
+        let mut dirty = DirtySet::new();
+        let eager = EagerPolicy;
+        let policy: &dyn PropagationPolicy<u32> = &eager;
+
+        policy.propagate(1, LAYOUT, &graph, &mut dirty);
+
+        let dirty_keys: Vec<_> = dirty.iter(LAYOUT).collect();
+        assert_eq!(dirty_keys.len(), 4);
+    }
+
+    #[test]
+    fn eager_handles_diamond() {
+        let mut graph = DirtyGraph::new();
+        // Diamond: 1 <- 2, 1 <- 3, 2 <- 4, 3 <- 4
+        graph
+            .add_dependency(2, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(3, 1, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(4, 2, LAYOUT, CycleHandling::Error)
+            .unwrap();
+        graph
+            .add_dependency(4, 3, LAYOUT, CycleHandling::Error)
+            .unwrap();
+
+        let mut dirty = DirtySet::new();
+        EagerPolicy.propagate(1, LAYOUT, &graph, &mut dirty);
+
+        assert!(dirty.is_dirty(1, LAYOUT));
+        assert!(dirty.is_dirty(2, LAYOUT));
+        assert!(dirty.is_dirty(3, LAYOUT));
+        assert!(dirty.is_dirty(4, LAYOUT));
+        // Node 4 should only appear once in the dirty set
+        assert_eq!(dirty.len(LAYOUT), 4);
+    }
+}

--- a/understory_dirty/src/scratch.rs
+++ b/understory_dirty/src/scratch.rs
@@ -1,0 +1,65 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Reusable scratch buffers for graph traversals.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::hash::Hash;
+
+use hashbrown::HashSet;
+
+/// Reusable scratch storage for graph traversals.
+///
+/// This is useful in tight loops (many marks per frame) to avoid allocating
+/// temporary `Vec`/`HashSet` state on every traversal.
+///
+/// The scratch buffers retain capacity across calls. Callers should reuse a
+/// single scratch instance per thread / update pass.
+///
+/// # See Also
+///
+/// - [`DirtyGraph::for_each_transitive_dependent`](crate::DirtyGraph::for_each_transitive_dependent):
+///   Scratch-powered traversal.
+/// - [`EagerPolicy::propagate_with_scratch`](crate::EagerPolicy::propagate_with_scratch):
+///   Scratch-powered eager propagation.
+#[derive(Debug, Default)]
+pub struct TraversalScratch<K>
+where
+    K: Copy + Eq + Hash,
+{
+    pub(crate) stack: Vec<K>,
+    pub(crate) visited: HashSet<K>,
+}
+
+impl<K> TraversalScratch<K>
+where
+    K: Copy + Eq + Hash,
+{
+    /// Creates an empty scratch buffer.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            stack: Vec::new(),
+            visited: HashSet::new(),
+        }
+    }
+
+    /// Creates an empty scratch buffer with pre-allocated capacity.
+    ///
+    /// `capacity` is a best-effort hint for both the internal stack and the
+    /// visited set.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            stack: Vec::with_capacity(capacity),
+            visited: HashSet::with_capacity(capacity),
+        }
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.stack.clear();
+        self.visited.clear();
+    }
+}

--- a/understory_dirty/src/set.rs
+++ b/understory_dirty/src/set.rs
@@ -1,0 +1,310 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Dirty set: accumulated dirty keys per channel.
+
+use core::hash::Hash;
+
+use hashbrown::HashSet;
+
+use crate::channel::Channel;
+
+/// Maximum number of channels supported (64).
+const MAX_CHANNELS: usize = 64;
+
+/// Accumulated dirty keys per channel with generation tracking.
+///
+/// `DirtySet` maintains a set of dirty keys for each channel, along with a
+/// generation counter that increments on every mutation. The generation can
+/// be used to detect stale computations or cache invalidation.
+///
+/// # Type Parameters
+///
+/// - `K`: The key type, typically a node identifier. Must be `Copy + Eq + Hash`.
+///
+/// # Example
+///
+/// ```
+/// use understory_dirty::{Channel, DirtySet};
+///
+/// const LAYOUT: Channel = Channel::new(0);
+/// const PAINT: Channel = Channel::new(1);
+///
+/// let mut dirty = DirtySet::<u32>::new();
+///
+/// // Mark nodes dirty
+/// dirty.mark(1, LAYOUT);
+/// dirty.mark(2, LAYOUT);
+/// dirty.mark(1, PAINT);
+///
+/// assert!(dirty.is_dirty(1, LAYOUT));
+/// assert!(dirty.is_dirty(2, LAYOUT));
+/// assert!(dirty.is_dirty(1, PAINT));
+/// assert!(!dirty.is_dirty(2, PAINT));
+///
+/// // Drain returns and clears dirty keys for a channel
+/// let layout_dirty: Vec<_> = dirty.drain(LAYOUT).collect();
+/// assert_eq!(layout_dirty.len(), 2);
+/// assert!(!dirty.is_dirty(1, LAYOUT));
+/// ```
+///
+/// # See Also
+///
+/// - [`DirtyTracker`](crate::DirtyTracker): Convenience wrapper combining a [`DirtyGraph`](crate::DirtyGraph)
+///   and `DirtySet`.
+/// - [`drain_sorted`](crate::drain_sorted): Drain a [`DirtySet`] in topological order given a graph.
+/// - [`drain_affected_sorted`](crate::drain_affected_sorted): Drain affected keys (roots + dependents), useful with [`LazyPolicy`](crate::LazyPolicy).
+#[derive(Debug)]
+pub struct DirtySet<K>
+where
+    K: Copy + Eq + Hash,
+{
+    /// Per-channel dirty key sets.
+    channels: [HashSet<K>; MAX_CHANNELS],
+    /// Generation counter, incremented on each mutation.
+    generation: u64,
+}
+
+impl<K> Default for DirtySet<K>
+where
+    K: Copy + Eq + Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K> DirtySet<K>
+where
+    K: Copy + Eq + Hash,
+{
+    /// Creates a new empty dirty set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            channels: core::array::from_fn(|_| HashSet::new()),
+            generation: 0,
+        }
+    }
+
+    /// Returns the current generation.
+    ///
+    /// The generation is incremented on every mutation (mark, clear, drain).
+    /// This can be used to detect whether the dirty set has changed since a
+    /// previous observation.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Marks a key as dirty in the given channel.
+    ///
+    /// Returns `true` if the key was newly inserted, `false` if it was already dirty.
+    pub fn mark(&mut self, key: K, channel: Channel) -> bool {
+        self.generation = self.generation.wrapping_add(1);
+        self.channels[channel.index() as usize].insert(key)
+    }
+
+    /// Returns `true` if the key is dirty in the given channel.
+    #[must_use]
+    pub fn is_dirty(&self, key: K, channel: Channel) -> bool {
+        self.channels[channel.index() as usize].contains(&key)
+    }
+
+    /// Returns `true` if there are any dirty keys in the given channel.
+    #[must_use]
+    pub fn has_dirty(&self, channel: Channel) -> bool {
+        !self.channels[channel.index() as usize].is_empty()
+    }
+
+    /// Returns `true` if there are no dirty keys in any channel.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.channels.iter().all(HashSet::is_empty)
+    }
+
+    /// Returns the number of dirty keys in the given channel.
+    #[must_use]
+    pub fn len(&self, channel: Channel) -> usize {
+        self.channels[channel.index() as usize].len()
+    }
+
+    /// Returns an iterator over the dirty keys in the given channel.
+    ///
+    /// This does not clear the dirty state. Use [`drain`](Self::drain) to
+    /// consume and clear.
+    pub fn iter(&self, channel: Channel) -> impl Iterator<Item = K> + '_ {
+        self.channels[channel.index() as usize].iter().copied()
+    }
+
+    /// Drains and returns the dirty keys for the given channel.
+    ///
+    /// After this call, the channel will have no dirty keys.
+    pub fn drain(&mut self, channel: Channel) -> impl Iterator<Item = K> + '_ {
+        self.generation = self.generation.wrapping_add(1);
+        self.channels[channel.index() as usize].drain()
+    }
+
+    /// Clears all dirty keys in the given channel.
+    pub fn clear(&mut self, channel: Channel) {
+        self.generation = self.generation.wrapping_add(1);
+        self.channels[channel.index() as usize].clear();
+    }
+
+    /// Clears all dirty keys in all channels.
+    pub fn clear_all(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        for set in &mut self.channels {
+            set.clear();
+        }
+    }
+
+    /// Removes a specific key from all channels.
+    ///
+    /// This is useful when a node is removed from the tree entirely.
+    pub fn remove_key(&mut self, key: K) {
+        let mut removed = false;
+        for set in &mut self.channels {
+            removed |= set.remove(&key);
+        }
+        if removed {
+            self.generation = self.generation.wrapping_add(1);
+        }
+    }
+}
+
+impl<K> Clone for DirtySet<K>
+where
+    K: Copy + Eq + Hash,
+{
+    fn clone(&self) -> Self {
+        Self {
+            channels: core::array::from_fn(|i| self.channels[i].clone()),
+            generation: self.generation,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    const LAYOUT: Channel = Channel::new(0);
+    const PAINT: Channel = Channel::new(1);
+
+    #[test]
+    fn mark_and_query() {
+        let mut dirty = DirtySet::<u32>::new();
+
+        assert!(!dirty.is_dirty(1, LAYOUT));
+        assert!(dirty.is_empty());
+
+        let inserted = dirty.mark(1, LAYOUT);
+        assert!(inserted);
+        assert!(dirty.is_dirty(1, LAYOUT));
+        assert!(!dirty.is_empty());
+        assert!(dirty.has_dirty(LAYOUT));
+
+        // Marking again returns false
+        let inserted_again = dirty.mark(1, LAYOUT);
+        assert!(!inserted_again);
+    }
+
+    #[test]
+    fn channel_independence() {
+        let mut dirty = DirtySet::<u32>::new();
+
+        dirty.mark(1, LAYOUT);
+        dirty.mark(2, PAINT);
+
+        assert!(dirty.is_dirty(1, LAYOUT));
+        assert!(!dirty.is_dirty(1, PAINT));
+        assert!(!dirty.is_dirty(2, LAYOUT));
+        assert!(dirty.is_dirty(2, PAINT));
+    }
+
+    #[test]
+    fn drain_clears_channel() {
+        let mut dirty = DirtySet::<u32>::new();
+
+        dirty.mark(1, LAYOUT);
+        dirty.mark(2, LAYOUT);
+        dirty.mark(1, PAINT);
+
+        let drained: Vec<_> = dirty.drain(LAYOUT).collect();
+        assert_eq!(drained.len(), 2);
+        assert!(!dirty.has_dirty(LAYOUT));
+        assert!(dirty.has_dirty(PAINT));
+    }
+
+    #[test]
+    fn clear_specific_channel() {
+        let mut dirty = DirtySet::<u32>::new();
+
+        dirty.mark(1, LAYOUT);
+        dirty.mark(1, PAINT);
+
+        dirty.clear(LAYOUT);
+        assert!(!dirty.has_dirty(LAYOUT));
+        assert!(dirty.has_dirty(PAINT));
+    }
+
+    #[test]
+    fn clear_all() {
+        let mut dirty = DirtySet::<u32>::new();
+
+        dirty.mark(1, LAYOUT);
+        dirty.mark(2, PAINT);
+
+        dirty.clear_all();
+        assert!(dirty.is_empty());
+    }
+
+    #[test]
+    fn remove_key_from_all_channels() {
+        let mut dirty = DirtySet::<u32>::new();
+
+        dirty.mark(1, LAYOUT);
+        dirty.mark(1, PAINT);
+        dirty.mark(2, LAYOUT);
+
+        dirty.remove_key(1);
+        assert!(!dirty.is_dirty(1, LAYOUT));
+        assert!(!dirty.is_dirty(1, PAINT));
+        assert!(dirty.is_dirty(2, LAYOUT));
+    }
+
+    #[test]
+    fn generation_increments() {
+        let mut dirty = DirtySet::<u32>::new();
+        let initial = dirty.generation();
+
+        dirty.mark(1, LAYOUT);
+        assert_eq!(dirty.generation(), initial + 1);
+
+        dirty.mark(2, LAYOUT);
+        assert_eq!(dirty.generation(), initial + 2);
+
+        let _ = dirty.drain(LAYOUT).count();
+        assert_eq!(dirty.generation(), initial + 3);
+
+        dirty.clear(PAINT);
+        assert_eq!(dirty.generation(), initial + 4);
+    }
+
+    #[test]
+    fn len_and_iter() {
+        let mut dirty = DirtySet::<u32>::new();
+
+        dirty.mark(1, LAYOUT);
+        dirty.mark(2, LAYOUT);
+        dirty.mark(3, LAYOUT);
+
+        assert_eq!(dirty.len(LAYOUT), 3);
+        assert_eq!(dirty.len(PAINT), 0);
+
+        let keys: Vec<_> = dirty.iter(LAYOUT).collect();
+        assert_eq!(keys.len(), 3);
+    }
+}

--- a/understory_dirty/src/tracker.rs
+++ b/understory_dirty/src/tracker.rs
@@ -1,0 +1,497 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Combined dirty tracker: graph + set convenience type.
+
+use alloc::vec::Vec;
+use core::hash::Hash;
+
+use crate::channel::Channel;
+use crate::drain::{DrainSorted, DrainSortedOwned};
+use crate::graph::{CycleError, CycleHandling, DirtyGraph};
+use crate::policy::PropagationPolicy;
+use crate::set::DirtySet;
+
+/// Combined dirty tracker with dependency graph and dirty set.
+///
+/// `DirtyTracker` is a convenience type that bundles a [`DirtyGraph`] and
+/// [`DirtySet`] together, providing a unified API for common dirty-tracking
+/// operations.
+///
+/// # Type Parameters
+///
+/// - `K`: The key type, typically a node identifier. Must be `Copy + Eq + Hash`.
+///
+/// # Example
+///
+/// ```
+/// use understory_dirty::{Channel, CycleHandling, DirtyTracker, EagerPolicy};
+///
+/// const LAYOUT: Channel = Channel::new(0);
+/// const PAINT: Channel = Channel::new(1);
+///
+/// let mut tracker = DirtyTracker::<u32>::new();
+///
+/// // Build dependency graph: 3 depends on 2, 2 depends on 1
+/// tracker.add_dependency(2, 1, LAYOUT).unwrap();
+/// tracker.add_dependency(3, 2, LAYOUT).unwrap();
+///
+/// // Mark with eager propagation (marks 1, 2, 3)
+/// tracker.mark_with(1, LAYOUT, &EagerPolicy);
+///
+/// // Or mark manually without propagation
+/// tracker.mark(1, PAINT);
+///
+/// // Drain in topological order: 1, 2, 3
+/// let order: Vec<_> = tracker.drain_sorted(LAYOUT).collect();
+/// assert_eq!(order, vec![1, 2, 3]);
+/// ```
+///
+/// # See Also
+///
+/// - [`DirtyGraph`] and [`DirtySet`]: The underlying components.
+/// - [`EagerPolicy`](crate::EagerPolicy) and [`LazyPolicy`](crate::LazyPolicy): Built-in propagation strategies.
+/// - [`drain_sorted`](crate::drain_sorted) and [`drain_affected_sorted`](crate::drain_affected_sorted): Free-function drain helpers.
+#[derive(Debug, Clone)]
+pub struct DirtyTracker<K>
+where
+    K: Copy + Eq + Hash,
+{
+    /// The dependency graph.
+    graph: DirtyGraph<K>,
+    /// The dirty set.
+    dirty: DirtySet<K>,
+    /// How to handle cycles when adding dependencies.
+    cycle_handling: CycleHandling,
+}
+
+impl<K> Default for DirtyTracker<K>
+where
+    K: Copy + Eq + Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K> DirtyTracker<K>
+where
+    K: Copy + Eq + Hash,
+{
+    /// Creates a new empty dirty tracker with default cycle handling.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_cycle_handling(CycleHandling::default())
+    }
+
+    /// Creates a new empty dirty tracker with the specified cycle handling.
+    #[must_use]
+    pub fn with_cycle_handling(cycle_handling: CycleHandling) -> Self {
+        Self {
+            graph: DirtyGraph::new(),
+            dirty: DirtySet::new(),
+            cycle_handling,
+        }
+    }
+
+    /// Returns a reference to the underlying dependency graph.
+    #[must_use]
+    pub fn graph(&self) -> &DirtyGraph<K> {
+        &self.graph
+    }
+
+    /// Returns a mutable reference to the underlying dependency graph.
+    #[must_use]
+    pub fn graph_mut(&mut self) -> &mut DirtyGraph<K> {
+        &mut self.graph
+    }
+
+    /// Returns a reference to the underlying dirty set.
+    #[must_use]
+    pub fn dirty(&self) -> &DirtySet<K> {
+        &self.dirty
+    }
+
+    /// Returns a mutable reference to the underlying dirty set.
+    #[must_use]
+    pub fn dirty_mut(&mut self) -> &mut DirtySet<K> {
+        &mut self.dirty
+    }
+
+    /// Returns the current generation of the dirty set.
+    ///
+    /// See [`DirtySet::generation`] for details.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.dirty.generation()
+    }
+
+    /// Returns the current cycle handling mode.
+    #[must_use]
+    pub fn cycle_handling(&self) -> CycleHandling {
+        self.cycle_handling
+    }
+
+    /// Sets the cycle handling mode for future operations.
+    pub fn set_cycle_handling(&mut self, handling: CycleHandling) {
+        self.cycle_handling = handling;
+    }
+
+    // -------------------------------------------------------------------------
+    // Graph operations
+    // -------------------------------------------------------------------------
+
+    /// Adds a dependency: `from` depends on `to` in the given channel.
+    ///
+    /// Uses the tracker's configured cycle handling mode.
+    ///
+    /// See [`DirtyGraph::add_dependency`] for details.
+    pub fn add_dependency(
+        &mut self,
+        from: K,
+        to: K,
+        channel: Channel,
+    ) -> Result<bool, CycleError<K>> {
+        self.graph
+            .add_dependency(from, to, channel, self.cycle_handling)
+    }
+
+    /// Adds a dependency with explicit cycle handling.
+    ///
+    /// See [`DirtyGraph::add_dependency`] for details.
+    pub fn add_dependency_with(
+        &mut self,
+        from: K,
+        to: K,
+        channel: Channel,
+        handling: CycleHandling,
+    ) -> Result<bool, CycleError<K>> {
+        self.graph.add_dependency(from, to, channel, handling)
+    }
+
+    /// Removes a dependency: `from` no longer depends on `to`.
+    ///
+    /// See [`DirtyGraph::remove_dependency`] for details.
+    pub fn remove_dependency(&mut self, from: K, to: K, channel: Channel) -> bool {
+        self.graph.remove_dependency(from, to, channel)
+    }
+
+    /// Removes a key from both the graph and the dirty set.
+    ///
+    /// This is useful when a node is removed from the tree entirely.
+    pub fn remove_key(&mut self, key: K) {
+        self.graph.remove_key(key);
+        self.dirty.remove_key(key);
+    }
+
+    // -------------------------------------------------------------------------
+    // Dirty marking
+    // -------------------------------------------------------------------------
+
+    /// Marks a key as dirty without propagation.
+    ///
+    /// Returns `true` if the key was newly marked dirty.
+    pub fn mark(&mut self, key: K, channel: Channel) -> bool {
+        self.dirty.mark(key, channel)
+    }
+
+    /// Marks a key as dirty using the given propagation policy.
+    ///
+    /// The policy determines how dirty marks spread through the dependency
+    /// graph. See [`PropagationPolicy`] for details.
+    pub fn mark_with<P>(&mut self, key: K, channel: Channel, policy: &P)
+    where
+        P: PropagationPolicy<K>,
+    {
+        policy.propagate(key, channel, &self.graph, &mut self.dirty);
+    }
+
+    /// Returns `true` if the key is dirty in the given channel.
+    #[must_use]
+    pub fn is_dirty(&self, key: K, channel: Channel) -> bool {
+        self.dirty.is_dirty(key, channel)
+    }
+
+    /// Returns `true` if there are any dirty keys in the given channel.
+    #[must_use]
+    pub fn has_dirty(&self, channel: Channel) -> bool {
+        self.dirty.has_dirty(channel)
+    }
+
+    /// Returns `true` if there are no dirty keys in any channel.
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        self.dirty.is_empty()
+    }
+
+    // -------------------------------------------------------------------------
+    // Draining
+    // -------------------------------------------------------------------------
+
+    /// Drains dirty keys in topological order using Kahn's algorithm.
+    ///
+    /// Keys are yielded in dependency order: a key is only yielded after
+    /// all of its dirty dependencies have been yielded. This ensures that
+    /// when processing the dirty set, a node is only processed after all
+    /// of its dependencies have been processed.
+    ///
+    /// The channel is cleared after the iterator is exhausted.
+    ///
+    /// Note: if the dependency subgraph induced by the dirty keys contains a
+    /// cycle, the drain will stall and some keys will not be yielded. You can
+    /// detect this by exhausting the iterator and checking
+    /// [`DrainSortedOwned::completion`], or by using
+    /// [`DrainSortedOwned::collect_with_completion`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use understory_dirty::{Channel, DirtyTracker, EagerPolicy};
+    ///
+    /// const LAYOUT: Channel = Channel::new(0);
+    ///
+    /// let mut tracker = DirtyTracker::<u32>::new();
+    /// tracker.add_dependency(2, 1, LAYOUT).unwrap();
+    /// tracker.add_dependency(3, 2, LAYOUT).unwrap();
+    ///
+    /// tracker.mark_with(1, LAYOUT, &EagerPolicy);
+    ///
+    /// // Process in order: 1, 2, 3
+    /// for key in tracker.drain_sorted(LAYOUT) {
+    ///     // recompute_layout(key);
+    /// }
+    /// ```
+    pub fn drain_sorted(&mut self, channel: Channel) -> DrainSortedOwned<'_, K> {
+        crate::drain::drain_sorted(&mut self.dirty, &self.graph, channel)
+    }
+
+    /// Drains all affected keys in topological order.
+    ///
+    /// Unlike [`drain_sorted`](Self::drain_sorted), this method first expands
+    /// the dirty set to include all transitive dependents of the marked keys.
+    /// This is the correct drain method to use with [`LazyPolicy`](crate::LazyPolicy).
+    ///
+    /// Note: the yielded order is only deterministic up to dependency ordering.
+    /// When multiple keys are simultaneously ready, the relative order among
+    /// them is not specified and may vary across runs or platforms.
+    ///
+    /// # Algorithm
+    ///
+    /// 1. Collect all keys currently marked dirty (the "roots").
+    /// 2. Compute all transitive dependents of each root.
+    /// 3. Return a topologically sorted drain over: roots ∪ dependents.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use understory_dirty::{Channel, DirtyTracker, LazyPolicy};
+    ///
+    /// const LAYOUT: Channel = Channel::new(0);
+    ///
+    /// let mut tracker = DirtyTracker::<u32>::new();
+    /// tracker.add_dependency(2, 1, LAYOUT).unwrap();
+    /// tracker.add_dependency(3, 2, LAYOUT).unwrap();
+    ///
+    /// // Mark only the root with lazy policy
+    /// tracker.mark_with(1, LAYOUT, &LazyPolicy);
+    ///
+    /// // drain_affected_sorted expands to all affected keys: 1, 2, 3
+    /// let order: Vec<_> = tracker.drain_affected_sorted(LAYOUT).collect();
+    /// assert_eq!(order, vec![1, 2, 3]);
+    /// ```
+    pub fn drain_affected_sorted(&mut self, channel: Channel) -> DrainSortedOwned<'_, K> {
+        crate::drain::drain_affected_sorted(&mut self.dirty, &self.graph, channel)
+    }
+
+    /// Collects dirty keys and returns a [`DrainSorted`] iterator.
+    ///
+    /// Unlike [`drain_sorted`](Self::drain_sorted), this method does not
+    /// clear the dirty set. It's useful when you need to iterate multiple
+    /// times or want to keep the dirty state.
+    #[must_use]
+    pub fn peek_sorted(&self, channel: Channel) -> DrainSorted<'_, K> {
+        let dirty_keys: Vec<K> = self.dirty.iter(channel).collect();
+        DrainSorted::new(&dirty_keys, &self.graph, channel)
+    }
+
+    /// Clears all dirty keys in the given channel.
+    pub fn clear(&mut self, channel: Channel) {
+        self.dirty.clear(channel);
+    }
+
+    /// Clears all dirty keys in all channels.
+    pub fn clear_all(&mut self) {
+        self.dirty.clear_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use crate::policy::{EagerPolicy, LazyPolicy};
+
+    const LAYOUT: Channel = Channel::new(0);
+    const PAINT: Channel = Channel::new(1);
+
+    #[test]
+    fn basic_workflow() {
+        let mut tracker = DirtyTracker::<u32>::new();
+
+        // Build graph
+        tracker.add_dependency(2, 1, LAYOUT).unwrap();
+        tracker.add_dependency(3, 2, LAYOUT).unwrap();
+
+        // Mark with eager policy
+        tracker.mark_with(1, LAYOUT, &EagerPolicy);
+
+        assert!(tracker.is_dirty(1, LAYOUT));
+        assert!(tracker.is_dirty(2, LAYOUT));
+        assert!(tracker.is_dirty(3, LAYOUT));
+
+        // Drain in topological order
+        let order: Vec<_> = tracker.drain_sorted(LAYOUT).collect();
+        assert_eq!(order, vec![1, 2, 3]);
+
+        // Channel is now clean
+        assert!(!tracker.has_dirty(LAYOUT));
+    }
+
+    #[test]
+    fn manual_mark_no_propagation() {
+        let mut tracker = DirtyTracker::<u32>::new();
+
+        tracker.add_dependency(2, 1, LAYOUT).unwrap();
+
+        // Manual mark - no propagation
+        tracker.mark(1, LAYOUT);
+
+        assert!(tracker.is_dirty(1, LAYOUT));
+        assert!(!tracker.is_dirty(2, LAYOUT));
+    }
+
+    #[test]
+    fn lazy_policy() {
+        let mut tracker = DirtyTracker::<u32>::new();
+
+        tracker.add_dependency(2, 1, LAYOUT).unwrap();
+        tracker.add_dependency(3, 2, LAYOUT).unwrap();
+
+        // Lazy mark - only marks the key itself
+        tracker.mark_with(1, LAYOUT, &LazyPolicy);
+
+        assert!(tracker.is_dirty(1, LAYOUT));
+        assert!(!tracker.is_dirty(2, LAYOUT));
+        assert!(!tracker.is_dirty(3, LAYOUT));
+    }
+
+    #[test]
+    fn remove_key() {
+        let mut tracker = DirtyTracker::<u32>::new();
+
+        tracker.add_dependency(2, 1, LAYOUT).unwrap();
+        tracker.mark(1, LAYOUT);
+        tracker.mark(2, LAYOUT);
+
+        tracker.remove_key(2);
+
+        // Node 2 is gone from both graph and dirty set
+        assert!(!tracker.graph().dependents(1, LAYOUT).any(|_| true));
+        assert!(!tracker.is_dirty(2, LAYOUT));
+        assert!(tracker.is_dirty(1, LAYOUT));
+    }
+
+    #[test]
+    fn peek_sorted_preserves_state() {
+        let mut tracker = DirtyTracker::<u32>::new();
+
+        tracker.add_dependency(2, 1, LAYOUT).unwrap();
+        tracker.mark(1, LAYOUT);
+        tracker.mark(2, LAYOUT);
+
+        // Peek does not clear
+        let order: Vec<_> = tracker.peek_sorted(LAYOUT).collect();
+        assert_eq!(order, vec![1, 2]);
+
+        // Still dirty
+        assert!(tracker.is_dirty(1, LAYOUT));
+        assert!(tracker.is_dirty(2, LAYOUT));
+    }
+
+    #[test]
+    fn generation_tracking() {
+        let mut tracker = DirtyTracker::<u32>::new();
+        let initial = tracker.generation();
+
+        tracker.mark(1, LAYOUT);
+        assert_eq!(tracker.generation(), initial + 1);
+
+        tracker.mark(2, LAYOUT);
+        assert_eq!(tracker.generation(), initial + 2);
+    }
+
+    #[test]
+    fn cycle_handling_modes() {
+        let mut tracker = DirtyTracker::with_cycle_handling(CycleHandling::Error);
+
+        tracker.add_dependency(2, 1, LAYOUT).unwrap();
+
+        // Self-cycle should error
+        let result = tracker.add_dependency(1, 1, LAYOUT);
+        assert!(result.is_err());
+
+        // Change to ignore mode
+        tracker.set_cycle_handling(CycleHandling::Ignore);
+        let result = tracker.add_dependency(1, 1, LAYOUT);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn multiple_channels() {
+        let mut tracker = DirtyTracker::<u32>::new();
+
+        tracker.add_dependency(2, 1, LAYOUT).unwrap();
+        tracker.add_dependency(2, 1, PAINT).unwrap();
+
+        tracker.mark_with(1, LAYOUT, &EagerPolicy);
+
+        // Only LAYOUT is dirty
+        assert!(tracker.is_dirty(1, LAYOUT));
+        assert!(tracker.is_dirty(2, LAYOUT));
+        assert!(!tracker.is_dirty(1, PAINT));
+        assert!(!tracker.is_dirty(2, PAINT));
+
+        tracker.mark_with(1, PAINT, &EagerPolicy);
+
+        // Now both are dirty
+        assert!(tracker.is_dirty(1, PAINT));
+        assert!(tracker.is_dirty(2, PAINT));
+    }
+
+    #[test]
+    fn clear_specific_channel() {
+        let mut tracker = DirtyTracker::<u32>::new();
+
+        tracker.mark(1, LAYOUT);
+        tracker.mark(1, PAINT);
+
+        tracker.clear(LAYOUT);
+
+        assert!(!tracker.has_dirty(LAYOUT));
+        assert!(tracker.has_dirty(PAINT));
+    }
+
+    #[test]
+    fn clear_all() {
+        let mut tracker = DirtyTracker::<u32>::new();
+
+        tracker.mark(1, LAYOUT);
+        tracker.mark(1, PAINT);
+
+        tracker.clear_all();
+
+        assert!(tracker.is_clean());
+    }
+}


### PR DESCRIPTION
… set + topo drain)

Introduce a new core crate, `understory_dirty`, providing dependency-based dirty tracking for incremental recomputation.

* Adds `no_std` + `alloc` primitives:
  * `Channeli` and `ChannelSet` for per-domain invalidation
  * `DirtyGraph<K>` for per-channel dependency edges with configurable cycle handling
  * `DirtySet<K>` for per-channel dirty membership with generation tracking
  * `DrainSorted`/`DrainSortedOwned` (Kahn drain) for processing dirty keys in dependency order
  * `PropagationPolicy` with built-in `EagerPolicy` and `LazyPolicy`
  * `drain_sorted` and `drain_affected_sorted` helpers
* Documents key contracts:
  * drains are topological but not deterministic in tie cases
  * cycles can stall drains; `DrainCompletion` allows detecting stalled drains

Motivation: centralize a small, reusable invalidation scheduler for future incremental systems (e.g. tree commits, dataflow transforms) without pulling in widget- or domain-specific semantics.