### PR TITLE
box_tree: Add `clipped_local_clip`

### DIFF
--- a/understory_box_tree/README.md
+++ b/understory_box_tree/README.md
@@ -90,8 +90,9 @@ Key operations:
 - [`Tree::local_transform`](Tree::local_transform) / [`Tree::local_bounds`](Tree::local_bounds) /
   [`Tree::local_clip`](Tree::local_clip) expose the node's current local geometry state for a
   live [`NodeId`].
-- [`Tree::clipped_local_clip`](Tree::clipped_local_clip) returns the node's local clip after
-  ancestor clipping, using the committed ancestor clip AABB projected into local space.
+- [`Tree::clipped_local_clip`](Tree::clipped_local_clip) returns the node's own local clip, if
+  any, after intersecting it with the committed ancestor clip AABB projected into local space.
+  Nodes without a local clip always return `None`.
 - [`Tree::children_of`](Tree::children_of) returns the children of a live [`NodeId`].
 - [`Tree::next_depth_first`](Tree::next_depth_first) and [`Tree::prev_depth_first`](Tree::prev_depth_first) provide depth-first tree traversal.
 

--- a/understory_box_tree/src/lib.rs
+++ b/understory_box_tree/src/lib.rs
@@ -73,8 +73,9 @@
 //! - [`Tree::local_transform`](Tree::local_transform) / [`Tree::local_bounds`](Tree::local_bounds) /
 //!   [`Tree::local_clip`](Tree::local_clip) expose the node's current local geometry state for a
 //!   live [`NodeId`].
-//! - [`Tree::clipped_local_clip`](Tree::clipped_local_clip) returns the node's local clip after
-//!   ancestor clipping, using the committed ancestor clip AABB projected into local space.
+//! - [`Tree::clipped_local_clip`](Tree::clipped_local_clip) returns the node's own local clip, if
+//!   any, after intersecting it with the committed ancestor clip AABB projected into local space.
+//!   Nodes without a local clip always return `None`.
 //! - [`Tree::children_of`](Tree::children_of) returns the children of a live [`NodeId`].
 //! - [`Tree::next_depth_first`](Tree::next_depth_first) and [`Tree::prev_depth_first`](Tree::prev_depth_first) provide depth-first tree traversal.
 //!

--- a/understory_box_tree/src/tree.rs
+++ b/understory_box_tree/src/tree.rs
@@ -1613,6 +1613,68 @@ mod tests {
     }
 
     #[test]
+    fn clipped_local_clip_tolerance_preserves_almost_aligned_corners() {
+        let mut tree = Tree::new();
+        let root = tree.insert(
+            None,
+            LocalNode {
+                local_bounds: Rect::new(0.0, 0.0, 200.0, 200.0),
+                local_clip: Some(RoundedRect::from_rect(
+                    Rect::new(0.0, 0.0, 100.0, 100.0),
+                    0.0,
+                )),
+                ..Default::default()
+            },
+        );
+        let child = tree.insert(
+            Some(root),
+            LocalNode {
+                local_bounds: Rect::new(0.0, 0.0, 200.0, 200.0),
+                local_transform: Affine::translate(Vec2::new(5e-10, 0.0)),
+                local_clip: Some(RoundedRect::from_rect(
+                    Rect::new(0.0, 0.0, 100.0, 100.0),
+                    RoundedRectRadii::new(10.0, 20.0, 30.0, 40.0),
+                )),
+                ..Default::default()
+            },
+        );
+        let _ = tree.commit();
+
+        let clip = tree.clipped_local_clip(child).unwrap();
+        assert_eq!(clip.rect(), Rect::new(0.0, 0.0, 99.999_999_999_5, 100.0));
+        assert_eq!(
+            clip.radii(),
+            RoundedRectRadii::new(10.0, 20.0, 30.0, 40.0),
+            "a nearly aligned ancestor boundary should preserve the untouched corners",
+        );
+    }
+
+    #[test]
+    fn clipped_local_clip_clamps_preserved_radii_after_ancestor_shrink() {
+        let local_clip = RoundedRect::from_rect(
+            Rect::new(0.0, 0.0, 100.0, 20.0),
+            RoundedRectRadii::new(4.0, 18.0, 18.0, 4.0),
+        );
+
+        let clipped = intersect_rounded_rect_with_rect_preserve_corners(
+            local_clip,
+            Rect::new(95.0, 0.0, 100.0, 20.0),
+        )
+        .unwrap();
+        let expected = RoundedRect::from_rect(
+            Rect::new(95.0, 0.0, 100.0, 20.0),
+            RoundedRectRadii::new(0.0, 18.0, 18.0, 0.0),
+        );
+
+        assert_eq!(clipped, expected);
+        assert_eq!(
+            clipped.radii(),
+            expected.radii(),
+            "preserved radii should follow Kurbo's clamping for the shrunken rect",
+        );
+    }
+
+    #[test]
     #[cfg(debug_assertions)]
     #[should_panic(expected = "Tree queries require calling `Tree::commit()`")]
     fn clipped_local_clip_without_commit_panics_in_debug() {


### PR DESCRIPTION
Add Tree::clipped_local_clip(id) to report a node local clip after intersecting it with ancestor clipping projected into the node local coordinate space.

Highlights

- API behavior:
  - Return None when the node has no local_clip, even if ancestors clip it.
  - When local_clip exists, intersect it with projected parent clip bounds.
  - Preserve rounded corner radii only for corners that remain intact.
- Implementation:
  - Add rounded-rect intersection helper that zeroes radii on clipped corners.
- Tests:
  - Add coverage for no-local-clip behavior under parent clipping.
  - Add coverage for partial clipping and corner-radius preservation.
  
This is a bit of a strange api but it's specifically to work around the case where when setting local clips on elements that have overflow x set to clip but overflow y set to visible (or vice versa), I set the local clip to extend to infinity. Then, once the box tree is committed and clips have been resolved, I set the renderer transform to the widget transform and I want to get the local clip while preserving corner radius but clipped to the parent clip so that it no longer extends to infinity. some renderers handle the large clips just fine but vello does not. 