### PR TITLE
understory_dirty: unify topological drain iterator

### DIFF
--- a/understory_dirty/src/graph.rs
+++ b/understory_dirty/src/graph.rs
@@ -105,7 +105,7 @@ pub enum CycleHandling {
 ///
 /// - [`DirtyTracker`](crate::DirtyTracker): Convenience wrapper combining graph + set.
 /// - [`CycleHandling`]: Cycle policy used by [`add_dependency`](Self::add_dependency).
-/// - [`DrainSorted`](crate::DrainSorted) / [`DrainSortedOwned`](crate::DrainSortedOwned): Drains dirty keys in dependency order.
+/// - [`DrainSorted`](crate::DrainSorted): Drains dirty keys in dependency order.
 #[derive(Debug, Clone)]
 pub struct DirtyGraph<K>
 where

--- a/understory_dirty/src/lib.rs
+++ b/understory_dirty/src/lib.rs
@@ -139,9 +139,7 @@ mod set;
 mod tracker;
 
 pub use channel::{Channel, ChannelSet, ChannelSetIter};
-pub use drain::{
-    DrainCompletion, DrainSorted, DrainSortedOwned, drain_affected_sorted, drain_sorted,
-};
+pub use drain::{DrainCompletion, DrainSorted, drain_affected_sorted, drain_sorted};
 pub use graph::{CycleError, CycleHandling, DirtyGraph};
 pub use policy::{EagerPolicy, LazyPolicy, PropagationPolicy};
 pub use scratch::TraversalScratch;


### PR DESCRIPTION
* Remove `DrainSortedOwned`; drain APIs now return `DrainSorted`
* Hide `DrainSorted` constructors; construct via drain/peek APIs
* Use capacity-aware internal constructors for predictable allocations