### PR TITLE
understory_dirty: inline thin wrappers

### DIFF
--- a/understory_dirty/src/channel.rs
+++ b/understory_dirty/src/channel.rs
@@ -131,11 +131,13 @@ impl ChannelSet {
     }
 
     /// Inserts a channel into the set.
+    #[inline]
     pub fn insert(&mut self, channel: Channel) {
         self.0 |= 1_u64 << channel.0;
     }
 
     /// Removes a channel from the set.
+    #[inline]
     pub fn remove(&mut self, channel: Channel) {
         self.0 &= !(1_u64 << channel.0);
     }

--- a/understory_dirty/src/graph.rs
+++ b/understory_dirty/src/graph.rs
@@ -424,6 +424,7 @@ where
     /// `key` should be recomputed).
     ///
     /// The iteration order is not specified and may vary across runs or platforms.
+    #[inline]
     pub fn dependencies(&self, key: K, channel: Channel) -> impl Iterator<Item = K> + '_ {
         self.forward
             .get(&(key, channel))
@@ -437,6 +438,7 @@ where
     /// they should be recomputed).
     ///
     /// The iteration order is not specified and may vary across runs or platforms.
+    #[inline]
     pub fn dependents(&self, key: K, channel: Channel) -> impl Iterator<Item = K> + '_ {
         self.reverse
             .get(&(key, channel))
@@ -502,6 +504,7 @@ where
     }
 
     /// Returns `true` if `key` has any dependencies in the given channel.
+    #[inline]
     #[must_use]
     pub fn has_dependencies(&self, key: K, channel: Channel) -> bool {
         self.forward

--- a/understory_dirty/src/set.rs
+++ b/understory_dirty/src/set.rs
@@ -93,6 +93,7 @@ where
     /// The generation is incremented on every mutation (mark, clear, drain).
     /// This can be used to detect whether the dirty set has changed since a
     /// previous observation.
+    #[inline]
     #[must_use]
     pub fn generation(&self) -> u64 {
         self.generation
@@ -101,18 +102,21 @@ where
     /// Marks a key as dirty in the given channel.
     ///
     /// Returns `true` if the key was newly inserted, `false` if it was already dirty.
+    #[inline]
     pub fn mark(&mut self, key: K, channel: Channel) -> bool {
         self.generation = self.generation.wrapping_add(1);
         self.channels[channel.index() as usize].insert(key)
     }
 
     /// Returns `true` if the key is dirty in the given channel.
+    #[inline]
     #[must_use]
     pub fn is_dirty(&self, key: K, channel: Channel) -> bool {
         self.channels[channel.index() as usize].contains(&key)
     }
 
     /// Returns `true` if there are any dirty keys in the given channel.
+    #[inline]
     #[must_use]
     pub fn has_dirty(&self, channel: Channel) -> bool {
         !self.channels[channel.index() as usize].is_empty()
@@ -141,6 +145,7 @@ where
     /// Drains and returns the dirty keys for the given channel.
     ///
     /// After this call, the channel will have no dirty keys.
+    #[inline]
     pub fn drain(&mut self, channel: Channel) -> impl Iterator<Item = K> + '_ {
         self.generation = self.generation.wrapping_add(1);
         self.channels[channel.index() as usize].drain()
@@ -149,6 +154,7 @@ where
     /// Removes `key` from the given channel.
     ///
     /// Returns `true` if `key` was present.
+    #[inline]
     pub fn take(&mut self, key: K, channel: Channel) -> bool {
         let removed = self.channels[channel.index() as usize].remove(&key);
         if removed {

--- a/understory_dirty/src/tracker.rs
+++ b/understory_dirty/src/tracker.rs
@@ -141,26 +141,29 @@ where
             cycle_handling,
         }
     }
-
     /// Returns a reference to the underlying dependency graph.
+    #[inline]
     #[must_use]
     pub fn graph(&self) -> &DirtyGraph<K> {
         &self.graph
     }
 
     /// Returns a mutable reference to the underlying dependency graph.
+    #[inline]
     #[must_use]
     pub fn graph_mut(&mut self) -> &mut DirtyGraph<K> {
         &mut self.graph
     }
 
     /// Returns a reference to the underlying dirty set.
+    #[inline]
     #[must_use]
     pub fn dirty(&self) -> &DirtySet<K> {
         &self.dirty
     }
 
     /// Returns a mutable reference to the underlying dirty set.
+    #[inline]
     #[must_use]
     pub fn dirty_mut(&mut self) -> &mut DirtySet<K> {
         &mut self.dirty
@@ -169,18 +172,21 @@ where
     /// Returns the current generation of the dirty set.
     ///
     /// See [`DirtySet::generation`] for details.
+    #[inline]
     #[must_use]
     pub fn generation(&self) -> u64 {
         self.dirty.generation()
     }
 
     /// Returns the current cycle handling mode.
+    #[inline]
     #[must_use]
     pub fn cycle_handling(&self) -> CycleHandling {
         self.cycle_handling
     }
 
     /// Sets the cycle handling mode for future operations.
+    #[inline]
     pub fn set_cycle_handling(&mut self, handling: CycleHandling) {
         self.cycle_handling = handling;
     }
@@ -268,6 +274,7 @@ where
     /// Marks a key as dirty without propagation.
     ///
     /// Returns `true` if the key was newly marked dirty.
+    #[inline]
     pub fn mark(&mut self, key: K, channel: Channel) -> bool {
         self.dirty.mark(key, channel)
     }
@@ -284,18 +291,21 @@ where
     }
 
     /// Returns `true` if the key is dirty in the given channel.
+    #[inline]
     #[must_use]
     pub fn is_dirty(&self, key: K, channel: Channel) -> bool {
         self.dirty.is_dirty(key, channel)
     }
 
     /// Returns `true` if there are any dirty keys in the given channel.
+    #[inline]
     #[must_use]
     pub fn has_dirty(&self, channel: Channel) -> bool {
         self.dirty.has_dirty(channel)
     }
 
     /// Returns `true` if there are no dirty keys in any channel.
+    #[inline]
     #[must_use]
     pub fn is_clean(&self) -> bool {
         self.dirty.is_empty()


### PR DESCRIPTION
Add `#[inline]` to small cross-crate-friendly accessors and wrappers in `DirtyTracker`/`DirtySet`/`DirtyGraph` and `ChannelSet`.