### PR TITLE
Add KEYBOARD_NAVIGABLE node flag

### DIFF
--- a/understory_box_tree/README.md
+++ b/understory_box_tree/README.md
@@ -70,11 +70,12 @@ for details.
 
 - [`Tree`]: container managing nodes and the spatial index synchronization.
 - [`LocalNode`]: per-node local data (bounds, transform, optional clip, z, flags).
-  See [`LocalNode::flags`] for visibility/picking/focusable controls.
-- [`NodeFlags`]: visibility, picking, and focusable controls.
+  See [`LocalNode::flags`] for visibility/picking/focus semantics.
+- [`NodeFlags`]: visibility, picking, logical-focus, and keyboard-navigation controls.
 - [`NodeId`]: generational handle of a node.
-- [`QueryFilter`]: restricts hit/intersect results (visible/pickable/focusable).
-  See [`NodeFlags::VISIBLE`], [`NodeFlags::PICKABLE`], and [`NodeFlags::FOCUSABLE`].
+- [`QueryFilter`]: restricts hit/intersect results (visible/pickable/focusable/keyboard-navigable).
+  See [`NodeFlags::VISIBLE`], [`NodeFlags::PICKABLE`], [`NodeFlags::FOCUSABLE`], and
+  [`NodeFlags::KEYBOARD_NAVIGABLE`].
 
 Key operations:
 - [`Tree::insert`](Tree::insert) → [`NodeId`]

--- a/understory_box_tree/src/lib.rs
+++ b/understory_box_tree/src/lib.rs
@@ -53,11 +53,12 @@
 //!
 //! - [`Tree`]: container managing nodes and the spatial index synchronization.
 //! - [`LocalNode`]: per-node local data (bounds, transform, optional clip, z, flags).
-//!   See [`LocalNode::flags`] for visibility/picking/focusable controls.
-//! - [`NodeFlags`]: visibility, picking, and focusable controls.
+//!   See [`LocalNode::flags`] for visibility/picking/focus semantics.
+//! - [`NodeFlags`]: visibility, picking, logical-focus, and keyboard-navigation controls.
 //! - [`NodeId`]: generational handle of a node.
-//! - [`QueryFilter`]: restricts hit/intersect results (visible/pickable/focusable).
-//!   See [`NodeFlags::VISIBLE`], [`NodeFlags::PICKABLE`], and [`NodeFlags::FOCUSABLE`].
+//! - [`QueryFilter`]: restricts hit/intersect results (visible/pickable/focusable/keyboard-navigable).
+//!   See [`NodeFlags::VISIBLE`], [`NodeFlags::PICKABLE`], [`NodeFlags::FOCUSABLE`], and
+//!   [`NodeFlags::KEYBOARD_NAVIGABLE`].
 //!
 //! Key operations:
 //! - [`Tree::insert`](Tree::insert) → [`NodeId`]

--- a/understory_box_tree/src/tree.rs
+++ b/understory_box_tree/src/tree.rs
@@ -128,9 +128,18 @@ impl QueryFilter {
         self
     }
 
-    /// Filter to only focusable nodes.
+    /// Filter to nodes that can own logical focus state.
+    ///
+    /// This requires [`NodeFlags::FOCUSABLE`]. For keyboard traversal, use
+    /// [`Self::keyboard_navigable`].
     pub fn focusable(mut self) -> Self {
         self.required_flags |= NodeFlags::FOCUSABLE;
+        self
+    }
+
+    /// Filter to nodes included in keyboard navigation traversal.
+    pub fn keyboard_navigable(mut self) -> Self {
+        self.required_flags |= NodeFlags::KEYBOARD_NAVIGABLE;
         self
     }
 
