### PR TITLE
understory_style: add StyleSheet selectors and cascades

### DIFF
--- a/understory_style/src/lib.rs
+++ b/understory_style/src/lib.rs
@@ -66,7 +66,10 @@
 //! to resolution functions.
 //!
 //! ```rust
-//! use understory_style::{ResolveCx, Style, Theme, ThemeBuilder, StyleBuilder};
+//! use understory_style::{
+//!     ClassId, IdSet, PseudoClassId, ResolveCx, Selector, SelectorInputs, StyleCascade,
+//!     StyleCascadeBuilder, StyleBuilder, StyleOrigin, StyleSheetBuilder, ThemeBuilder,
+//! };
 //! use understory_property::{
 //!     DependencyObject, PropertyMetadataBuilder, PropertyRegistry, PropertyStore,
 //! };
@@ -74,14 +77,36 @@
 //! let mut registry = PropertyRegistry::new();
 //! let width = registry.register("Width", PropertyMetadataBuilder::new(0.0_f64).build());
 //!
-//! let style = StyleBuilder::new().set(width, 100.0).build();
 //! let theme = ThemeBuilder::new().build();
+//!
+//! const PRIMARY: ClassId = ClassId(1);
+//! const HOVER: PseudoClassId = PseudoClassId(1);
+//!
+//! // Base style for a "button"
+//! let base = StyleBuilder::new().set(width, 100.0).build();
+//! // Hover style when PRIMARY + HOVER
+//! let hover = StyleBuilder::new().set(width, 120.0).build();
+//!
+//! let hover_selector = Selector {
+//!     type_tag: None,
+//!     required_classes: IdSet::from_ids([PRIMARY]),
+//!     required_pseudos: IdSet::from_ids([HOVER]),
+//! };
+//!
+//! let sheet = StyleSheetBuilder::new()
+//!     .rule(hover_selector, hover)
+//!     .build();
+//!
+//! let style: StyleCascade = StyleCascadeBuilder::new()
+//!     .push_style(StyleOrigin::Base, base)
+//!     .push_sheet(StyleOrigin::Sheet, sheet)
+//!     .build();
 //!
 //! struct Element {
 //!     key: u32,
 //!     parent: Option<u32>,
 //!     store: PropertyStore<u32>,
-//!     style: Option<Style>,
+//!     style: Option<StyleCascade>,
 //! }
 //!
 //! impl DependencyObject<u32> for Element {
@@ -101,9 +126,15 @@
 //! // Create resolution context
 //! let cx = ResolveCx::new(&registry, &theme, |_key| None);
 //!
-//! // Resolve with style
-//! let value = cx.get_value(&element, width, element.style.as_ref());
+//! // Resolve with style (no hover)
+//! let inputs = SelectorInputs::new(None, &[PRIMARY], &[]);
+//! let value = cx.get_value(&element, &inputs, width, element.style.as_ref());
 //! assert_eq!(value, 100.0);
+//!
+//! // Resolve with style (hovered)
+//! let hovered = SelectorInputs::new(None, &[PRIMARY], &[HOVER]);
+//! let value = cx.get_value(&element, &hovered, width, element.style.as_ref());
+//! assert_eq!(value, 120.0);
 //! ```
 //!
 //! ## `no_std` Support
@@ -115,9 +146,16 @@
 extern crate alloc;
 
 mod resolve;
+mod selector;
 mod style;
+mod stylesheet;
 mod theme;
 
 pub use resolve::ResolveCx;
+pub use selector::{ClassId, IdSet, PseudoClassId, Selector, SelectorInputs, Specificity, TypeTag};
 pub use style::{Style, StyleBuilder};
+pub use stylesheet::{
+    StyleCascade, StyleCascadeBuilder, StyleOrigin, StyleRule, StyleSheet, StyleSheetBuilder,
+    StyleSource,
+};
 pub use theme::{ResourceKey, Theme, ThemeBuilder};

--- a/understory_style/src/selector.rs
+++ b/understory_style/src/selector.rs
@@ -1,0 +1,276 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Selector inputs and selector predicates for style matching.
+//!
+//! This module intentionally starts small: selectors are single-element
+//! predicates over a [`SelectorInputs`] snapshot (no combinators).
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
+
+/// Bucketed selector specificity: `(pseudos, classes, type_tag)`.
+///
+/// The fields are ordered highest-weight-first so that derived `Ord`
+/// gives correct CSS-like lexicographic ordering: pseudoclass count
+/// outranks class count, which outranks type tag presence.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Specificity(pub u32, pub u32, pub u32);
+
+/// A stable identifier for an element "type" in selectors.
+///
+/// This is application-defined (e.g. `Button`, `Text`, `SliderThumb`).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TypeTag(pub u32);
+
+/// A stable identifier for a user-defined class (e.g. `.primary`).
+///
+/// Class IDs are application-defined and intentionally unbounded.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ClassId(pub u32);
+
+/// A stable identifier for a pseudoclass (e.g. `:hover`, `:focus`).
+///
+/// Pseudoclass IDs are application-defined and intentionally unbounded.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PseudoClassId(pub u32);
+
+/// An owned, sorted, deduplicated set of IDs.
+///
+/// This representation is optimized for "small sets" and unbounded vocabularies:
+/// membership is O(log n), subset checks are O(n+m) via merge walk.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IdSet<T>(Box<[T]>);
+
+impl<T> Default for IdSet<T> {
+    fn default() -> Self {
+        Self(Vec::new().into_boxed_slice())
+    }
+}
+
+impl<T> IdSet<T>
+where
+    T: Copy + Ord,
+{
+    /// Constructs a set from an iterator, sorting and deduplicating.
+    #[must_use]
+    pub fn from_ids(iter: impl IntoIterator<Item = T>) -> Self {
+        let mut ids: Vec<T> = iter.into_iter().collect();
+        ids.sort();
+        ids.dedup();
+        Self(ids.into_boxed_slice())
+    }
+
+    /// Returns `true` if the set is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the number of IDs in the set.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns the set as a slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        &self.0
+    }
+
+    /// Returns `true` if this set contains the given ID.
+    #[must_use]
+    pub fn contains(&self, id: T) -> bool {
+        self.0.binary_search(&id).is_ok()
+    }
+
+    /// Returns `true` if this set is a subset of `other`.
+    #[must_use]
+    pub fn is_subset_of_slice(&self, other: &[T]) -> bool {
+        is_subset(self.as_slice(), other)
+    }
+}
+
+impl<T> FromIterator<T> for IdSet<T>
+where
+    T: Copy + Ord,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self::from_ids(iter)
+    }
+}
+
+/// A borrowed snapshot of selector inputs for a single element.
+///
+/// The `classes` and `pseudos` slices must be sorted and deduplicated.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SelectorInputs<'a> {
+    /// Optional type tag for the element.
+    pub type_tag: Option<TypeTag>,
+    /// Sorted, unique class IDs.
+    pub classes: &'a [ClassId],
+    /// Sorted, unique pseudoclass IDs.
+    pub pseudos: &'a [PseudoClassId],
+}
+
+impl SelectorInputs<'static> {
+    /// Empty selector inputs (no type, classes, or pseudos).
+    pub const EMPTY: Self = Self {
+        type_tag: None,
+        classes: &[],
+        pseudos: &[],
+    };
+}
+
+impl<'a> SelectorInputs<'a> {
+    /// Constructs selector inputs from borrowed slices.
+    ///
+    /// # Panics (debug only)
+    ///
+    /// Panics in debug builds if the slices are not sorted and deduplicated.
+    #[must_use]
+    pub fn new(
+        type_tag: Option<TypeTag>,
+        classes: &'a [ClassId],
+        pseudos: &'a [PseudoClassId],
+    ) -> Self {
+        debug_assert!(
+            is_sorted_unique(classes),
+            "`classes` must be sorted and unique"
+        );
+        debug_assert!(
+            is_sorted_unique(pseudos),
+            "`pseudos` must be sorted and unique"
+        );
+        Self {
+            type_tag,
+            classes,
+            pseudos,
+        }
+    }
+}
+
+/// A selector predicate over [`SelectorInputs`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Selector {
+    /// Optional type tag predicate.
+    pub type_tag: Option<TypeTag>,
+    /// Required class IDs.
+    pub required_classes: IdSet<ClassId>,
+    /// Required pseudoclass IDs.
+    pub required_pseudos: IdSet<PseudoClassId>,
+}
+
+impl Selector {
+    /// Returns `true` if this selector matches the given inputs.
+    #[must_use]
+    pub fn matches(&self, inputs: &SelectorInputs<'_>) -> bool {
+        if let Some(required) = self.type_tag
+            && inputs.type_tag != Some(required)
+        {
+            return false;
+        }
+        self.required_classes.is_subset_of_slice(inputs.classes)
+            && self.required_pseudos.is_subset_of_slice(inputs.pseudos)
+    }
+
+    /// Returns a bucketed specificity score.
+    ///
+    /// The returned [`Specificity`] orders `(pseudos, classes, type_tag)`,
+    /// so pseudoclass count outranks class count, which outranks type tag
+    /// presence — matching CSS semantics.
+    #[must_use]
+    pub fn specificity(&self) -> Specificity {
+        let type_score = u32::from(self.type_tag.is_some());
+        let classes = u32::try_from(self.required_classes.len()).unwrap_or(u32::MAX);
+        let pseudos = u32::try_from(self.required_pseudos.len()).unwrap_or(u32::MAX);
+        Specificity(pseudos, classes, type_score)
+    }
+}
+
+fn is_sorted_unique<T: Ord>(slice: &[T]) -> bool {
+    slice
+        .windows(2)
+        .all(|w| w[0].cmp(&w[1]) == core::cmp::Ordering::Less)
+}
+
+fn is_subset<T: Ord>(needles: &[T], haystack: &[T]) -> bool {
+    if needles.is_empty() {
+        return true;
+    }
+    if haystack.is_empty() {
+        return false;
+    }
+
+    let mut i = 0;
+    let mut j = 0;
+    while i < needles.len() && j < haystack.len() {
+        match needles[i].cmp(&haystack[j]) {
+            core::cmp::Ordering::Less => return false,
+            core::cmp::Ordering::Equal => {
+                i += 1;
+                j += 1;
+            }
+            core::cmp::Ordering::Greater => j += 1,
+        }
+    }
+    i == needles.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_set_from_iter_sorts_and_dedups() {
+        let set = IdSet::from_ids([ClassId(3), ClassId(1), ClassId(3), ClassId(2)]);
+        assert_eq!(set.as_slice(), &[ClassId(1), ClassId(2), ClassId(3)]);
+        assert!(set.contains(ClassId(2)));
+        assert!(!set.contains(ClassId(4)));
+    }
+
+    #[test]
+    fn selector_matches_subsets() {
+        let selector = Selector {
+            type_tag: Some(TypeTag(1)),
+            required_classes: IdSet::from_ids([ClassId(2), ClassId(3)]),
+            required_pseudos: IdSet::from_ids([PseudoClassId(10)]),
+        };
+
+        let classes = [ClassId(1), ClassId(2), ClassId(3)];
+        let pseudos = [PseudoClassId(10)];
+        let inputs = SelectorInputs::new(Some(TypeTag(1)), &classes, &pseudos);
+        assert!(selector.matches(&inputs));
+
+        let missing = [ClassId(2)];
+        let inputs_missing = SelectorInputs::new(Some(TypeTag(1)), &missing, &pseudos);
+        assert!(!selector.matches(&inputs_missing));
+    }
+
+    #[test]
+    fn selector_specificity_is_stable() {
+        let selector = Selector {
+            type_tag: Some(TypeTag(1)),
+            required_classes: IdSet::from_ids([ClassId(2), ClassId(3)]),
+            required_pseudos: IdSet::from_ids([PseudoClassId(10)]),
+        };
+        assert_eq!(selector.specificity(), Specificity(1, 2, 1));
+    }
+
+    #[test]
+    fn specificity_class_beats_type() {
+        let type_only = Selector {
+            type_tag: Some(TypeTag(1)),
+            required_classes: IdSet::default(),
+            required_pseudos: IdSet::default(),
+        };
+        let class_only = Selector {
+            type_tag: None,
+            required_classes: IdSet::from_ids([ClassId(1)]),
+            required_pseudos: IdSet::default(),
+        };
+        assert!(class_only.specificity() > type_only.specificity());
+    }
+}