@@ -1863,6 +1872,48 @@ mod tests {
         // nothing, as the only focusable child is `focusable_child`, and we're testing a point
         // outside it
         assert!(set_equality(&focusable_containing, &[]));
+    }
+
+    #[test]
+    fn query_filter_keyboard_navigable_only() {
+        let mut tree = Tree::new();
+        let root = tree.insert(
+            None,
+            LocalNode {
+                local_bounds: Rect::new(0.0, 0.0, 200.0, 200.0),
+                flags: NodeFlags::VISIBLE | NodeFlags::PICKABLE | NodeFlags::FOCUSABLE,
+                ..Default::default()
+            },
+        );
+        let keyboard_nav_child = tree.insert(
+            Some(root),
+            LocalNode {
+                local_bounds: Rect::new(10.0, 10.0, 60.0, 60.0),
+                flags: NodeFlags::VISIBLE | NodeFlags::PICKABLE | NodeFlags::KEYBOARD_NAVIGABLE,
+                ..Default::default()
+            },
+        );
+        let _non_keyboard_nav_child = tree.insert(
+            Some(root),
+            LocalNode {
+                local_bounds: Rect::new(70.0, 10.0, 120.0, 60.0),
+                flags: NodeFlags::VISIBLE | NodeFlags::PICKABLE | NodeFlags::FOCUSABLE,
+                ..Default::default()
+            },
+        );
+        let _ = tree.commit();
+
+        let hit_keyboard_nav = tree.hit_test_point(
+            Point::new(30.0, 30.0),
+            QueryFilter::new().visible().pickable().keyboard_navigable(),
+        );
+        assert_eq!(hit_keyboard_nav.unwrap().node, keyboard_nav_child);
+
+        let hit_non_keyboard_nav = tree.hit_test_point(
+            Point::new(90.0, 30.0),
+            QueryFilter::new().visible().pickable().keyboard_navigable(),
+        );
+        assert!(hit_non_keyboard_nav.is_none());
     }
 
     #[test]

--- a/understory_box_tree/src/types.rs
+++ b/understory_box_tree/src/types.rs
@@ -54,8 +54,22 @@ bitflags::bitflags! {
         const VISIBLE  = 0b0000_0001;
         /// Node is pickable (participates in hit testing).
         const PICKABLE = 0b0000_0010;
-        /// Node is focusable (can receive keyboard focus).
+        /// Node can own logical focus state.
+        ///
+        /// This represents "can be focused" semantics and may be used by higher-level focus state,
+        /// even when the node should not participate in keyboard traversal.
+        ///
+        /// [`Self::KEYBOARD_NAVIGABLE`] implies this capability semantically, even if callers do
+        /// not also set this bit explicitly.
         const FOCUSABLE = 0b0000_0100;
+        /// Node participates in keyboard navigation traversal.
+        ///
+        /// This flag implies that the node is focusable and should be included in keyboard
+        /// navigation traversal.
+        ///
+        /// It remains separate from [`Self::FOCUSABLE`] so apps can distinguish "focusable in
+        /// principle" from "reachable via keyboard navigation policies".
+        const KEYBOARD_NAVIGABLE = 0b0000_1000;
     }
 }
 
@@ -109,7 +123,9 @@ pub struct LocalNode {
     ///
     /// - [`NodeFlags::VISIBLE`] controls participation in visibility queries and hit testing.
     /// - [`NodeFlags::PICKABLE`] is consulted by hit testing.
-    /// - [`NodeFlags::FOCUSABLE`] is consulted by focus/navigation layers.
+    /// - [`NodeFlags::FOCUSABLE`] marks nodes that can own logical focus state.
+    /// - [`NodeFlags::KEYBOARD_NAVIGABLE`] marks nodes included in keyboard navigation traversal
+    ///   and semantically implies [`NodeFlags::FOCUSABLE`].
     ///
     /// Flags do not affect layout; they only influence queries and higher-level behavior.
     pub flags: NodeFlags,

--- a/understory_focus/src/adapters/box_tree.rs
+++ b/understory_focus/src/adapters/box_tree.rs
@@ -16,7 +16,7 @@
 //! use understory_focus::adapters::box_tree::build_focus_space_for_scope;
 //! use understory_focus::{DefaultPolicy, FocusPolicy, Navigation, WrapMode};
 //!
-//! // Build a tiny box tree: root with a single focusable child.
+//! // Build a tiny box tree: root with a single keyboard-navigable child.
 //! let mut tree = Tree::new();
 //! let root = tree.insert(
 //!     None,
@@ -30,7 +30,7 @@
 //!     Some(root),
 //!     LocalNode {
 //!         local_bounds: Rect::new(20.0, 20.0, 80.0, 60.0),
-//!         flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+//!         flags: NodeFlags::VISIBLE | NodeFlags::KEYBOARD_NAVIGABLE,
 //!         ..LocalNode::default()
 //!     },
 //! );
@@ -41,7 +41,7 @@
 //! let space = build_focus_space_for_scope(&tree, root, &(), &mut buf);
 //! let policy = DefaultPolicy { wrap: WrapMode::Scope };
 //!
-//! // In this trivial case, "next" from the only focusable node just wraps.
+//! // In this trivial case, "next" from the only keyboard-navigable node just wraps.
 //! assert_eq!(policy.next(button, Navigation::Next, &space), Some(button));
 //! ```
 
@@ -74,7 +74,8 @@ where
 /// - Traverses the box tree in depth-first order starting at `scope_root`.
 /// - Includes only nodes that are:
 ///   - Live in the tree.
-///   - Marked focusable via [`NodeFlags::FOCUSABLE`].
+///   - Marked keyboard-navigable via [`NodeFlags::KEYBOARD_NAVIGABLE`], which semantically
+///     implies focusability.
 ///   - Marked visible via [`NodeFlags::VISIBLE`] (to avoid focusing hidden nodes).
 ///   - Enabled according to [`FocusProps::enabled`].
 /// - Uses [`Tree::world_bounds`](Tree::world_bounds) to populate `rect` and
@@ -111,9 +112,9 @@ where
 
         if let (Some(flags), Some(bounds)) = (tree.flags(id), tree.world_bounds(id)) {
             let fp = props_lookup.props(&id);
-            let focusable = flags.contains(NodeFlags::FOCUSABLE);
+            let keyboard_navigable = flags.contains(NodeFlags::KEYBOARD_NAVIGABLE);
             let visible = flags.contains(NodeFlags::VISIBLE);
-            if focusable && visible && fp.enabled {
+            if keyboard_navigable && visible && fp.enabled {
                 out.push(FocusEntry {
                     id,
                     rect: bounds,
@@ -146,10 +147,10 @@ mod tests {
     use understory_box_tree::LocalNode;
 
     #[test]
-    fn builds_focus_space_for_focusable_nodes() {
+    fn builds_focus_space_for_keyboard_navigable_nodes() {
         let mut tree = Tree::new();
 
-        // Root: visible but not focusable.
+        // Root: visible but not keyboard-navigable.
         let root = tree.insert(
             None,
             LocalNode {
@@ -157,11 +158,11 @@ mod tests {
                 ..LocalNode::default()
             },
         );
-        // Child A: visible + focusable.
+        // Child A: visible + keyboard-navigable.
         let a = tree.insert(
             Some(root),
             LocalNode {
-                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                flags: NodeFlags::VISIBLE | NodeFlags::KEYBOARD_NAVIGABLE,
                 ..LocalNode::default()
             },
         );
@@ -191,14 +192,14 @@ mod tests {
         let root = tree.insert(
             None,
             LocalNode {
-                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                flags: NodeFlags::VISIBLE | NodeFlags::KEYBOARD_NAVIGABLE,
                 ..LocalNode::default()
             },
         );
         let disabled_child = tree.insert(
             Some(root),
             LocalNode {
-                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                flags: NodeFlags::VISIBLE | NodeFlags::KEYBOARD_NAVIGABLE,
                 ..LocalNode::default()
             },
         );
@@ -226,9 +227,61 @@ mod tests {
         let mut buf = Vec::new();
         let space = build_focus_space_for_scope(&tree, root, &lookup, &mut buf);
 
-        // Root is focusable and enabled; disabled_child should be skipped.
+        // Root is keyboard-navigable and enabled; disabled_child should be skipped.
         assert_eq!(space.nodes.len(), 1);
         assert_eq!(space.nodes[0].id, root);
+    }
+
+    #[test]
+    fn treats_keyboard_navigable_as_implying_focusable() {
+        let mut tree = Tree::new();
+        let root = tree.insert(
+            None,
+            LocalNode {
+                flags: NodeFlags::VISIBLE,
+                ..LocalNode::default()
+            },
+        );
+        let keyboard_only = tree.insert(
+            Some(root),
+            LocalNode {
+                flags: NodeFlags::VISIBLE | NodeFlags::KEYBOARD_NAVIGABLE,
+                ..LocalNode::default()
+            },
+        );
+        let _ = tree.commit();
+
+        let mut buf = Vec::new();
+        let space = build_focus_space_for_scope(&tree, root, &(), &mut buf);
+
+        assert_eq!(space.nodes.len(), 1);
+        assert_eq!(space.nodes[0].id, keyboard_only);
+    }
+
+    #[test]
+    fn includes_node_with_explicit_focusable_and_keyboard_navigable_flags() {
+        let mut tree = Tree::new();
+        let root = tree.insert(
+            None,
+            LocalNode {
+                flags: NodeFlags::VISIBLE,
+                ..LocalNode::default()
+            },
+        );
+        let fully_flagged = tree.insert(
+            Some(root),
+            LocalNode {
+                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE | NodeFlags::KEYBOARD_NAVIGABLE,
+                ..LocalNode::default()
+            },
+        );
+        let _ = tree.commit();
+
+        let mut buf = Vec::new();
+        let space = build_focus_space_for_scope(&tree, root, &(), &mut buf);
+
+        assert_eq!(space.nodes.len(), 1);
+        assert_eq!(space.nodes[0].id, fully_flagged);
     }
 
     #[test]
@@ -237,7 +290,7 @@ mod tests {
 
         let mut tree = Tree::new();
 
-        // Root is visible but not focusable; children are visible + focusable.
+        // Root is visible but not keyboard-navigable; children are visible + keyboard-navigable.
         let root = tree.insert(
             None,
             LocalNode {
@@ -250,7 +303,7 @@ mod tests {
             Some(root),
             LocalNode {
                 local_bounds: Rect::new(10.0, 10.0, 40.0, 40.0),
-                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                flags: NodeFlags::VISIBLE | NodeFlags::KEYBOARD_NAVIGABLE,
                 ..LocalNode::default()
             },
         );
@@ -258,7 +311,7 @@ mod tests {
             Some(root),
             LocalNode {
                 local_bounds: Rect::new(80.0, 10.0, 110.0, 40.0),
-                flags: NodeFlags::VISIBLE | NodeFlags::FOCUSABLE,
+                flags: NodeFlags::VISIBLE | NodeFlags::KEYBOARD_NAVIGABLE,
                 ..LocalNode::default()
             },
         );


### PR DESCRIPTION
Add a distinct keyboard-navigation flag to box-tree node flags while keeping FOCUSABLE as a separate logical-focus signal.

Behavior

- NodeFlags now include both:
  - FOCUSABLE: node can own logical focus state.
  - KEYBOARD_NAVIGABLE: node participates in keyboard traversal.
- QueryFilter::focusable() now requires FOCUSABLE.
- Added QueryFilter::keyboard_navigable() to require KEYBOARD_NAVIGABLE.
- understory_focus box-tree adapter explicitly selects candidates using KEYBOARD_NAVIGABLE (plus VISIBLE and enabled focus props).

Why both flags exist

- Some nodes should be focusable in principle without being reachable through keyboard navigation policies.
- Separating these concerns avoids coupling logical focus ownership to traversal eligibility.