--- a/understory_style/src/stylesheet.rs
+++ b/understory_style/src/stylesheet.rs
@@ -1,0 +1,390 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Rule-based style selection.
+//!
+//! A [`StyleSheet`] is a collection of [`StyleRule`]s. Each rule combines a
+//! [`Selector`] predicate and a [`Style`] payload (property setters).
+//!
+//! This module is intentionally limited to single-element matching (no
+//! combinators). The embedder is responsible for providing a [`SelectorInputs`]
+//! snapshot for each element.
+
+use alloc::rc::Rc;
+use alloc::vec::Vec;
+
+use understory_property::Property;
+
+use crate::selector::{Selector, SelectorInputs, Specificity};
+use crate::style::Style;
+
+/// The origin/strength of a style source within the Style layer.
+///
+/// Higher origins win over lower ones regardless of selector specificity.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum StyleOrigin {
+    /// Low-precedence base styling (e.g. control defaults).
+    Base = 0,
+    /// Rule-based styling (stylesheets).
+    Sheet = 1,
+    /// High-precedence overrides (e.g. explicit style assignment).
+    Override = 2,
+}
+
+/// A single rule in a [`StyleSheet`].
+#[derive(Clone, Debug)]
+pub struct StyleRule {
+    selector: Selector,
+    style: Style,
+    order: u32,
+}
+
+impl StyleRule {
+    /// Returns the selector.
+    #[must_use]
+    pub fn selector(&self) -> &Selector {
+        &self.selector
+    }
+
+    /// Returns the rule's style payload.
+    #[must_use]
+    pub fn style(&self) -> &Style {
+        &self.style
+    }
+}
+
+#[derive(Debug, Default)]
+struct StyleSheetData {
+    rules: Vec<StyleRule>,
+}
+
+/// A collection of style rules.
+///
+/// `StyleSheet` is immutable after creation. Use [`StyleSheetBuilder`] to
+/// construct instances.
+#[derive(Clone, Debug, Default)]
+pub struct StyleSheet {
+    inner: Rc<StyleSheetData>,
+}
+
+impl StyleSheet {
+    /// Returns the number of rules in this sheet.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.rules.len()
+    }
+
+    /// Returns `true` if this sheet has no rules.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.rules.is_empty()
+    }
+
+    /// Returns an iterator over rules.
+    pub fn rules(&self) -> impl Iterator<Item = &StyleRule> + '_ {
+        self.inner.rules.iter()
+    }
+
+    /// Returns the best matching value for a property in this sheet.
+    #[must_use]
+    pub fn get_value_ref<T: Clone + 'static>(
+        &self,
+        inputs: &SelectorInputs<'_>,
+        property: Property<T>,
+    ) -> Option<&T> {
+        let mut best: Option<(Specificity, u32, &T)> = None;
+
+        for rule in &self.inner.rules {
+            if !rule.selector.matches(inputs) {
+                continue;
+            }
+            let Some(value) = rule.style.get(property) else {
+                continue;
+            };
+
+            let spec = rule.selector.specificity();
+            let key = (spec, rule.order);
+
+            match best {
+                None => best = Some((key.0, key.1, value)),
+                Some((best_spec, best_order, _)) => {
+                    if key.0 > best_spec || (key.0 == best_spec && key.1 > best_order) {
+                        best = Some((key.0, key.1, value));
+                    }
+                }
+            }
+        }
+
+        best.map(|(_, _, v)| v)
+    }
+}
+
+/// Builder for constructing [`StyleSheet`] instances.
+#[derive(Debug, Default)]
+pub struct StyleSheetBuilder {
+    rules: Vec<StyleRule>,
+    next_order: u32,
+}
+
+impl StyleSheetBuilder {
+    /// Creates a new empty stylesheet builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a rule to the sheet.
+    #[must_use]
+    pub fn rule(mut self, selector: Selector, style: Style) -> Self {
+        let order = self.next_order;
+        self.next_order = self.next_order.saturating_add(1);
+        self.rules.push(StyleRule {
+            selector,
+            style,
+            order,
+        });
+        self
+    }
+
+    /// Builds the stylesheet.
+    #[must_use]
+    pub fn build(self) -> StyleSheet {
+        StyleSheet {
+            inner: Rc::new(StyleSheetData { rules: self.rules }),
+        }
+    }
+}
+
+/// A style source within a [`StyleCascade`].
+#[derive(Clone, Debug)]
+pub enum StyleSource {
+    /// A direct style (unconditional setters).
+    Style {
+        /// Origin/strength of this source in the cascade.
+        origin: StyleOrigin,
+        /// The direct style setters.
+        style: Style,
+    },
+    /// A stylesheet (conditional rules).
+    Sheet {
+        /// Origin/strength of this source in the cascade.
+        origin: StyleOrigin,
+        /// The stylesheet rules.
+        sheet: StyleSheet,
+    },
+}
+
+#[derive(Debug, Default)]
+struct StyleCascadeData {
+    sources: Vec<StyleSource>,
+}
+
+/// A composed, ordered set of style sources.
+///
+/// The cascade resolves the Style-layer value for a property given
+/// [`SelectorInputs`]. It is independent of dependency-property storage and
+/// higher-level invalidation; it simply answers "what style value applies?"
+#[derive(Clone, Debug, Default)]
+pub struct StyleCascade {
+    inner: Rc<StyleCascadeData>,
+}
+
+impl StyleCascade {
+    /// Returns the number of sources in this cascade.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.sources.len()
+    }
+
+    /// Returns `true` if this cascade has no sources.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.sources.is_empty()
+    }
+
+    /// Returns an iterator over sources.
+    pub fn sources(&self) -> impl Iterator<Item = &StyleSource> + '_ {
+        self.inner.sources.iter()
+    }
+
+    /// Returns the best Style-layer value for a property.
+    ///
+    /// Ordering is deterministic:
+    /// 1. Higher [`StyleOrigin`] wins.
+    /// 2. Higher selector specificity wins (styles have specificity 0).
+    /// 3. Later sources win (source order).
+    /// 4. Later rules win within a sheet (rule order).
+    #[must_use]
+    pub fn get_value_ref<T: Clone + 'static>(
+        &self,
+        inputs: &SelectorInputs<'_>,
+        property: Property<T>,
+    ) -> Option<&T> {
+        // Lexicographic tuple ordering gives the correct cascade priority:
+        // (origin, specificity, source_index, rule_order)
+        // — higher origin wins first, then higher specificity, then later
+        // source, then later rule within a sheet.
+        type Key = (StyleOrigin, Specificity, usize, u32);
+        let mut best: Option<(Key, &T)> = None;
+
+        for (source_index, source) in self.inner.sources.iter().enumerate() {
+            match source {
+                StyleSource::Style { origin, style } => {
+                    let Some(value) = style.get(property) else {
+                        continue;
+                    };
+                    let key: Key = (*origin, Specificity::default(), source_index, 0);
+                    let replace = match best {
+                        None => true,
+                        Some((cur, _)) => key > cur,
+                    };
+                    if replace {
+                        best = Some((key, value));
+                    }
+                }
+                StyleSource::Sheet { origin, sheet } => {
+                    // Find best rule in this sheet for the property.
+                    let mut sheet_best: Option<(Specificity, u32, &T)> = None;
+                    for rule in sheet.rules() {
+                        if !rule.selector.matches(inputs) {
+                            continue;
+                        }
+                        let Some(value) = rule.style.get(property) else {
+                            continue;
+                        };
+                        let spec = rule.selector.specificity();
+                        match sheet_best {
+                            None => sheet_best = Some((spec, rule.order, value)),
+                            Some((best_spec, best_order, _)) => {
+                                if spec > best_spec
+                                    || (spec == best_spec && rule.order > best_order)
+                                {
+                                    sheet_best = Some((spec, rule.order, value));
+                                }
+                            }
+                        }
+                    }
+
+                    let Some((spec, rule_order, value)) = sheet_best else {
+                        continue;
+                    };
+                    let key: Key = (*origin, spec, source_index, rule_order);
+                    let replace = match best {
+                        None => true,
+                        Some((cur, _)) => key > cur,
+                    };
+                    if replace {
+                        best = Some((key, value));
+                    }
+                }
+            }
+        }
+
+        best.map(|(_, v)| v)
+    }
+}
+
+/// Builder for constructing [`StyleCascade`] instances.
+#[derive(Debug, Default)]
+pub struct StyleCascadeBuilder {
+    sources: Vec<StyleSource>,
+}
+
+impl StyleCascadeBuilder {
+    /// Creates a new empty cascade builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a direct style source.
+    #[must_use]
+    pub fn push_style(mut self, origin: StyleOrigin, style: Style) -> Self {
+        self.sources.push(StyleSource::Style { origin, style });
+        self
+    }
+
+    /// Adds a stylesheet source.
+    #[must_use]
+    pub fn push_sheet(mut self, origin: StyleOrigin, sheet: StyleSheet) -> Self {
+        self.sources.push(StyleSource::Sheet { origin, sheet });
+        self
+    }
+
+    /// Builds the cascade.
+    #[must_use]
+    pub fn build(self) -> StyleCascade {
+        StyleCascade {
+            inner: Rc::new(StyleCascadeData {
+                sources: self.sources,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::selector::{ClassId, IdSet, PseudoClassId, Selector, SelectorInputs, TypeTag};
+    use crate::style::StyleBuilder;
+    use understory_property::{PropertyMetadataBuilder, PropertyRegistry};
+
+    #[test]
+    fn sheet_picks_highest_specificity_then_order() {
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register("Width", PropertyMetadataBuilder::new(0.0_f64).build());
+
+        let s1 = StyleBuilder::new().set(width, 10.0).build();
+        let s2 = StyleBuilder::new().set(width, 20.0).build();
+        let s3 = StyleBuilder::new().set(width, 30.0).build();
+
+        let base = Selector::default();
+        let classy = Selector {
+            type_tag: None,
+            required_classes: IdSet::from_ids([ClassId(1)]),
+            required_pseudos: IdSet::default(),
+        };
+
+        let sheet = StyleSheetBuilder::new()
+            .rule(base.clone(), s1)
+            .rule(base, s2.clone())
+            .rule(classy, s3)
+            .build();
+
+        let classes = [ClassId(1)];
+        let inputs = SelectorInputs::new(None, &classes, &[]);
+        assert_eq!(sheet.get_value_ref(&inputs, width), Some(&30.0));
+
+        let inputs2 = SelectorInputs::new(None, &[], &[]);
+        // Same specificity (0), later rule wins.
+        assert_eq!(sheet.get_value_ref(&inputs2, width), Some(&20.0));
+    }
+
+    #[test]
+    fn cascade_origin_beats_specificity() {
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register("Width", PropertyMetadataBuilder::new(0.0_f64).build());
+
+        let base_style = StyleBuilder::new().set(width, 10.0).build();
+        let override_style = StyleBuilder::new().set(width, 99.0).build();
+        let rule_style = StyleBuilder::new().set(width, 50.0).build();
+
+        let hover = Selector {
+            type_tag: Some(TypeTag(1)),
+            required_classes: IdSet::default(),
+            required_pseudos: IdSet::from_ids([PseudoClassId(1)]),
+        };
+
+        let sheet = StyleSheetBuilder::new().rule(hover, rule_style).build();
+
+        let cascade = StyleCascadeBuilder::new()
+            .push_style(StyleOrigin::Base, base_style)
+            .push_sheet(StyleOrigin::Sheet, sheet)
+            .push_style(StyleOrigin::Override, override_style)
+            .build();
+
+        let pseudos = [PseudoClassId(1)];
+        let inputs = SelectorInputs::new(Some(TypeTag(1)), &[], &pseudos);
+        assert_eq!(cascade.get_value_ref(&inputs, width), Some(&99.0));
+    }
+}


### PR DESCRIPTION
## Motivation

`Style` is a good payload type (an immutable map of property setters), but real UI styling needs a way to *select* which setters apply based on per-element context (classes, pseudo-classes, optional type tags) while staying `no_std`-friendly and deterministic.

This change adds a minimal rule engine to `understory_style` so embedders can express “when X, set Y” without pushing selector logic into `understory_property` or inventing ad-hoc variant APIs.

## What changed

- Add selector vocabulary:
    - `SelectorInputs`: borrowed snapshot of an element’s `type_tag`, `classes`, and `pseudos`.
    - `Selector`: a single-element predicate (no combinators) over `SelectorInputs`.
    - `IdSet<T>`: owned, sorted+dedup set representation suitable for unbounded ID spaces.
- Add rule-based style selection:
    - `StyleRule` + `StyleSheet` + `StyleSheetBuilder`.
    - `StyleCascade` + `StyleCascadeBuilder` to compose multiple style sources.
    - Deterministic tie-break:
    1) `StyleOrigin` (Base < Sheet < Override)
    2) selector specificity
    3) later sources
    4) later rules within a sheet
- Wire `ResolveCx` to resolve the “Style” precedence layer via `StyleCascade` and `SelectorInputs`.
- Update docs and benches to demonstrate the new API.

## Design notes / invariants

- `SelectorInputs` assumes `classes`/`pseudos` are sorted and unique (debug-asserted), so matching stays allocation-free and fast.
- Selectors are intentionally limited to single-element predicates for now; no ancestor/descendant combinators.
- No new dependencies; `understory_style` remains `#![no_std]` + `alloc`.

## Future work

- Optional indexing/compilation for sheets/cascades if matching becomes hot.
- Add negation/parts/attributes (still single-element) as needed.
- Provide conservative invalidation helpers (e.g. “which channels can change when pseudo X toggles”).