### PR TITLE
Add headless axis and guide primitives with a movable ruler demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "understory_axis"
+version = "0.1.0"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "understory_benches"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "understory_guide"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+ "understory_axis",
+]
+
+[[package]]
 name = "understory_index"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "understory_axis",
+  "understory_guide",
   "understory_index",
   "understory_box_tree",
   "understory_focus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "understory_axis",
   "understory_index",
   "understory_box_tree",
   "understory_focus",

--- a/understory_axis/Cargo.toml
+++ b/understory_axis/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["ui", "axis", "scale", "no_std", "understory"]
 categories = ["gui", "data-structures", "no-std"]
 
 [dependencies]
+libm = { version = "0.2", default-features = false }
 
 [lints]
 workspace = true

--- a/understory_axis/Cargo.toml
+++ b/understory_axis/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "understory_axis"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "Headless numeric axis scale and tick primitives for Understory."
+keywords = ["ui", "axis", "scale", "no_std", "understory"]
+categories = ["gui", "data-structures", "no-std"]
+
+[dependencies]
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+std = []
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_axis/README.md
+++ b/understory_axis/README.md
@@ -5,7 +5,8 @@ Headless numeric axis scale and tick primitives for Understory.
 This crate owns:
 
 - 1D axis scale selection from world-units-per-pixel
-- configurable numeric step ladders
+- configurable major-step ladders
+- configurable subdivision policy
 - major / medium / minor tick classification
 - labeled-tick eligibility
 - spacing metadata for callers that want consistent axis-derived policy
@@ -17,4 +18,5 @@ Typical usage:
 - format labels in the caller's own domain language
 
 It does not own domain-specific label formatting such as timestamps, dates, or
-units.
+units. It currently models linear numeric axes only; a true logarithmic axis is
+a separate future concern.

--- a/understory_axis/README.md
+++ b/understory_axis/README.md
@@ -5,6 +5,7 @@ Headless numeric axis scale and tick primitives for Understory.
 This crate owns:
 
 - 1D axis scale selection from world-units-per-pixel
+- configurable numeric step ladders
 - major / medium / minor tick classification
 - labeled-tick eligibility
 - spacing metadata for callers that want consistent axis-derived policy

--- a/understory_axis/README.md
+++ b/understory_axis/README.md
@@ -1,10 +1,10 @@
 # Understory Axis
 
-Headless numeric axis scale and tick primitives for Understory.
+Headless numeric axis mapping and tick primitives for Understory.
 
 This crate owns:
 
-- 1D axis scale selection from world-units-per-pixel
+- 1D linear and log axis mappings
 - configurable major-step ladders
 - configurable subdivision policy
 - major / medium / minor tick classification
@@ -13,10 +13,10 @@ This crate owns:
 
 Typical usage:
 
-- derive an `AxisScale1D` from world-units-per-pixel
+- define an `AxisMapping1D` for the visible domain and view span
+- derive an `AxisScale1D` from that mapping
 - iterate ticks across a visible numeric range
 - format labels in the caller's own domain language
 
 It does not own domain-specific label formatting such as timestamps, dates, or
-units. It currently models linear numeric axes only; a true logarithmic axis is
-a separate future concern.
+units, and it does not own chart layout or rendering.

--- a/understory_axis/README.md
+++ b/understory_axis/README.md
@@ -7,6 +7,13 @@ This crate owns:
 - 1D axis scale selection from world-units-per-pixel
 - major / medium / minor tick classification
 - labeled-tick eligibility
+- spacing metadata for callers that want consistent axis-derived policy
+
+Typical usage:
+
+- derive an `AxisScale1D` from world-units-per-pixel
+- iterate ticks across a visible numeric range
+- format labels in the caller's own domain language
 
 It does not own domain-specific label formatting such as timestamps, dates, or
 units.

--- a/understory_axis/README.md
+++ b/understory_axis/README.md
@@ -1,0 +1,12 @@
+# Understory Axis
+
+Headless numeric axis scale and tick primitives for Understory.
+
+This crate owns:
+
+- 1D axis scale selection from world-units-per-pixel
+- major / medium / minor tick classification
+- labeled-tick eligibility
+
+It does not own domain-specific label formatting such as timestamps, dates, or
+units.

--- a/understory_axis/README.md
+++ b/understory_axis/README.md
@@ -10,11 +10,13 @@ This crate owns:
 - major / medium / minor tick classification
 - labeled-tick eligibility
 - spacing metadata for callers that want consistent axis-derived policy
+- scalar ruler snapshots ready for 2D placement by higher layers
 
 Typical usage:
 
 - define an `AxisMapping1D` for the visible domain and view span
 - derive an `AxisScale1D` from that mapping
+- optionally derive an `AxisRuler1D` for scalar mark positions
 - iterate ticks across a visible numeric range
 - format labels in the caller's own domain language
 

--- a/understory_axis/src/lib.rs
+++ b/understory_axis/src/lib.rs
@@ -11,13 +11,17 @@
 //! - 1-2-5 step sizing
 //! - label eligibility decisions based on spacing thresholds
 //! - spacing metadata for callers that need consistent axis-derived policy
-//! - configurable numeric step ladders for different axis domains
+//! - configurable major-step ladders and subdivision policies for different axis domains
 //!
 //! It does not own:
 //! - domain-specific label formatting
 //! - time units or dates
 //! - viewport transforms
 //! - rendering or text layout
+//!
+//! It currently models linear numeric axes. A true logarithmic axis needs a
+//! different world/view contract and range-dependent tick placement, so it is
+//! not represented here as "just another ladder."
 //!
 //! The intended split is:
 //! - a caller supplies world-units-per-pixel and a visible numeric range
@@ -27,7 +31,10 @@
 //! ## Minimal example
 //!
 //! ```rust
-//! use understory_axis::{AxisScale1D, AxisScaleOptions, AxisStepLadder, AxisTickKind};
+//! use understory_axis::{
+//!     AxisMajorStepLadder, AxisScale1D, AxisScaleOptions, AxisSubdivisionPolicy,
+//!     AxisTickKind,
+//! };
 //!
 //! let scale = AxisScale1D::with_options(
 //!     0.5,
@@ -35,7 +42,8 @@
 //!         target_major_spacing_px: 100.0,
 //!         min_major_step: 0.0,
 //!         medium_label_min_spacing_px: 220.0,
-//!         step_ladder: AxisStepLadder::Decimal125,
+//!         major_step_ladder: AxisMajorStepLadder::Decimal125,
+//!         subdivision_policy: AxisSubdivisionPolicy::Auto,
 //!     },
 //! );
 //!
@@ -83,8 +91,18 @@ pub struct AxisScaleOptions {
     pub min_major_step: f64,
     /// Minimum major spacing in pixels before medium ticks become label-eligible.
     pub medium_label_min_spacing_px: f64,
-    /// Numeric ladder used to choose major tick steps.
-    pub step_ladder: AxisStepLadder,
+    /// Sparse set of canonical major-step anchors.
+    ///
+    /// This chooses the "nice" major step nearest to the desired spacing. It
+    /// does not determine how that major step is subdivided into medium/minor
+    /// ticks; that is handled separately by [`AxisSubdivisionPolicy`].
+    pub major_step_ladder: AxisMajorStepLadder,
+    /// Policy for subdividing the chosen major step into medium/minor ticks.
+    ///
+    /// This is where values like "3" or "4" usually belong. They tend to make
+    /// sense as subdivisions of a major step more often than as globally
+    /// canonical major-step anchors.
+    pub subdivision_policy: AxisSubdivisionPolicy,
 }
 
 impl Default for AxisScaleOptions {
@@ -93,14 +111,26 @@ impl Default for AxisScaleOptions {
             target_major_spacing_px: 96.0,
             min_major_step: 0.0,
             medium_label_min_spacing_px: 220.0,
-            step_ladder: AxisStepLadder::Decimal125,
+            major_step_ladder: AxisMajorStepLadder::Decimal125,
+            subdivision_policy: AxisSubdivisionPolicy::Auto,
         }
     }
 }
 
-/// Numeric ladder used to choose major axis steps.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum AxisStepLadder {
+/// Sparse set of canonical major-step anchors for a linear numeric axis.
+///
+/// A ladder answers one narrow question: once a caller knows the approximate
+/// major spacing it wants, which "nice" major step should that snap to?
+///
+/// `1-2-5` is the common default because it gives stable, memorable breakpoints
+/// across decades: `... 0.1, 0.2, 0.5, 1, 2, 5, 10 ...`.
+///
+/// Values like `3` and `4` are usually more useful as subdivisions of a chosen
+/// major step than as globally canonical major anchors. For example, a major
+/// step of `20` often wants four minor `5`s; that does not mean `4` itself
+/// should become a top-level major-step rung.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum AxisMajorStepLadder {
     /// Decimal `1-2-5` major steps: `... 0.1, 0.2, 0.5, 1, 2, 5, 10 ...`.
     Decimal125,
     /// Binary power-of-two major steps: `... 1, 2, 4, 8, 16 ...`.
@@ -108,6 +138,34 @@ pub enum AxisStepLadder {
     /// This is useful for sample indices, memory-like domains, and other
     /// quantities that naturally prefer binary breakpoints over decimal ones.
     BinaryPowerOfTwo,
+    /// Time-like major steps using decimal sub-second spacing and sexagesimal
+    /// larger units.
+    ///
+    /// `units_per_second` declares how many caller-defined world units make up
+    /// one second. For example:
+    ///
+    /// - `1.0` for world units already expressed in seconds
+    /// - `1_000.0` for milliseconds
+    /// - `1_000_000.0` for microseconds
+    ///
+    /// Below one second this falls back to decimal `1-2-5` steps; at and above
+    /// one second it prefers time-oriented anchors such as `1s`, `2s`, `5s`,
+    /// `10s`, `15s`, `30s`, `1m`, `2m`, `5m`, `10m`, `15m`, `30m`, `1h`, and so on.
+    TimeLike {
+        /// Number of caller-defined world units that correspond to one second.
+        units_per_second: f64,
+    },
+}
+
+/// Policy for subdividing a chosen major step into medium/minor ticks.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AxisSubdivisionPolicy {
+    /// Use the ladder's default subdivision behavior.
+    Auto,
+    /// Divide each major step into a fixed number of equal minor intervals.
+    ///
+    /// `0` is treated as `1`, which yields no effective subdivision.
+    Fixed(usize),
 }
 
 /// A derived 1D axis scale over a continuous numeric domain.
@@ -135,9 +193,13 @@ impl AxisScale1D {
         let target_major_step = world_units_per_pixel * options.target_major_spacing_px;
         let major_step = choose_step(
             target_major_step.max(options.min_major_step).max(1e-12),
-            options.step_ladder,
+            options.major_step_ladder,
         );
-        let subdivisions = subdivisions_for_step(major_step, options.step_ladder);
+        let subdivisions = subdivisions_for_step(
+            major_step,
+            options.major_step_ladder,
+            options.subdivision_policy,
+        );
         let minor_step = major_step / subdivisions as f64;
         let medium_interval = if subdivisions.is_multiple_of(2) {
             Some(subdivisions / 2)
@@ -283,30 +345,10 @@ impl Iterator for AxisTicksIter {
     }
 }
 
-fn choose_step(target: f64, ladder: AxisStepLadder) -> f64 {
+fn choose_step(target: f64, ladder: AxisMajorStepLadder) -> f64 {
     match ladder {
-        AxisStepLadder::Decimal125 => {
-            let mut unit = 1.0_f64;
-            if target >= 1.0 {
-                while unit * 10.0 <= target {
-                    unit *= 10.0;
-                }
-            } else {
-                while unit > target {
-                    unit /= 10.0;
-                }
-            }
-
-            for mantissa in [1.0_f64, 2.0, 5.0, 10.0] {
-                let step = mantissa * unit;
-                if step >= target {
-                    return step;
-                }
-            }
-
-            10.0 * unit
-        }
-        AxisStepLadder::BinaryPowerOfTwo => {
+        AxisMajorStepLadder::Decimal125 => choose_decimal_125_step(target),
+        AxisMajorStepLadder::BinaryPowerOfTwo => {
             let mut step = 1.0_f64;
             if target >= 1.0 {
                 while step < target {
@@ -319,34 +361,135 @@ fn choose_step(target: f64, ladder: AxisStepLadder) -> f64 {
             }
             step
         }
+        AxisMajorStepLadder::TimeLike { units_per_second } => {
+            choose_time_like_step(target, units_per_second)
+        }
     }
 }
 
-fn subdivisions_for_step(step: f64, ladder: AxisStepLadder) -> usize {
-    match ladder {
-        AxisStepLadder::Decimal125 => {
-            let step = step.abs().max(1e-12);
-            let mut scale = 1.0_f64;
-            if step >= 1.0 {
-                while scale * 10.0 <= step {
-                    scale *= 10.0;
-                }
-            } else {
-                while scale > step {
-                    scale /= 10.0;
-                }
-            }
-            let normalized = step / scale;
-            if normalized <= 1.0 + 1e-6 {
-                10
-            } else if normalized <= 2.0 + 1e-6 {
-                4
-            } else {
-                5
-            }
+fn choose_decimal_125_step(target: f64) -> f64 {
+    let mut unit = 1.0_f64;
+    if target >= 1.0 {
+        while unit * 10.0 <= target {
+            unit *= 10.0;
         }
-        AxisStepLadder::BinaryPowerOfTwo => 4,
+    } else {
+        while unit > target {
+            unit /= 10.0;
+        }
     }
+
+    for mantissa in [1.0_f64, 2.0, 5.0, 10.0] {
+        let step = mantissa * unit;
+        if step >= target {
+            return step;
+        }
+    }
+
+    10.0 * unit
+}
+
+fn choose_time_like_step(target: f64, units_per_second: f64) -> f64 {
+    const LARGE_TIME_STEPS_SECONDS: &[f64] = &[
+        1.0, 2.0, 5.0, 10.0, 15.0, 30.0, 60.0, 120.0, 300.0, 600.0, 900.0, 1_800.0, 3_600.0,
+        7_200.0, 10_800.0, 21_600.0, 43_200.0, 86_400.0, 172_800.0, 604_800.0,
+    ];
+
+    let units_per_second = units_per_second.abs().max(f64::MIN_POSITIVE);
+    let target_seconds = target / units_per_second;
+    if target_seconds < 1.0 {
+        return choose_decimal_125_step(target_seconds) * units_per_second;
+    }
+
+    for &step_seconds in LARGE_TIME_STEPS_SECONDS {
+        if step_seconds >= target_seconds {
+            return step_seconds * units_per_second;
+        }
+    }
+
+    choose_decimal_125_step(target_seconds / 86_400.0) * 86_400.0 * units_per_second
+}
+
+fn subdivisions_for_step(
+    step: f64,
+    ladder: AxisMajorStepLadder,
+    policy: AxisSubdivisionPolicy,
+) -> usize {
+    match policy {
+        AxisSubdivisionPolicy::Auto => auto_subdivisions_for_step(step, ladder),
+        AxisSubdivisionPolicy::Fixed(count) => count.max(1),
+    }
+}
+
+fn auto_subdivisions_for_step(step: f64, ladder: AxisMajorStepLadder) -> usize {
+    match ladder {
+        AxisMajorStepLadder::Decimal125 => decimal_125_subdivisions(step),
+        AxisMajorStepLadder::BinaryPowerOfTwo => 4,
+        AxisMajorStepLadder::TimeLike { units_per_second } => {
+            time_like_subdivisions(step, units_per_second)
+        }
+    }
+}
+
+fn decimal_125_subdivisions(step: f64) -> usize {
+    let step = step.abs().max(1e-12);
+    let mut scale = 1.0_f64;
+    if step >= 1.0 {
+        while scale * 10.0 <= step {
+            scale *= 10.0;
+        }
+    } else {
+        while scale > step {
+            scale /= 10.0;
+        }
+    }
+    let normalized = step / scale;
+    if normalized <= 1.0 + 1e-6 {
+        10
+    } else if normalized <= 2.0 + 1e-6 {
+        4
+    } else {
+        5
+    }
+}
+
+fn time_like_subdivisions(step: f64, units_per_second: f64) -> usize {
+    let units_per_second = units_per_second.abs().max(f64::MIN_POSITIVE);
+    let step_seconds = step / units_per_second;
+    if step_seconds < 1.0 {
+        return decimal_125_subdivisions(step_seconds);
+    }
+
+    if approx_eq(step_seconds, 15.0) || approx_eq(step_seconds, 30.0) {
+        3
+    } else if approx_eq(step_seconds, 60.0)
+        || approx_eq(step_seconds, 3_600.0)
+        || approx_eq(step_seconds, 21_600.0)
+        || approx_eq(step_seconds, 86_400.0)
+    {
+        6
+    } else if approx_eq(step_seconds, 120.0)
+        || approx_eq(step_seconds, 7_200.0)
+        || approx_eq(step_seconds, 43_200.0)
+        || approx_eq(step_seconds, 172_800.0)
+    {
+        4
+    } else if approx_eq(step_seconds, 300.0) || approx_eq(step_seconds, 600.0) {
+        5
+    } else if approx_eq(step_seconds, 900.0)
+        || approx_eq(step_seconds, 1_800.0)
+        || approx_eq(step_seconds, 10_800.0)
+    {
+        3
+    } else if approx_eq(step_seconds, 604_800.0) {
+        7
+    } else {
+        decimal_125_subdivisions(step_seconds)
+    }
+}
+
+fn approx_eq(a: f64, b: f64) -> bool {
+    (a - b).abs() <= 1e-9 * a.abs().max(b.abs()).max(1.0)
 }
 
 fn floor_to_i64(value: f64) -> i64 {
@@ -379,7 +522,9 @@ fn ceil_to_i64(value: f64) -> i64 {
 mod tests {
     use alloc::vec::Vec;
 
-    use super::{AxisScale1D, AxisScaleOptions, AxisStepLadder, AxisTickKind};
+    use super::{
+        AxisMajorStepLadder, AxisScale1D, AxisScaleOptions, AxisSubdivisionPolicy, AxisTickKind,
+    };
 
     #[test]
     fn larger_world_units_produce_larger_major_steps() {
@@ -396,7 +541,8 @@ mod tests {
                 target_major_spacing_px: 320.0,
                 min_major_step: 0.0,
                 medium_label_min_spacing_px: 220.0,
-                step_ladder: AxisStepLadder::Decimal125,
+                major_step_ladder: AxisMajorStepLadder::Decimal125,
+                subdivision_policy: AxisSubdivisionPolicy::Auto,
             },
         );
         let ticks = scale.ticks_in_range(0.0..100.0);
@@ -432,7 +578,8 @@ mod tests {
                 target_major_spacing_px: 96.0,
                 min_major_step: 0.0,
                 medium_label_min_spacing_px: 220.0,
-                step_ladder: AxisStepLadder::Decimal125,
+                major_step_ladder: AxisMajorStepLadder::Decimal125,
+                subdivision_policy: AxisSubdivisionPolicy::Auto,
             },
         );
         assert!((scale.major_spacing_px() - scale.major_step() / 0.5).abs() < 1e-9);
@@ -446,14 +593,15 @@ mod tests {
     }
 
     #[test]
-    fn binary_step_ladder_prefers_power_of_two_steps() {
+    fn binary_major_step_ladder_prefers_power_of_two_steps() {
         let scale = AxisScale1D::with_options(
             0.75,
             AxisScaleOptions {
                 target_major_spacing_px: 8.0,
                 min_major_step: 0.0,
                 medium_label_min_spacing_px: 220.0,
-                step_ladder: AxisStepLadder::BinaryPowerOfTwo,
+                major_step_ladder: AxisMajorStepLadder::BinaryPowerOfTwo,
+                subdivision_policy: AxisSubdivisionPolicy::Auto,
             },
         );
         assert_eq!(scale.major_step(), 8.0);
@@ -469,7 +617,8 @@ mod tests {
                 target_major_spacing_px: 96.0,
                 min_major_step: 0.0,
                 medium_label_min_spacing_px: 220.0,
-                step_ladder: AxisStepLadder::Decimal125,
+                major_step_ladder: AxisMajorStepLadder::Decimal125,
+                subdivision_policy: AxisSubdivisionPolicy::Auto,
             },
         );
         assert_eq!(coarse.label_step(), coarse.major_step());
@@ -480,12 +629,48 @@ mod tests {
                 target_major_spacing_px: 320.0,
                 min_major_step: 0.0,
                 medium_label_min_spacing_px: 220.0,
-                step_ladder: AxisStepLadder::Decimal125,
+                major_step_ladder: AxisMajorStepLadder::Decimal125,
+                subdivision_policy: AxisSubdivisionPolicy::Auto,
             },
         );
         assert_eq!(
             fine.label_step(),
             fine.medium_step().unwrap_or(fine.major_step())
         );
+    }
+
+    #[test]
+    fn time_like_major_step_ladder_prefers_15_and_30_boundaries() {
+        let scale = AxisScale1D::with_options(
+            125.0,
+            AxisScaleOptions {
+                target_major_spacing_px: 96.0,
+                min_major_step: 0.0,
+                medium_label_min_spacing_px: 220.0,
+                major_step_ladder: AxisMajorStepLadder::TimeLike {
+                    units_per_second: 1_000.0,
+                },
+                subdivision_policy: AxisSubdivisionPolicy::Auto,
+            },
+        );
+        assert_eq!(scale.major_step(), 15_000.0);
+        assert_eq!(scale.minor_step(), 5_000.0);
+    }
+
+    #[test]
+    fn fixed_subdivision_policy_overrides_ladder_defaults() {
+        let scale = AxisScale1D::with_options(
+            0.75,
+            AxisScaleOptions {
+                target_major_spacing_px: 8.0,
+                min_major_step: 0.0,
+                medium_label_min_spacing_px: 220.0,
+                major_step_ladder: AxisMajorStepLadder::BinaryPowerOfTwo,
+                subdivision_policy: AxisSubdivisionPolicy::Fixed(8),
+            },
+        );
+        assert_eq!(scale.major_step(), 8.0);
+        assert_eq!(scale.minor_step(), 1.0);
+        assert_eq!(scale.medium_step(), Some(4.0));
     }
 }

--- a/understory_axis/src/lib.rs
+++ b/understory_axis/src/lib.rs
@@ -1,14 +1,14 @@
 // Copyright 2026 the Understory Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Understory Axis: headless numeric axis scale and tick primitives.
+//! Understory Axis: headless axis mapping and tick primitives.
 //!
-//! This crate focuses on one narrow concern: deriving stable, "nice" 1D tick
-//! positions from a continuous numeric axis.
+//! This crate focuses on one narrow concern: mapping numeric domains onto a 1D
+//! view span and deriving stable, "nice" tick positions for that mapping.
 //!
 //! It owns:
+//! - linear and logarithmic 1D axis mappings
 //! - major / medium / minor tick selection
-//! - 1-2-5 step sizing
 //! - label eligibility decisions based on spacing thresholds
 //! - spacing metadata for callers that need consistent axis-derived policy
 //! - configurable major-step ladders and subdivision policies for different axis domains
@@ -19,12 +19,8 @@
 //! - viewport transforms
 //! - rendering or text layout
 //!
-//! It currently models linear numeric axes. A true logarithmic axis needs a
-//! different world/view contract and range-dependent tick placement, so it is
-//! not represented here as "just another ladder."
-//!
 //! The intended split is:
-//! - a caller supplies world-units-per-pixel and a visible numeric range
+//! - a caller supplies a headless axis mapping plus tick policy
 //! - this crate returns tick positions plus their semantic kind
 //! - the caller formats tick labels appropriate to its own domain
 //!
@@ -32,12 +28,13 @@
 //!
 //! ```rust
 //! use understory_axis::{
-//!     AxisMajorStepLadder, AxisScale1D, AxisScaleOptions, AxisSubdivisionPolicy,
-//!     AxisTickKind,
+//!     AxisMajorStepLadder, AxisMapping1D, AxisScale1D, AxisScaleOptions,
+//!     AxisSubdivisionPolicy, AxisTickKind,
 //! };
 //!
-//! let scale = AxisScale1D::with_options(
-//!     0.5,
+//! let mapping = AxisMapping1D::linear(0.0..200.0, 0.0..100.0);
+//! let scale = AxisScale1D::from_mapping(
+//!     &mapping,
 //!     AxisScaleOptions {
 //!         target_major_spacing_px: 100.0,
 //!         min_major_step: 0.0,
@@ -168,15 +165,175 @@ pub enum AxisSubdivisionPolicy {
     Fixed(usize),
 }
 
-/// A derived 1D axis scale over a continuous numeric domain.
+/// A headless 1D axis mapping over a visible domain range and view span.
+#[derive(Clone, Debug, PartialEq)]
+pub enum AxisMapping1D {
+    /// Linear mapping with a constant domain-units-per-pixel ratio.
+    Linear(AxisLinearMapping1D),
+    /// Logarithmic mapping over a positive domain.
+    Log(AxisLogMapping1D),
+}
+
+impl AxisMapping1D {
+    /// Creates a linear mapping for a visible domain and view span.
+    #[must_use]
+    pub fn linear(view_span: Range<f64>, visible_domain: Range<f64>) -> Self {
+        Self::Linear(AxisLinearMapping1D {
+            view_span,
+            visible_domain,
+        })
+    }
+
+    /// Creates a logarithmic mapping for a visible positive domain and view span.
+    ///
+    /// Invalid bases fall back to `10.0`.
+    #[must_use]
+    pub fn log(view_span: Range<f64>, visible_domain: Range<f64>, base: f64) -> Self {
+        Self::Log(AxisLogMapping1D {
+            view_span,
+            visible_domain,
+            base: normalized_log_base(base),
+        })
+    }
+
+    /// Returns the current view span in device coordinates.
+    #[must_use]
+    pub fn view_span(&self) -> Range<f64> {
+        match self {
+            Self::Linear(mapping) => mapping.view_span.clone(),
+            Self::Log(mapping) => mapping.view_span.clone(),
+        }
+    }
+
+    /// Returns the currently visible domain range.
+    #[must_use]
+    pub fn visible_domain(&self) -> Range<f64> {
+        match self {
+            Self::Linear(mapping) => mapping.visible_domain.clone(),
+            Self::Log(mapping) => mapping.visible_domain.clone(),
+        }
+    }
+
+    /// Maps a domain value into the view span.
+    #[must_use]
+    pub fn domain_to_view(&self, value: f64) -> f64 {
+        match self {
+            Self::Linear(mapping) => mapping.domain_to_view(value),
+            Self::Log(mapping) => mapping.domain_to_view(value),
+        }
+    }
+
+    /// Maps a view coordinate back into the domain.
+    #[must_use]
+    pub fn view_to_domain(&self, value: f64) -> f64 {
+        match self {
+            Self::Linear(mapping) => mapping.view_to_domain(value),
+            Self::Log(mapping) => mapping.view_to_domain(value),
+        }
+    }
+}
+
+/// Linear 1D axis mapping with a constant domain-units-per-pixel ratio.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AxisLinearMapping1D {
+    view_span: Range<f64>,
+    visible_domain: Range<f64>,
+}
+
+impl AxisLinearMapping1D {
+    fn domain_to_view(&self, value: f64) -> f64 {
+        let domain_len = self.visible_domain.end - self.visible_domain.start;
+        let view_len = self.view_span.end - self.view_span.start;
+        if domain_len == 0.0 {
+            return self.view_span.start;
+        }
+        self.view_span.start + (value - self.visible_domain.start) * view_len / domain_len
+    }
+
+    fn view_to_domain(&self, value: f64) -> f64 {
+        let view_len = self.view_span.end - self.view_span.start;
+        let domain_len = self.visible_domain.end - self.visible_domain.start;
+        if view_len == 0.0 {
+            return self.visible_domain.start;
+        }
+        self.visible_domain.start + (value - self.view_span.start) * domain_len / view_len
+    }
+}
+
+/// Logarithmic 1D axis mapping over a positive domain.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AxisLogMapping1D {
+    view_span: Range<f64>,
+    visible_domain: Range<f64>,
+    base: f64,
+}
+
+impl AxisLogMapping1D {
+    fn domain_to_view(&self, value: f64) -> f64 {
+        let min = self.visible_domain.start.min(self.visible_domain.end);
+        let max = self.visible_domain.start.max(self.visible_domain.end);
+        if value <= 0.0 || min <= 0.0 || max <= 0.0 {
+            return self.view_span.start;
+        }
+        let log_min = log_in_base(min, self.base);
+        let log_max = log_in_base(max, self.base);
+        let view_len = self.view_span.end - self.view_span.start;
+        if log_max == log_min {
+            return self.view_span.start;
+        }
+        self.view_span.start
+            + (log_in_base(value, self.base) - log_min) * view_len / (log_max - log_min)
+    }
+
+    fn view_to_domain(&self, value: f64) -> f64 {
+        let min = self.visible_domain.start.min(self.visible_domain.end);
+        let max = self.visible_domain.start.max(self.visible_domain.end);
+        if min <= 0.0 || max <= 0.0 {
+            return min.max(f64::MIN_POSITIVE);
+        }
+        let log_min = log_in_base(min, self.base);
+        let log_max = log_in_base(max, self.base);
+        let view_len = self.view_span.end - self.view_span.start;
+        if view_len == 0.0 {
+            return min;
+        }
+        let log_value = log_min + (value - self.view_span.start) * (log_max - log_min) / view_len;
+        libm::pow(self.base, log_value)
+    }
+}
+
+/// A derived 1D axis tick guide over a numeric mapping.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct AxisScale1D {
-    world_units_per_pixel: f64,
-    major_step: f64,
-    minor_step: f64,
-    subdivisions: usize,
-    medium_interval: Option<usize>,
-    medium_labels: bool,
+    kind: AxisScaleKind,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum AxisScaleKind {
+    Linear {
+        world_units_per_pixel: f64,
+        major_step: f64,
+        minor_step: f64,
+        subdivisions: usize,
+        medium_interval: Option<usize>,
+        medium_labels: bool,
+    },
+    Log {
+        base: f64,
+        log_units_per_pixel: f64,
+        major_log_step: f64,
+        subdivisions: usize,
+        medium_interval: Option<usize>,
+        medium_labels: bool,
+        subdivision_mode: LogSubdivisionMode,
+    },
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum LogSubdivisionMode {
+    None,
+    IntegerMultiples { base_int: usize },
+    EvenLogIntervals,
 }
 
 impl AxisScale1D {
@@ -189,6 +346,31 @@ impl AxisScale1D {
     /// Derive a scale from a world-units-per-pixel ratio and explicit options.
     #[must_use]
     pub fn with_options(world_units_per_pixel: f64, options: AxisScaleOptions) -> Self {
+        Self::linear_from_world_units_per_pixel(world_units_per_pixel, options)
+    }
+
+    /// Derive a scale from an explicit axis mapping and tick policy.
+    #[must_use]
+    pub fn from_mapping(mapping: &AxisMapping1D, options: AxisScaleOptions) -> Self {
+        match mapping {
+            AxisMapping1D::Linear(mapping) => {
+                let view_len = (mapping.view_span.end - mapping.view_span.start).abs();
+                let domain_len = (mapping.visible_domain.end - mapping.visible_domain.start).abs();
+                let world_units_per_pixel = if view_len > 0.0 {
+                    domain_len / view_len
+                } else {
+                    f64::MIN_POSITIVE
+                };
+                Self::linear_from_world_units_per_pixel(world_units_per_pixel, options)
+            }
+            AxisMapping1D::Log(mapping) => Self::log_from_mapping(mapping, options),
+        }
+    }
+
+    fn linear_from_world_units_per_pixel(
+        world_units_per_pixel: f64,
+        options: AxisScaleOptions,
+    ) -> Self {
         let world_units_per_pixel = world_units_per_pixel.abs().max(f64::MIN_POSITIVE);
         let target_major_step = world_units_per_pixel * options.target_major_spacing_px;
         let major_step = choose_step(
@@ -210,138 +392,365 @@ impl AxisScale1D {
         let medium_labels = major_spacing_px >= options.medium_label_min_spacing_px;
 
         Self {
-            world_units_per_pixel,
-            major_step,
-            minor_step,
-            subdivisions,
-            medium_interval,
-            medium_labels,
+            kind: AxisScaleKind::Linear {
+                world_units_per_pixel,
+                major_step,
+                minor_step,
+                subdivisions,
+                medium_interval,
+                medium_labels,
+            },
         }
     }
 
-    /// Returns the world-units-per-pixel ratio used to derive this axis scale.
-    #[must_use]
-    pub fn world_units_per_pixel(&self) -> f64 {
-        self.world_units_per_pixel
-    }
-
-    /// Returns the derived major step in world units.
-    #[must_use]
-    pub fn major_step(&self) -> f64 {
-        self.major_step
-    }
-
-    /// Returns the step in world units implied by the smallest label-eligible ticks.
-    #[must_use]
-    pub fn label_step(&self) -> f64 {
-        if self.medium_labels {
-            self.medium_step().unwrap_or(self.major_step)
+    fn log_from_mapping(mapping: &AxisLogMapping1D, options: AxisScaleOptions) -> Self {
+        let min = mapping.visible_domain.start.min(mapping.visible_domain.end);
+        let max = mapping.visible_domain.start.max(mapping.visible_domain.end);
+        let view_len = (mapping.view_span.end - mapping.view_span.start)
+            .abs()
+            .max(f64::MIN_POSITIVE);
+        let log_units_per_pixel = if min > 0.0 && max > 0.0 {
+            (log_in_base(max, mapping.base) - log_in_base(min, mapping.base)).abs() / view_len
         } else {
-            self.major_step
+            f64::MIN_POSITIVE
+        };
+        let target_major_step = log_units_per_pixel * options.target_major_spacing_px;
+        let major_log_step = choose_log_major_step(target_major_step.max(1e-12));
+        let major_spacing_px = major_log_step / log_units_per_pixel.max(f64::MIN_POSITIVE);
+        let medium_labels = major_spacing_px >= options.medium_label_min_spacing_px;
+        let (subdivisions, medium_interval, subdivision_mode) =
+            derive_log_subdivision_mode(mapping.base, major_log_step, options.subdivision_policy);
+
+        Self {
+            kind: AxisScaleKind::Log {
+                base: mapping.base,
+                log_units_per_pixel,
+                major_log_step,
+                subdivisions,
+                medium_interval,
+                medium_labels,
+                subdivision_mode,
+            },
         }
     }
 
-    /// Returns the derived medium step in world units when the scale has one.
+    /// Returns the domain-units-per-pixel ratio used to derive this axis scale when constant.
+    #[must_use]
+    pub fn world_units_per_pixel(&self) -> Option<f64> {
+        match self.kind {
+            AxisScaleKind::Linear {
+                world_units_per_pixel,
+                ..
+            } => Some(world_units_per_pixel),
+            AxisScaleKind::Log { .. } => None,
+        }
+    }
+
+    /// Returns the derived major step in domain units when the axis has a uniform domain step.
+    #[must_use]
+    pub fn major_step(&self) -> Option<f64> {
+        match self.kind {
+            AxisScaleKind::Linear { major_step, .. } => Some(major_step),
+            AxisScaleKind::Log { .. } => None,
+        }
+    }
+
+    /// Returns the step in domain units implied by the smallest label-eligible ticks when uniform.
+    #[must_use]
+    pub fn label_step(&self) -> Option<f64> {
+        match self.kind {
+            AxisScaleKind::Linear {
+                major_step,
+                minor_step,
+                medium_interval,
+                medium_labels,
+                ..
+            } => {
+                if medium_labels {
+                    Some(
+                        medium_interval
+                            .map(|interval| minor_step * interval as f64)
+                            .unwrap_or(major_step),
+                    )
+                } else {
+                    Some(major_step)
+                }
+            }
+            AxisScaleKind::Log { .. } => None,
+        }
+    }
+
+    /// Returns the derived medium step in domain units when the axis has a uniform domain step.
     #[must_use]
     pub fn medium_step(&self) -> Option<f64> {
-        self.medium_interval
-            .map(|interval| self.minor_step * interval as f64)
+        match self.kind {
+            AxisScaleKind::Linear {
+                minor_step,
+                medium_interval,
+                ..
+            } => medium_interval.map(|interval| minor_step * interval as f64),
+            AxisScaleKind::Log { .. } => None,
+        }
     }
 
-    /// Returns the derived minor step in world units.
+    /// Returns the derived minor step in domain units when the axis has a uniform domain step.
     #[must_use]
-    pub fn minor_step(&self) -> f64 {
-        self.minor_step
+    pub fn minor_step(&self) -> Option<f64> {
+        match self.kind {
+            AxisScaleKind::Linear { minor_step, .. } => Some(minor_step),
+            AxisScaleKind::Log { .. } => None,
+        }
     }
 
-    /// Returns the spacing in pixels between major ticks.
+    /// Returns the spacing in pixels between major ticks when uniform in view space.
     #[must_use]
-    pub fn major_spacing_px(&self) -> f64 {
-        self.major_step / self.world_units_per_pixel
+    pub fn major_spacing_px(&self) -> Option<f64> {
+        match self.kind {
+            AxisScaleKind::Linear {
+                world_units_per_pixel,
+                major_step,
+                ..
+            } => Some(major_step / world_units_per_pixel),
+            AxisScaleKind::Log {
+                log_units_per_pixel,
+                major_log_step,
+                ..
+            } => Some(major_log_step / log_units_per_pixel),
+        }
     }
 
-    /// Returns the spacing in pixels between medium ticks when the scale has one.
+    /// Returns the spacing in pixels between medium ticks when it is uniform in view space.
     #[must_use]
     pub fn medium_spacing_px(&self) -> Option<f64> {
-        self.medium_step()
-            .map(|step| step / self.world_units_per_pixel)
+        match self.kind {
+            AxisScaleKind::Linear {
+                world_units_per_pixel,
+                minor_step,
+                medium_interval,
+                ..
+            } => {
+                medium_interval.map(|interval| minor_step * interval as f64 / world_units_per_pixel)
+            }
+            AxisScaleKind::Log {
+                log_units_per_pixel,
+                major_log_step,
+                medium_interval,
+                subdivision_mode: LogSubdivisionMode::EvenLogIntervals,
+                ..
+            } => medium_interval.map(|interval| {
+                let log_step = major_log_step / interval as f64;
+                log_step / log_units_per_pixel
+            }),
+            AxisScaleKind::Log { .. } => None,
+        }
     }
 
-    /// Returns the spacing in pixels between minor ticks.
+    /// Returns the spacing in pixels between minor ticks when it is uniform in view space.
     #[must_use]
-    pub fn minor_spacing_px(&self) -> f64 {
-        self.minor_step / self.world_units_per_pixel
+    pub fn minor_spacing_px(&self) -> Option<f64> {
+        match self.kind {
+            AxisScaleKind::Linear {
+                world_units_per_pixel,
+                minor_step,
+                ..
+            } => Some(minor_step / world_units_per_pixel),
+            AxisScaleKind::Log {
+                log_units_per_pixel,
+                major_log_step,
+                subdivisions,
+                subdivision_mode: LogSubdivisionMode::EvenLogIntervals,
+                ..
+            } => Some((major_log_step / subdivisions as f64) / log_units_per_pixel),
+            AxisScaleKind::Log { .. } => None,
+        }
     }
 
     /// Returns whether medium ticks are eligible for labeling under this scale.
     #[must_use]
     pub fn medium_ticks_are_labeled(&self) -> bool {
-        self.medium_labels
+        match self.kind {
+            AxisScaleKind::Linear { medium_labels, .. } => medium_labels,
+            AxisScaleKind::Log { medium_labels, .. } => medium_labels,
+        }
     }
 
     /// Iterates ticks covering the provided visible range plus one minor step on each side.
     #[must_use]
     pub fn iter_ticks_in_range(&self, visible: Range<f64>) -> AxisTicksIter {
         AxisTicksIter {
-            scale: *self,
-            visible_start: visible.start,
-            visible_end: visible.end,
-            next_index: floor_to_i64(visible.start / self.minor_step) - 1,
-            end_index: ceil_to_i64(visible.end / self.minor_step) + 1,
+            inner: self.ticks_in_range(visible).into_iter(),
         }
     }
 
     /// Returns ticks covering the provided visible range plus one minor step on each side.
     #[must_use]
     pub fn ticks_in_range(&self, visible: Range<f64>) -> Vec<AxisTick> {
-        self.iter_ticks_in_range(visible).collect()
+        match self.kind {
+            AxisScaleKind::Linear {
+                minor_step,
+                subdivisions,
+                medium_interval,
+                medium_labels,
+                ..
+            } => build_linear_ticks(
+                visible,
+                minor_step,
+                subdivisions,
+                medium_interval,
+                medium_labels,
+            ),
+            AxisScaleKind::Log {
+                base,
+                major_log_step,
+                subdivisions,
+                medium_interval,
+                medium_labels,
+                subdivision_mode,
+                ..
+            } => build_log_ticks(
+                visible,
+                base,
+                major_log_step,
+                subdivisions,
+                medium_interval,
+                medium_labels,
+                subdivision_mode,
+            ),
+        }
     }
 }
 
 /// Iterator over ticks produced by an [`AxisScale1D`] for a visible numeric range.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct AxisTicksIter {
-    scale: AxisScale1D,
-    visible_start: f64,
-    visible_end: f64,
-    next_index: i64,
-    end_index: i64,
+    inner: alloc::vec::IntoIter<AxisTick>,
 }
 
 impl Iterator for AxisTicksIter {
     type Item = AxisTick;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while self.next_index <= self.end_index {
-            let index = self.next_index;
-            self.next_index += 1;
-            let value = index as f64 * self.scale.minor_step;
-            if value < self.visible_start - self.scale.minor_step
-                || value > self.visible_end + self.scale.minor_step
-            {
-                continue;
-            }
-            let sub_index = usize::try_from(index.rem_euclid(self.scale.subdivisions as i64))
-                .expect("rem_euclid stays within subdivision count");
-            let (kind, labeled) = if sub_index == 0 {
-                (AxisTickKind::Major, true)
-            } else if self
-                .scale
-                .medium_interval
-                .is_some_and(|interval| sub_index.is_multiple_of(interval))
-            {
-                (AxisTickKind::Medium, self.scale.medium_labels)
-            } else {
-                (AxisTickKind::Minor, false)
-            };
-            return Some(AxisTick {
-                value,
-                kind,
-                labeled,
-            });
-        }
+        self.inner.next()
+    }
+}
 
-        None
+fn build_linear_ticks(
+    visible: Range<f64>,
+    minor_step: f64,
+    subdivisions: usize,
+    medium_interval: Option<usize>,
+    medium_labels: bool,
+) -> Vec<AxisTick> {
+    let start_index = floor_to_i64(visible.start / minor_step) - 1;
+    let end_index = ceil_to_i64(visible.end / minor_step) + 1;
+    let mut ticks = Vec::new();
+
+    for index in start_index..=end_index {
+        let value = index as f64 * minor_step;
+        if value < visible.start - minor_step || value > visible.end + minor_step {
+            continue;
+        }
+        let sub_index = usize::try_from(index.rem_euclid(subdivisions as i64))
+            .expect("rem_euclid stays within subdivision count");
+        let (kind, labeled) = if sub_index == 0 {
+            (AxisTickKind::Major, true)
+        } else if medium_interval.is_some_and(|interval| sub_index.is_multiple_of(interval)) {
+            (AxisTickKind::Medium, medium_labels)
+        } else {
+            (AxisTickKind::Minor, false)
+        };
+        ticks.push(AxisTick {
+            value,
+            kind,
+            labeled,
+        });
+    }
+
+    ticks
+}
+
+fn build_log_ticks(
+    visible: Range<f64>,
+    base: f64,
+    major_log_step: f64,
+    subdivisions: usize,
+    medium_interval: Option<usize>,
+    medium_labels: bool,
+    subdivision_mode: LogSubdivisionMode,
+) -> Vec<AxisTick> {
+    let min = visible.start.min(visible.end).max(f64::MIN_POSITIVE);
+    let max = visible.start.max(visible.end);
+    if !min.is_finite() || !max.is_finite() || max <= 0.0 {
+        return Vec::new();
+    }
+
+    let log_min = log_in_base(min, base);
+    let log_max = log_in_base(max.max(min), base);
+    let start_index = floor_to_i64(log_min / major_log_step) - 1;
+    let end_index = ceil_to_i64(log_max / major_log_step) + 1;
+    let mut ticks = Vec::new();
+
+    for major_index in start_index..=end_index {
+        let major_log = major_index as f64 * major_log_step;
+        match subdivision_mode {
+            LogSubdivisionMode::None => push_log_tick(
+                &mut ticks,
+                libm::pow(base, major_log),
+                min,
+                max,
+                AxisTickKind::Major,
+                true,
+            ),
+            LogSubdivisionMode::IntegerMultiples { base_int } => {
+                let decade_value = libm::pow(base, major_log);
+                let medium_factor = integer_multiple_medium_factor(base_int);
+                for factor in 1..base_int {
+                    let value = decade_value * factor as f64;
+                    let (kind, labeled) = if factor == 1 {
+                        (AxisTickKind::Major, true)
+                    } else if Some(factor) == medium_factor {
+                        (AxisTickKind::Medium, medium_labels)
+                    } else {
+                        (AxisTickKind::Minor, false)
+                    };
+                    push_log_tick(&mut ticks, value, min, max, kind, labeled);
+                }
+            }
+            LogSubdivisionMode::EvenLogIntervals => {
+                let medium_index = medium_interval.unwrap_or(0);
+                let log_minor_step = major_log_step / subdivisions as f64;
+                for sub_index in 0..subdivisions {
+                    let value = libm::pow(base, major_log + sub_index as f64 * log_minor_step);
+                    let (kind, labeled) = if sub_index == 0 {
+                        (AxisTickKind::Major, true)
+                    } else if medium_interval.is_some_and(|_| sub_index == medium_index) {
+                        (AxisTickKind::Medium, medium_labels)
+                    } else {
+                        (AxisTickKind::Minor, false)
+                    };
+                    push_log_tick(&mut ticks, value, min, max, kind, labeled);
+                }
+            }
+        }
+    }
+
+    ticks
+}
+
+fn push_log_tick(
+    ticks: &mut Vec<AxisTick>,
+    value: f64,
+    min: f64,
+    max: f64,
+    kind: AxisTickKind,
+    labeled: bool,
+) {
+    if value.is_finite() && value >= min && value <= max {
+        ticks.push(AxisTick {
+            value,
+            kind,
+            labeled,
+        });
     }
 }
 
@@ -365,6 +774,10 @@ fn choose_step(target: f64, ladder: AxisMajorStepLadder) -> f64 {
             choose_time_like_step(target, units_per_second)
         }
     }
+}
+
+fn choose_log_major_step(target: f64) -> f64 {
+    choose_decimal_125_step(target)
 }
 
 fn choose_decimal_125_step(target: f64) -> f64 {
@@ -410,6 +823,18 @@ fn choose_time_like_step(target: f64, units_per_second: f64) -> f64 {
     choose_decimal_125_step(target_seconds / 86_400.0) * 86_400.0 * units_per_second
 }
 
+fn normalized_log_base(base: f64) -> f64 {
+    if base.is_finite() && base > 0.0 && !approx_eq(base, 1.0) {
+        base
+    } else {
+        10.0
+    }
+}
+
+fn log_in_base(value: f64, base: f64) -> f64 {
+    libm::log(value) / libm::log(normalized_log_base(base))
+}
+
 fn subdivisions_for_step(
     step: f64,
     ladder: AxisMajorStepLadder,
@@ -427,6 +852,43 @@ fn auto_subdivisions_for_step(step: f64, ladder: AxisMajorStepLadder) -> usize {
         AxisMajorStepLadder::BinaryPowerOfTwo => 4,
         AxisMajorStepLadder::TimeLike { units_per_second } => {
             time_like_subdivisions(step, units_per_second)
+        }
+    }
+}
+
+fn derive_log_subdivision_mode(
+    base: f64,
+    major_log_step: f64,
+    policy: AxisSubdivisionPolicy,
+) -> (usize, Option<usize>, LogSubdivisionMode) {
+    match policy {
+        AxisSubdivisionPolicy::Fixed(count) => {
+            let subdivisions = count.max(1);
+            let medium_interval = if subdivisions.is_multiple_of(2) {
+                Some(subdivisions / 2)
+            } else {
+                None
+            };
+            let mode = if subdivisions > 1 {
+                LogSubdivisionMode::EvenLogIntervals
+            } else {
+                LogSubdivisionMode::None
+            };
+            (subdivisions, medium_interval, mode)
+        }
+        AxisSubdivisionPolicy::Auto => {
+            if approx_eq(major_log_step, 1.0)
+                && let Some(base_int) = small_integer_base(base)
+                && base_int > 2
+            {
+                (
+                    base_int - 1,
+                    None,
+                    LogSubdivisionMode::IntegerMultiples { base_int },
+                )
+            } else {
+                (1, None, LogSubdivisionMode::None)
+            }
         }
     }
 }
@@ -450,6 +912,32 @@ fn decimal_125_subdivisions(step: f64) -> usize {
         4
     } else {
         5
+    }
+}
+
+fn small_integer_base(base: f64) -> Option<usize> {
+    let rounded = libm::round(base);
+    if approx_eq(base, rounded) && (2.0..=16.0).contains(&rounded) {
+        #[expect(
+            clippy::cast_sign_loss,
+            clippy::cast_possible_truncation,
+            reason = "bounded to a small positive integer range"
+        )]
+        {
+            Some(rounded as usize)
+        }
+    } else {
+        None
+    }
+}
+
+fn integer_multiple_medium_factor(base_int: usize) -> Option<usize> {
+    if base_int >= 4 && base_int.is_multiple_of(2) {
+        Some(base_int / 2)
+    } else if base_int >= 5 {
+        Some(5.min(base_int - 1))
+    } else {
+        None
     }
 }
 
@@ -523,14 +1011,18 @@ mod tests {
     use alloc::vec::Vec;
 
     use super::{
-        AxisMajorStepLadder, AxisScale1D, AxisScaleOptions, AxisSubdivisionPolicy, AxisTickKind,
+        AxisMajorStepLadder, AxisMapping1D, AxisScale1D, AxisScaleOptions, AxisSubdivisionPolicy,
+        AxisTickKind,
     };
 
     #[test]
     fn larger_world_units_produce_larger_major_steps() {
         let coarse = AxisScale1D::new(2.0);
         let fine = AxisScale1D::new(0.2);
-        assert!(coarse.major_step() > fine.major_step());
+        assert!(
+            coarse.major_step().expect("linear scale has a major step")
+                > fine.major_step().expect("linear scale has a major step")
+        );
     }
 
     #[test]
@@ -582,8 +1074,16 @@ mod tests {
                 subdivision_policy: AxisSubdivisionPolicy::Auto,
             },
         );
-        assert!((scale.major_spacing_px() - scale.major_step() / 0.5).abs() < 1e-9);
-        assert!((scale.minor_spacing_px() - scale.minor_step() / 0.5).abs() < 1e-9);
+        let major_step = scale.major_step().expect("linear scale has a major step");
+        let minor_step = scale.minor_step().expect("linear scale has a minor step");
+        let major_spacing = scale
+            .major_spacing_px()
+            .expect("linear scale has major spacing");
+        let minor_spacing = scale
+            .minor_spacing_px()
+            .expect("linear scale has minor spacing");
+        assert!((major_spacing - major_step / 0.5).abs() < 1e-9);
+        assert!((minor_spacing - minor_step / 0.5).abs() < 1e-9);
         if let Some(medium_step) = scale.medium_step() {
             let medium_spacing = scale
                 .medium_spacing_px()
@@ -604,9 +1104,9 @@ mod tests {
                 subdivision_policy: AxisSubdivisionPolicy::Auto,
             },
         );
-        assert_eq!(scale.major_step(), 8.0);
+        assert_eq!(scale.major_step(), Some(8.0));
         assert_eq!(scale.medium_step(), Some(4.0));
-        assert_eq!(scale.minor_step(), 2.0);
+        assert_eq!(scale.minor_step(), Some(2.0));
     }
 
     #[test]
@@ -635,7 +1135,10 @@ mod tests {
         );
         assert_eq!(
             fine.label_step(),
-            fine.medium_step().unwrap_or(fine.major_step())
+            Some(
+                fine.medium_step()
+                    .unwrap_or(fine.major_step().expect("linear scale has a major step"))
+            )
         );
     }
 
@@ -653,8 +1156,8 @@ mod tests {
                 subdivision_policy: AxisSubdivisionPolicy::Auto,
             },
         );
-        assert_eq!(scale.major_step(), 15_000.0);
-        assert_eq!(scale.minor_step(), 5_000.0);
+        assert_eq!(scale.major_step(), Some(15_000.0));
+        assert_eq!(scale.minor_step(), Some(5_000.0));
     }
 
     #[test]
@@ -669,8 +1172,50 @@ mod tests {
                 subdivision_policy: AxisSubdivisionPolicy::Fixed(8),
             },
         );
-        assert_eq!(scale.major_step(), 8.0);
-        assert_eq!(scale.minor_step(), 1.0);
+        assert_eq!(scale.major_step(), Some(8.0));
+        assert_eq!(scale.minor_step(), Some(1.0));
         assert_eq!(scale.medium_step(), Some(4.0));
+    }
+
+    #[test]
+    fn explicit_linear_mapping_matches_linear_convenience() {
+        let mapping = AxisMapping1D::linear(20.0..220.0, 50.0..150.0);
+        let from_mapping = AxisScale1D::from_mapping(&mapping, AxisScaleOptions::default());
+        let from_ratio = AxisScale1D::with_options(0.5, AxisScaleOptions::default());
+        assert_eq!(from_mapping.major_step(), from_ratio.major_step());
+        assert_eq!(from_mapping.minor_step(), from_ratio.minor_step());
+    }
+
+    #[test]
+    fn log_mapping_generates_power_ticks_without_uniform_domain_step() {
+        let mapping = AxisMapping1D::log(0.0..300.0, 1.0..1_000.0, 10.0);
+        let scale = AxisScale1D::from_mapping(&mapping, AxisScaleOptions::default());
+        let ticks = scale.ticks_in_range(1.0..1_000.0);
+        assert!(
+            ticks
+                .iter()
+                .any(|tick| tick.value == 1.0 && tick.kind == AxisTickKind::Major)
+        );
+        assert!(
+            ticks
+                .iter()
+                .any(|tick| tick.value == 10.0 && tick.kind == AxisTickKind::Major)
+        );
+        assert!(
+            ticks
+                .iter()
+                .any(|tick| tick.value == 100.0 && tick.kind == AxisTickKind::Major)
+        );
+        assert_eq!(scale.major_step(), None);
+        assert_eq!(scale.label_step(), None);
+    }
+
+    #[test]
+    fn log_mapping_round_trips_domain_and_view_values() {
+        let mapping = AxisMapping1D::log(10.0..210.0, 1.0..100.0, 10.0);
+        let value = 10.0;
+        let view = mapping.domain_to_view(value);
+        let round_trip = mapping.view_to_domain(view);
+        assert!((round_trip - value).abs() < 1e-9);
     }
 }

--- a/understory_axis/src/lib.rs
+++ b/understory_axis/src/lib.rs
@@ -10,6 +10,7 @@
 //! - major / medium / minor tick selection
 //! - 1-2-5 step sizing
 //! - label eligibility decisions based on spacing thresholds
+//! - spacing metadata for callers that need consistent axis-derived policy
 //!
 //! It does not own:
 //! - domain-specific label formatting
@@ -36,7 +37,7 @@
 //!     },
 //! );
 //!
-//! let ticks = scale.ticks_in_range(0.0..100.0);
+//! let ticks: std::vec::Vec<_> = scale.iter_ticks_in_range(0.0..100.0).collect();
 //! assert!(ticks.iter().any(|tick| tick.kind == AxisTickKind::Major && tick.labeled));
 //! ```
 //!
@@ -95,6 +96,7 @@ impl Default for AxisScaleOptions {
 /// A derived 1D axis scale over a continuous numeric domain.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct AxisScale1D {
+    world_units_per_pixel: f64,
     major_step: f64,
     minor_step: f64,
     subdivisions: usize,
@@ -112,7 +114,8 @@ impl AxisScale1D {
     /// Derive a scale from a world-units-per-pixel ratio and explicit options.
     #[must_use]
     pub fn with_options(world_units_per_pixel: f64, options: AxisScaleOptions) -> Self {
-        let target_major_step = world_units_per_pixel.abs() * options.target_major_spacing_px;
+        let world_units_per_pixel = world_units_per_pixel.abs().max(f64::MIN_POSITIVE);
+        let target_major_step = world_units_per_pixel * options.target_major_spacing_px;
         let major_step = choose_step(target_major_step.max(options.min_major_step).max(1e-12));
         let subdivisions = subdivisions_for_step(major_step);
         let minor_step = major_step / subdivisions as f64;
@@ -121,10 +124,11 @@ impl AxisScale1D {
         } else {
             None
         };
-        let major_spacing_px = major_step / world_units_per_pixel.abs().max(f64::MIN_POSITIVE);
+        let major_spacing_px = major_step / world_units_per_pixel;
         let medium_labels = major_spacing_px >= options.medium_label_min_spacing_px;
 
         Self {
+            world_units_per_pixel,
             major_step,
             minor_step,
             subdivisions,
@@ -133,10 +137,23 @@ impl AxisScale1D {
         }
     }
 
+    /// Returns the world-units-per-pixel ratio used to derive this axis scale.
+    #[must_use]
+    pub fn world_units_per_pixel(&self) -> f64 {
+        self.world_units_per_pixel
+    }
+
     /// Returns the derived major step in world units.
     #[must_use]
     pub fn major_step(&self) -> f64 {
         self.major_step
+    }
+
+    /// Returns the derived medium step in world units when the scale has one.
+    #[must_use]
+    pub fn medium_step(&self) -> Option<f64> {
+        self.medium_interval
+            .map(|interval| self.minor_step * interval as f64)
     }
 
     /// Returns the derived minor step in world units.
@@ -145,38 +162,94 @@ impl AxisScale1D {
         self.minor_step
     }
 
+    /// Returns the spacing in pixels between major ticks.
+    #[must_use]
+    pub fn major_spacing_px(&self) -> f64 {
+        self.major_step / self.world_units_per_pixel
+    }
+
+    /// Returns the spacing in pixels between medium ticks when the scale has one.
+    #[must_use]
+    pub fn medium_spacing_px(&self) -> Option<f64> {
+        self.medium_step()
+            .map(|step| step / self.world_units_per_pixel)
+    }
+
+    /// Returns the spacing in pixels between minor ticks.
+    #[must_use]
+    pub fn minor_spacing_px(&self) -> f64 {
+        self.minor_step / self.world_units_per_pixel
+    }
+
+    /// Returns whether medium ticks are eligible for labeling under this scale.
+    #[must_use]
+    pub fn medium_ticks_are_labeled(&self) -> bool {
+        self.medium_labels
+    }
+
+    /// Iterates ticks covering the provided visible range plus one minor step on each side.
+    #[must_use]
+    pub fn iter_ticks_in_range(&self, visible: Range<f64>) -> AxisTicksIter {
+        AxisTicksIter {
+            scale: *self,
+            visible_start: visible.start,
+            visible_end: visible.end,
+            next_index: floor_to_i64(visible.start / self.minor_step) - 1,
+            end_index: ceil_to_i64(visible.end / self.minor_step) + 1,
+        }
+    }
+
     /// Returns ticks covering the provided visible range plus one minor step on each side.
     #[must_use]
     pub fn ticks_in_range(&self, visible: Range<f64>) -> Vec<AxisTick> {
-        let start_index = floor_to_i64(visible.start / self.minor_step) - 1;
-        let end_index = ceil_to_i64(visible.end / self.minor_step) + 1;
-        let mut ticks = Vec::new();
+        self.iter_ticks_in_range(visible).collect()
+    }
+}
 
-        for index in start_index..=end_index {
-            let value = index as f64 * self.minor_step;
-            if value < visible.start - self.minor_step || value > visible.end + self.minor_step {
+/// Iterator over ticks produced by an [`AxisScale1D`] for a visible numeric range.
+#[derive(Clone, Debug)]
+pub struct AxisTicksIter {
+    scale: AxisScale1D,
+    visible_start: f64,
+    visible_end: f64,
+    next_index: i64,
+    end_index: i64,
+}
+
+impl Iterator for AxisTicksIter {
+    type Item = AxisTick;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.next_index <= self.end_index {
+            let index = self.next_index;
+            self.next_index += 1;
+            let value = index as f64 * self.scale.minor_step;
+            if value < self.visible_start - self.scale.minor_step
+                || value > self.visible_end + self.scale.minor_step
+            {
                 continue;
             }
-            let sub_index = usize::try_from(index.rem_euclid(self.subdivisions as i64))
+            let sub_index = usize::try_from(index.rem_euclid(self.scale.subdivisions as i64))
                 .expect("rem_euclid stays within subdivision count");
             let (kind, labeled) = if sub_index == 0 {
                 (AxisTickKind::Major, true)
             } else if self
+                .scale
                 .medium_interval
                 .is_some_and(|interval| sub_index.is_multiple_of(interval))
             {
-                (AxisTickKind::Medium, self.medium_labels)
+                (AxisTickKind::Medium, self.scale.medium_labels)
             } else {
                 (AxisTickKind::Minor, false)
             };
-            ticks.push(AxisTick {
+            return Some(AxisTick {
                 value,
                 kind,
                 labeled,
             });
         }
 
-        ticks
+        None
     }
 }
 
@@ -252,6 +325,8 @@ fn ceil_to_i64(value: f64) -> i64 {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::{AxisScale1D, AxisScaleOptions, AxisTickKind};
 
     #[test]
@@ -286,5 +361,33 @@ mod tests {
         assert!(!ticks.is_empty());
         assert!(ticks.iter().any(|tick| tick.value <= 10.0));
         assert!(ticks.iter().any(|tick| tick.value >= 40.0));
+    }
+
+    #[test]
+    fn iterator_matches_vec_helper() {
+        let scale = AxisScale1D::new(0.25);
+        let via_iter: Vec<_> = scale.iter_ticks_in_range(-15.0..42.0).collect();
+        let via_vec = scale.ticks_in_range(-15.0..42.0);
+        assert_eq!(via_iter, via_vec);
+    }
+
+    #[test]
+    fn spacing_metadata_matches_steps() {
+        let scale = AxisScale1D::with_options(
+            0.5,
+            AxisScaleOptions {
+                target_major_spacing_px: 96.0,
+                min_major_step: 0.0,
+                medium_label_min_spacing_px: 220.0,
+            },
+        );
+        assert!((scale.major_spacing_px() - scale.major_step() / 0.5).abs() < 1e-9);
+        assert!((scale.minor_spacing_px() - scale.minor_step() / 0.5).abs() < 1e-9);
+        if let Some(medium_step) = scale.medium_step() {
+            let medium_spacing = scale
+                .medium_spacing_px()
+                .expect("medium step implies medium spacing");
+            assert!((medium_spacing - medium_step / 0.5).abs() < 1e-9);
+        }
     }
 }

--- a/understory_axis/src/lib.rs
+++ b/understory_axis/src/lib.rs
@@ -11,6 +11,7 @@
 //! - 1-2-5 step sizing
 //! - label eligibility decisions based on spacing thresholds
 //! - spacing metadata for callers that need consistent axis-derived policy
+//! - configurable numeric step ladders for different axis domains
 //!
 //! It does not own:
 //! - domain-specific label formatting
@@ -26,7 +27,7 @@
 //! ## Minimal example
 //!
 //! ```rust
-//! use understory_axis::{AxisScale1D, AxisScaleOptions, AxisTickKind};
+//! use understory_axis::{AxisScale1D, AxisScaleOptions, AxisStepLadder, AxisTickKind};
 //!
 //! let scale = AxisScale1D::with_options(
 //!     0.5,
@@ -34,6 +35,7 @@
 //!         target_major_spacing_px: 100.0,
 //!         min_major_step: 0.0,
 //!         medium_label_min_spacing_px: 220.0,
+//!         step_ladder: AxisStepLadder::Decimal125,
 //!     },
 //! );
 //!
@@ -81,6 +83,8 @@ pub struct AxisScaleOptions {
     pub min_major_step: f64,
     /// Minimum major spacing in pixels before medium ticks become label-eligible.
     pub medium_label_min_spacing_px: f64,
+    /// Numeric ladder used to choose major tick steps.
+    pub step_ladder: AxisStepLadder,
 }
 
 impl Default for AxisScaleOptions {
@@ -89,8 +93,21 @@ impl Default for AxisScaleOptions {
             target_major_spacing_px: 96.0,
             min_major_step: 0.0,
             medium_label_min_spacing_px: 220.0,
+            step_ladder: AxisStepLadder::Decimal125,
         }
     }
+}
+
+/// Numeric ladder used to choose major axis steps.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AxisStepLadder {
+    /// Decimal `1-2-5` major steps: `... 0.1, 0.2, 0.5, 1, 2, 5, 10 ...`.
+    Decimal125,
+    /// Binary power-of-two major steps: `... 1, 2, 4, 8, 16 ...`.
+    ///
+    /// This is useful for sample indices, memory-like domains, and other
+    /// quantities that naturally prefer binary breakpoints over decimal ones.
+    BinaryPowerOfTwo,
 }
 
 /// A derived 1D axis scale over a continuous numeric domain.
@@ -116,8 +133,11 @@ impl AxisScale1D {
     pub fn with_options(world_units_per_pixel: f64, options: AxisScaleOptions) -> Self {
         let world_units_per_pixel = world_units_per_pixel.abs().max(f64::MIN_POSITIVE);
         let target_major_step = world_units_per_pixel * options.target_major_spacing_px;
-        let major_step = choose_step(target_major_step.max(options.min_major_step).max(1e-12));
-        let subdivisions = subdivisions_for_step(major_step);
+        let major_step = choose_step(
+            target_major_step.max(options.min_major_step).max(1e-12),
+            options.step_ladder,
+        );
+        let subdivisions = subdivisions_for_step(major_step, options.step_ladder);
         let minor_step = major_step / subdivisions as f64;
         let medium_interval = if subdivisions.is_multiple_of(2) {
             Some(subdivisions / 2)
@@ -147,6 +167,16 @@ impl AxisScale1D {
     #[must_use]
     pub fn major_step(&self) -> f64 {
         self.major_step
+    }
+
+    /// Returns the step in world units implied by the smallest label-eligible ticks.
+    #[must_use]
+    pub fn label_step(&self) -> f64 {
+        if self.medium_labels {
+            self.medium_step().unwrap_or(self.major_step)
+        } else {
+            self.major_step
+        }
     }
 
     /// Returns the derived medium step in world units when the scale has one.
@@ -253,47 +283,69 @@ impl Iterator for AxisTicksIter {
     }
 }
 
-fn choose_step(target: f64) -> f64 {
-    let mut unit = 1.0_f64;
-    if target >= 1.0 {
-        while unit * 10.0 <= target {
-            unit *= 10.0;
+fn choose_step(target: f64, ladder: AxisStepLadder) -> f64 {
+    match ladder {
+        AxisStepLadder::Decimal125 => {
+            let mut unit = 1.0_f64;
+            if target >= 1.0 {
+                while unit * 10.0 <= target {
+                    unit *= 10.0;
+                }
+            } else {
+                while unit > target {
+                    unit /= 10.0;
+                }
+            }
+
+            for mantissa in [1.0_f64, 2.0, 5.0, 10.0] {
+                let step = mantissa * unit;
+                if step >= target {
+                    return step;
+                }
+            }
+
+            10.0 * unit
         }
-    } else {
-        while unit > target {
-            unit /= 10.0;
+        AxisStepLadder::BinaryPowerOfTwo => {
+            let mut step = 1.0_f64;
+            if target >= 1.0 {
+                while step < target {
+                    step *= 2.0;
+                }
+            } else {
+                while step * 0.5 >= target {
+                    step *= 0.5;
+                }
+            }
+            step
         }
     }
-
-    for mantissa in [1.0_f64, 2.0, 5.0, 10.0] {
-        let step = mantissa * unit;
-        if step >= target {
-            return step;
-        }
-    }
-
-    10.0 * unit
 }
 
-fn subdivisions_for_step(step: f64) -> usize {
-    let step = step.abs().max(1e-12);
-    let mut scale = 1.0_f64;
-    if step >= 1.0 {
-        while scale * 10.0 <= step {
-            scale *= 10.0;
+fn subdivisions_for_step(step: f64, ladder: AxisStepLadder) -> usize {
+    match ladder {
+        AxisStepLadder::Decimal125 => {
+            let step = step.abs().max(1e-12);
+            let mut scale = 1.0_f64;
+            if step >= 1.0 {
+                while scale * 10.0 <= step {
+                    scale *= 10.0;
+                }
+            } else {
+                while scale > step {
+                    scale /= 10.0;
+                }
+            }
+            let normalized = step / scale;
+            if normalized <= 1.0 + 1e-6 {
+                10
+            } else if normalized <= 2.0 + 1e-6 {
+                4
+            } else {
+                5
+            }
         }
-    } else {
-        while scale > step {
-            scale /= 10.0;
-        }
-    }
-    let normalized = step / scale;
-    if normalized <= 1.0 + 1e-6 {
-        10
-    } else if normalized <= 2.0 + 1e-6 {
-        4
-    } else {
-        5
+        AxisStepLadder::BinaryPowerOfTwo => 4,
     }
 }
 
@@ -327,7 +379,7 @@ fn ceil_to_i64(value: f64) -> i64 {
 mod tests {
     use alloc::vec::Vec;
 
-    use super::{AxisScale1D, AxisScaleOptions, AxisTickKind};
+    use super::{AxisScale1D, AxisScaleOptions, AxisStepLadder, AxisTickKind};
 
     #[test]
     fn larger_world_units_produce_larger_major_steps() {
@@ -344,6 +396,7 @@ mod tests {
                 target_major_spacing_px: 320.0,
                 min_major_step: 0.0,
                 medium_label_min_spacing_px: 220.0,
+                step_ladder: AxisStepLadder::Decimal125,
             },
         );
         let ticks = scale.ticks_in_range(0.0..100.0);
@@ -379,6 +432,7 @@ mod tests {
                 target_major_spacing_px: 96.0,
                 min_major_step: 0.0,
                 medium_label_min_spacing_px: 220.0,
+                step_ladder: AxisStepLadder::Decimal125,
             },
         );
         assert!((scale.major_spacing_px() - scale.major_step() / 0.5).abs() < 1e-9);
@@ -389,5 +443,49 @@ mod tests {
                 .expect("medium step implies medium spacing");
             assert!((medium_spacing - medium_step / 0.5).abs() < 1e-9);
         }
+    }
+
+    #[test]
+    fn binary_step_ladder_prefers_power_of_two_steps() {
+        let scale = AxisScale1D::with_options(
+            0.75,
+            AxisScaleOptions {
+                target_major_spacing_px: 8.0,
+                min_major_step: 0.0,
+                medium_label_min_spacing_px: 220.0,
+                step_ladder: AxisStepLadder::BinaryPowerOfTwo,
+            },
+        );
+        assert_eq!(scale.major_step(), 8.0);
+        assert_eq!(scale.medium_step(), Some(4.0));
+        assert_eq!(scale.minor_step(), 2.0);
+    }
+
+    #[test]
+    fn label_step_tracks_smallest_label_eligible_ticks() {
+        let coarse = AxisScale1D::with_options(
+            1.0,
+            AxisScaleOptions {
+                target_major_spacing_px: 96.0,
+                min_major_step: 0.0,
+                medium_label_min_spacing_px: 220.0,
+                step_ladder: AxisStepLadder::Decimal125,
+            },
+        );
+        assert_eq!(coarse.label_step(), coarse.major_step());
+
+        let fine = AxisScale1D::with_options(
+            0.05,
+            AxisScaleOptions {
+                target_major_spacing_px: 320.0,
+                min_major_step: 0.0,
+                medium_label_min_spacing_px: 220.0,
+                step_ladder: AxisStepLadder::Decimal125,
+            },
+        );
+        assert_eq!(
+            fine.label_step(),
+            fine.medium_step().unwrap_or(fine.major_step())
+        );
     }
 }

--- a/understory_axis/src/lib.rs
+++ b/understory_axis/src/lib.rs
@@ -12,6 +12,7 @@
 //! - label eligibility decisions based on spacing thresholds
 //! - spacing metadata for callers that need consistent axis-derived policy
 //! - configurable major-step ladders and subdivision policies for different axis domains
+//! - scalar ruler snapshots that can be placed along arbitrary 2D baselines
 //!
 //! It does not own:
 //! - domain-specific label formatting
@@ -22,6 +23,7 @@
 //! The intended split is:
 //! - a caller supplies a headless axis mapping plus tick policy
 //! - this crate returns tick positions plus their semantic kind
+//! - an adapter above this crate decides how to place those scalar marks in 2D
 //! - the caller formats tick labels appropriate to its own domain
 //!
 //! ## Minimal example
@@ -77,6 +79,103 @@ pub struct AxisTick {
     pub kind: AxisTickKind,
     /// Whether a higher layer should consider labeling this tick.
     pub labeled: bool,
+}
+
+/// Scalar styling options for a headless ruler snapshot.
+///
+/// These values are lengths in caller-defined view units. A higher layer can
+/// interpret them along any 2D normal direction when placing a ruler, guide, or
+/// timeline header.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AxisRulerOptions {
+    /// Length assigned to major marks.
+    pub major_mark_extent: f64,
+    /// Length assigned to medium marks.
+    pub medium_mark_extent: f64,
+    /// Length assigned to minor marks.
+    pub minor_mark_extent: f64,
+}
+
+impl Default for AxisRulerOptions {
+    fn default() -> Self {
+        Self {
+            major_mark_extent: 18.0,
+            medium_mark_extent: 14.0,
+            minor_mark_extent: 9.0,
+        }
+    }
+}
+
+impl AxisRulerOptions {
+    /// Returns the mark length for a semantic tick kind.
+    #[must_use]
+    pub fn mark_extent(&self, kind: AxisTickKind) -> f64 {
+        match kind {
+            AxisTickKind::Major => self.major_mark_extent,
+            AxisTickKind::Medium => self.medium_mark_extent,
+            AxisTickKind::Minor => self.minor_mark_extent,
+        }
+    }
+}
+
+/// A single scalar ruler mark positioned along a 1D view span.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AxisRulerMark {
+    /// Tick coordinate in caller-defined domain units.
+    pub value: f64,
+    /// Tick position in the mapped 1D view span.
+    pub view_position: f64,
+    /// Semantic tick kind.
+    pub kind: AxisTickKind,
+    /// Whether a higher layer should consider labeling this mark.
+    pub labeled: bool,
+    /// Mark length in caller-defined view units.
+    pub mark_extent: f64,
+}
+
+/// A headless scalar ruler snapshot derived from an axis mapping and tick guide.
+///
+/// This does not choose any 2D orientation. A higher layer can place the
+/// returned scalar `view_position` values along an arbitrary line or curve.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AxisRuler1D {
+    view_span: Range<f64>,
+    marks: Vec<AxisRulerMark>,
+}
+
+impl AxisRuler1D {
+    /// Builds a ruler snapshot covering the mapping's visible domain.
+    #[must_use]
+    pub fn from_mapping(
+        mapping: &AxisMapping1D,
+        scale: &AxisScale1D,
+        options: AxisRulerOptions,
+    ) -> Self {
+        let view_span = mapping.view_span();
+        let marks = scale
+            .iter_ticks_in_range(mapping.visible_domain())
+            .map(|tick| AxisRulerMark {
+                value: tick.value,
+                view_position: mapping.domain_to_view(tick.value),
+                kind: tick.kind,
+                labeled: tick.labeled,
+                mark_extent: options.mark_extent(tick.kind),
+            })
+            .collect();
+        Self { view_span, marks }
+    }
+
+    /// Returns the ruler's view span in device coordinates.
+    #[must_use]
+    pub fn view_span(&self) -> Range<f64> {
+        self.view_span.clone()
+    }
+
+    /// Returns the scalar marks in view order.
+    #[must_use]
+    pub fn marks(&self) -> &[AxisRulerMark] {
+        &self.marks
+    }
 }
 
 /// Options controlling automatic 1D axis scale derivation.
@@ -1011,8 +1110,8 @@ mod tests {
     use alloc::vec::Vec;
 
     use super::{
-        AxisMajorStepLadder, AxisMapping1D, AxisScale1D, AxisScaleOptions, AxisSubdivisionPolicy,
-        AxisTickKind,
+        AxisMajorStepLadder, AxisMapping1D, AxisRuler1D, AxisRulerOptions, AxisScale1D,
+        AxisScaleOptions, AxisSubdivisionPolicy, AxisTickKind,
     };
 
     #[test]
@@ -1217,5 +1316,47 @@ mod tests {
         let view = mapping.domain_to_view(value);
         let round_trip = mapping.view_to_domain(view);
         assert!((round_trip - value).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ruler_snapshot_uses_mapping_positions_and_mark_extents() {
+        let mapping = AxisMapping1D::linear(20.0..220.0, 0.0..100.0);
+        let scale = AxisScale1D::from_mapping(&mapping, AxisScaleOptions::default());
+        let options = AxisRulerOptions {
+            major_mark_extent: 21.0,
+            medium_mark_extent: 13.0,
+            minor_mark_extent: 7.0,
+        };
+        let ruler = AxisRuler1D::from_mapping(&mapping, &scale, options);
+        assert_eq!(ruler.view_span(), 20.0..220.0);
+        assert!(!ruler.marks().is_empty());
+        for mark in ruler.marks() {
+            assert!((mark.view_position - mapping.domain_to_view(mark.value)).abs() < 1e-9);
+            let expected_extent = match mark.kind {
+                AxisTickKind::Major => 21.0,
+                AxisTickKind::Medium => 13.0,
+                AxisTickKind::Minor => 7.0,
+            };
+            assert_eq!(mark.mark_extent, expected_extent);
+        }
+    }
+
+    #[test]
+    fn log_ruler_snapshot_tracks_log_major_positions() {
+        let mapping = AxisMapping1D::log(0.0..300.0, 1.0..1_000.0, 10.0);
+        let scale = AxisScale1D::from_mapping(&mapping, AxisScaleOptions::default());
+        let ruler = AxisRuler1D::from_mapping(&mapping, &scale, AxisRulerOptions::default());
+        let major_positions: Vec<_> = ruler
+            .marks()
+            .iter()
+            .filter(|mark| mark.kind == AxisTickKind::Major)
+            .map(|mark| (mark.value, mark.view_position))
+            .collect();
+        for value in [1.0, 10.0, 100.0] {
+            let expected = mapping.domain_to_view(value);
+            assert!(major_positions.iter().any(|(mark_value, position)| {
+                *mark_value == value && (*position - expected).abs() < 1e-9
+            }));
+        }
     }
 }

--- a/understory_axis/src/lib.rs
+++ b/understory_axis/src/lib.rs
@@ -1,0 +1,290 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Understory Axis: headless numeric axis scale and tick primitives.
+//!
+//! This crate focuses on one narrow concern: deriving stable, "nice" 1D tick
+//! positions from a continuous numeric axis.
+//!
+//! It owns:
+//! - major / medium / minor tick selection
+//! - 1-2-5 step sizing
+//! - label eligibility decisions based on spacing thresholds
+//!
+//! It does not own:
+//! - domain-specific label formatting
+//! - time units or dates
+//! - viewport transforms
+//! - rendering or text layout
+//!
+//! The intended split is:
+//! - a caller supplies world-units-per-pixel and a visible numeric range
+//! - this crate returns tick positions plus their semantic kind
+//! - the caller formats tick labels appropriate to its own domain
+//!
+//! ## Minimal example
+//!
+//! ```rust
+//! use understory_axis::{AxisScale1D, AxisScaleOptions, AxisTickKind};
+//!
+//! let scale = AxisScale1D::with_options(
+//!     0.5,
+//!     AxisScaleOptions {
+//!         target_major_spacing_px: 100.0,
+//!         min_major_step: 0.0,
+//!         medium_label_min_spacing_px: 220.0,
+//!     },
+//! );
+//!
+//! let ticks = scale.ticks_in_range(0.0..100.0);
+//! assert!(ticks.iter().any(|tick| tick.kind == AxisTickKind::Major && tick.labeled));
+//! ```
+//!
+//! This crate is `no_std` and uses `alloc`.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::ops::Range;
+
+/// Semantic classification for an axis tick.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AxisTickKind {
+    /// Primary grid/tick mark.
+    Major,
+    /// Secondary subdivision that may optionally be labeled.
+    Medium,
+    /// Fine subdivision without labeling.
+    Minor,
+}
+
+/// A single axis tick position plus label eligibility.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AxisTick {
+    /// Tick coordinate in caller-defined world units.
+    pub value: f64,
+    /// Semantic tick kind.
+    pub kind: AxisTickKind,
+    /// Whether a higher layer should consider labeling this tick.
+    pub labeled: bool,
+}
+
+/// Options controlling automatic 1D axis scale derivation.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AxisScaleOptions {
+    /// Desired spacing in pixels between major ticks.
+    pub target_major_spacing_px: f64,
+    /// Lower bound for the major tick step in world units.
+    pub min_major_step: f64,
+    /// Minimum major spacing in pixels before medium ticks become label-eligible.
+    pub medium_label_min_spacing_px: f64,
+}
+
+impl Default for AxisScaleOptions {
+    fn default() -> Self {
+        Self {
+            target_major_spacing_px: 96.0,
+            min_major_step: 0.0,
+            medium_label_min_spacing_px: 220.0,
+        }
+    }
+}
+
+/// A derived 1D axis scale over a continuous numeric domain.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AxisScale1D {
+    major_step: f64,
+    minor_step: f64,
+    subdivisions: usize,
+    medium_interval: Option<usize>,
+    medium_labels: bool,
+}
+
+impl AxisScale1D {
+    /// Derive a scale from a world-units-per-pixel ratio using default options.
+    #[must_use]
+    pub fn new(world_units_per_pixel: f64) -> Self {
+        Self::with_options(world_units_per_pixel, AxisScaleOptions::default())
+    }
+
+    /// Derive a scale from a world-units-per-pixel ratio and explicit options.
+    #[must_use]
+    pub fn with_options(world_units_per_pixel: f64, options: AxisScaleOptions) -> Self {
+        let target_major_step = world_units_per_pixel.abs() * options.target_major_spacing_px;
+        let major_step = choose_step(target_major_step.max(options.min_major_step).max(1e-12));
+        let subdivisions = subdivisions_for_step(major_step);
+        let minor_step = major_step / subdivisions as f64;
+        let medium_interval = if subdivisions.is_multiple_of(2) {
+            Some(subdivisions / 2)
+        } else {
+            None
+        };
+        let major_spacing_px = major_step / world_units_per_pixel.abs().max(f64::MIN_POSITIVE);
+        let medium_labels = major_spacing_px >= options.medium_label_min_spacing_px;
+
+        Self {
+            major_step,
+            minor_step,
+            subdivisions,
+            medium_interval,
+            medium_labels,
+        }
+    }
+
+    /// Returns the derived major step in world units.
+    #[must_use]
+    pub fn major_step(&self) -> f64 {
+        self.major_step
+    }
+
+    /// Returns the derived minor step in world units.
+    #[must_use]
+    pub fn minor_step(&self) -> f64 {
+        self.minor_step
+    }
+
+    /// Returns ticks covering the provided visible range plus one minor step on each side.
+    #[must_use]
+    pub fn ticks_in_range(&self, visible: Range<f64>) -> Vec<AxisTick> {
+        let start_index = floor_to_i64(visible.start / self.minor_step) - 1;
+        let end_index = ceil_to_i64(visible.end / self.minor_step) + 1;
+        let mut ticks = Vec::new();
+
+        for index in start_index..=end_index {
+            let value = index as f64 * self.minor_step;
+            if value < visible.start - self.minor_step || value > visible.end + self.minor_step {
+                continue;
+            }
+            let sub_index = usize::try_from(index.rem_euclid(self.subdivisions as i64))
+                .expect("rem_euclid stays within subdivision count");
+            let (kind, labeled) = if sub_index == 0 {
+                (AxisTickKind::Major, true)
+            } else if self
+                .medium_interval
+                .is_some_and(|interval| sub_index.is_multiple_of(interval))
+            {
+                (AxisTickKind::Medium, self.medium_labels)
+            } else {
+                (AxisTickKind::Minor, false)
+            };
+            ticks.push(AxisTick {
+                value,
+                kind,
+                labeled,
+            });
+        }
+
+        ticks
+    }
+}
+
+fn choose_step(target: f64) -> f64 {
+    let mut unit = 1.0_f64;
+    if target >= 1.0 {
+        while unit * 10.0 <= target {
+            unit *= 10.0;
+        }
+    } else {
+        while unit > target {
+            unit /= 10.0;
+        }
+    }
+
+    for mantissa in [1.0_f64, 2.0, 5.0, 10.0] {
+        let step = mantissa * unit;
+        if step >= target {
+            return step;
+        }
+    }
+
+    10.0 * unit
+}
+
+fn subdivisions_for_step(step: f64) -> usize {
+    let step = step.abs().max(1e-12);
+    let mut scale = 1.0_f64;
+    if step >= 1.0 {
+        while scale * 10.0 <= step {
+            scale *= 10.0;
+        }
+    } else {
+        while scale > step {
+            scale /= 10.0;
+        }
+    }
+    let normalized = step / scale;
+    if normalized <= 1.0 + 1e-6 {
+        10
+    } else if normalized <= 2.0 + 1e-6 {
+        4
+    } else {
+        5
+    }
+}
+
+fn floor_to_i64(value: f64) -> i64 {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "deliberate truncation step for small axis tick indexing"
+    )]
+    let truncated = value as i64;
+    if (truncated as f64) > value {
+        truncated - 1
+    } else {
+        truncated
+    }
+}
+
+fn ceil_to_i64(value: f64) -> i64 {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "deliberate truncation step for small axis tick indexing"
+    )]
+    let truncated = value as i64;
+    if (truncated as f64) < value {
+        truncated + 1
+    } else {
+        truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AxisScale1D, AxisScaleOptions, AxisTickKind};
+
+    #[test]
+    fn larger_world_units_produce_larger_major_steps() {
+        let coarse = AxisScale1D::new(2.0);
+        let fine = AxisScale1D::new(0.2);
+        assert!(coarse.major_step() > fine.major_step());
+    }
+
+    #[test]
+    fn medium_ticks_can_be_label_eligible() {
+        let scale = AxisScale1D::with_options(
+            0.05,
+            AxisScaleOptions {
+                target_major_spacing_px: 320.0,
+                min_major_step: 0.0,
+                medium_label_min_spacing_px: 220.0,
+            },
+        );
+        let ticks = scale.ticks_in_range(0.0..100.0);
+        assert!(
+            ticks
+                .iter()
+                .any(|tick| tick.kind == AxisTickKind::Medium && tick.labeled)
+        );
+    }
+
+    #[test]
+    fn ticks_cover_requested_range() {
+        let scale = AxisScale1D::new(0.5);
+        let ticks = scale.ticks_in_range(10.0..40.0);
+        assert!(!ticks.is_empty());
+        assert!(ticks.iter().any(|tick| tick.value <= 10.0));
+        assert!(ticks.iter().any(|tick| tick.value >= 40.0));
+    }
+}

--- a/understory_guide/Cargo.toml
+++ b/understory_guide/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "understory_guide"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "Headless 2D guide geometry primitives for Understory."
+keywords = ["ui", "guide", "geometry", "no_std", "understory"]
+categories = ["gui", "graphics", "no-std"]
+
+[dependencies]
+kurbo.workspace = true
+understory_axis = { path = "../understory_axis", default-features = false }
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+std = ["kurbo/std", "understory_axis/std"]
+libm = ["kurbo/libm"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_guide/README.md
+++ b/understory_guide/README.md
@@ -1,0 +1,22 @@
+# Understory Guide
+
+`understory_guide` provides small, headless 2D guide geometry primitives.
+
+It owns:
+
+- line-guide pose and projection math
+- semantic hit targets for guide body and handles
+- lifting `understory_axis::AxisRuler1D` marks onto a 2D guide
+
+It does not own:
+
+- rendering
+- text shaping
+- event routing
+- domain navigation policy
+
+Typical usage:
+
+1. derive an `AxisRuler1D` from `understory_axis`
+2. place it on screen with a `LineGuide2D`
+3. render the resulting `AxisGuide2D` marks in app code

--- a/understory_guide/src/lib.rs
+++ b/understory_guide/src/lib.rs
@@ -1,0 +1,353 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Understory Guide: headless 2D guide geometry primitives.
+//!
+//! This crate owns small 2D geometric adapters above lower-level numeric axis
+//! and selection primitives. It is intended for things like floating rulers,
+//! measurement guides, and timeline headers attached to arbitrary baselines.
+//!
+//! It owns:
+//! - line-guide pose and projection math
+//! - semantic hit targets for guide body and endpoint handles
+//! - lifting [`understory_axis::AxisRuler1D`] marks into 2D geometry
+//!
+//! It does not own:
+//! - rendering
+//! - text shaping
+//! - event routing
+//! - domain navigation policy
+//!
+//! This crate is `no_std` and uses `alloc`.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::f64::consts::PI;
+
+#[cfg(not(feature = "std"))]
+use kurbo::common::FloatFuncs as _;
+use kurbo::{Point, Vec2};
+use understory_axis::{AxisRuler1D, AxisTickKind};
+
+/// Semantic hit targets for a line guide.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum GuideHit {
+    /// The guide baseline.
+    Body,
+    /// The guide's start endpoint handle.
+    StartHandle,
+    /// The guide's end endpoint handle.
+    EndHandle,
+}
+
+/// A headless 2D line guide pose.
+///
+/// The guide stores only a center point, direction, and length. Rendering,
+/// styling, and interaction state all remain the responsibility of a higher
+/// layer.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct LineGuide2D {
+    center: Point,
+    angle_rad: f64,
+    length: f64,
+}
+
+impl LineGuide2D {
+    /// Creates a new guide pose.
+    ///
+    /// Negative lengths are treated as zero.
+    #[must_use]
+    pub fn new(center: Point, angle_rad: f64, length: f64) -> Self {
+        Self {
+            center,
+            angle_rad,
+            length: length.max(0.0),
+        }
+    }
+
+    /// Creates a guide from its endpoints.
+    ///
+    /// Returns `None` when the endpoints coincide.
+    #[must_use]
+    pub fn from_endpoints(start: Point, end: Point) -> Option<Self> {
+        let delta = end - start;
+        let length = delta.hypot();
+        if length <= 0.0 {
+            return None;
+        }
+        Some(Self::new(start.lerp(end, 0.5), delta.atan2(), length))
+    }
+
+    /// Returns the guide center point.
+    #[must_use]
+    pub fn center(self) -> Point {
+        self.center
+    }
+
+    /// Returns the guide angle in radians.
+    #[must_use]
+    pub fn angle_rad(self) -> f64 {
+        self.angle_rad
+    }
+
+    /// Returns the guide length in view units.
+    #[must_use]
+    pub fn length(self) -> f64 {
+        self.length
+    }
+
+    /// Returns the guide tangent unit vector.
+    #[must_use]
+    pub fn tangent(self) -> Vec2 {
+        Vec2::new(self.angle_rad.cos(), self.angle_rad.sin())
+    }
+
+    /// Returns the guide left-hand normal unit vector.
+    #[must_use]
+    pub fn normal(self) -> Vec2 {
+        let tangent = self.tangent();
+        Vec2::new(-tangent.y, tangent.x)
+    }
+
+    /// Returns the guide start point.
+    #[must_use]
+    pub fn start(self) -> Point {
+        self.center - self.tangent() * (self.length * 0.5)
+    }
+
+    /// Returns the guide end point.
+    #[must_use]
+    pub fn end(self) -> Point {
+        self.center + self.tangent() * (self.length * 0.5)
+    }
+
+    /// Returns the point at a scalar view position along the guide.
+    ///
+    /// `view_position = 0` corresponds to [`Self::start`] and
+    /// `view_position = self.length()` corresponds to [`Self::end`].
+    #[must_use]
+    pub fn point_at_view_position(self, view_position: f64) -> Point {
+        self.start() + self.tangent() * view_position
+    }
+
+    /// Projects a point onto the guide tangent and returns its scalar position.
+    ///
+    /// The returned value is unclamped and may lie outside the guide length.
+    #[must_use]
+    pub fn project_view_position(self, point: Point) -> f64 {
+        let delta = point - self.start();
+        delta.dot(self.tangent())
+    }
+
+    /// Returns the signed distance from the point to the guide baseline.
+    #[must_use]
+    pub fn signed_distance_to_baseline(self, point: Point) -> f64 {
+        let delta = point - self.start();
+        delta.dot(self.normal())
+    }
+
+    /// Returns the nearest point on the finite guide baseline.
+    #[must_use]
+    pub fn nearest_point_on_baseline(self, point: Point) -> Point {
+        let scalar = self.project_view_position(point).clamp(0.0, self.length);
+        self.point_at_view_position(scalar)
+    }
+
+    /// Returns an angle suitable for label placement without upside-down text.
+    #[must_use]
+    pub fn upright_label_angle_rad(self) -> f64 {
+        let tangent = self.tangent();
+        if tangent.x < 0.0 {
+            self.angle_rad + PI
+        } else {
+            self.angle_rad
+        }
+    }
+
+    /// Returns the normal direction associated with [`Self::upright_label_angle_rad`].
+    #[must_use]
+    pub fn upright_label_normal(self) -> Vec2 {
+        let tangent = self.tangent();
+        if tangent.x < 0.0 {
+            -self.normal()
+        } else {
+            self.normal()
+        }
+    }
+
+    /// Hit-tests the guide body and endpoint handles.
+    ///
+    /// `baseline_tolerance` and `handle_tolerance` are interpreted in view units.
+    #[must_use]
+    pub fn hit_test(
+        self,
+        point: Point,
+        baseline_tolerance: f64,
+        handle_tolerance: f64,
+    ) -> Option<GuideHit> {
+        if point.distance(self.start()) <= handle_tolerance {
+            return Some(GuideHit::StartHandle);
+        }
+        if point.distance(self.end()) <= handle_tolerance {
+            return Some(GuideHit::EndHandle);
+        }
+
+        let scalar = self.project_view_position(point);
+        ((0.0..=self.length).contains(&scalar)
+            && self.signed_distance_to_baseline(point).abs() <= baseline_tolerance)
+            .then_some(GuideHit::Body)
+    }
+}
+
+/// Options for lifting an axis ruler onto a 2D guide.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AxisGuideOptions {
+    /// Extra distance between a tick tip and its label anchor.
+    pub label_offset: f64,
+}
+
+impl Default for AxisGuideOptions {
+    fn default() -> Self {
+        Self { label_offset: 14.0 }
+    }
+}
+
+/// A single axis ruler mark lifted into 2D.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AxisGuideMark2D {
+    /// Tick coordinate in caller-defined domain units.
+    pub value: f64,
+    /// Semantic tick kind.
+    pub kind: AxisTickKind,
+    /// Whether a higher layer should consider labeling this mark.
+    pub labeled: bool,
+    /// Point where the mark meets the guide baseline.
+    pub baseline_point: Point,
+    /// Mark tip point.
+    pub tip_point: Point,
+    /// Suggested label anchor point.
+    pub label_anchor: Point,
+}
+
+/// A 2D axis guide derived from a scalar ruler snapshot and a line pose.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AxisGuide2D {
+    line: LineGuide2D,
+    label_angle_rad: f64,
+    marks: Vec<AxisGuideMark2D>,
+}
+
+impl AxisGuide2D {
+    /// Builds a 2D guide from a scalar ruler snapshot.
+    #[must_use]
+    pub fn from_ruler(ruler: &AxisRuler1D, line: LineGuide2D, options: AxisGuideOptions) -> Self {
+        let mark_normal = line.normal();
+        let label_normal = line.upright_label_normal();
+        let label_angle_rad = line.upright_label_angle_rad();
+        let marks = ruler
+            .marks()
+            .iter()
+            .map(|mark| {
+                let baseline_point = line.point_at_view_position(mark.view_position);
+                let tip_point = baseline_point + mark_normal * mark.mark_extent;
+                let label_anchor =
+                    baseline_point + label_normal * (mark.mark_extent + options.label_offset);
+                AxisGuideMark2D {
+                    value: mark.value,
+                    kind: mark.kind,
+                    labeled: mark.labeled,
+                    baseline_point,
+                    tip_point,
+                    label_anchor,
+                }
+            })
+            .collect();
+        Self {
+            line,
+            label_angle_rad,
+            marks,
+        }
+    }
+
+    /// Returns the underlying line guide pose.
+    #[must_use]
+    pub fn line(&self) -> LineGuide2D {
+        self.line
+    }
+
+    /// Returns the angle that label text should use to remain upright.
+    #[must_use]
+    pub fn label_angle_rad(&self) -> f64 {
+        self.label_angle_rad
+    }
+
+    /// Returns the lifted 2D marks in ruler order.
+    #[must_use]
+    pub fn marks(&self) -> &[AxisGuideMark2D] {
+        &self.marks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AxisGuide2D, AxisGuideOptions, GuideHit, LineGuide2D};
+    use kurbo::Point;
+    use understory_axis::{
+        AxisMajorStepLadder, AxisMapping1D, AxisRuler1D, AxisRulerOptions, AxisScale1D,
+        AxisScaleOptions, AxisSubdivisionPolicy,
+    };
+
+    #[test]
+    fn line_guide_projects_and_hits_points() {
+        let guide = LineGuide2D::new(Point::new(50.0, 40.0), 0.0, 100.0);
+        assert_eq!(guide.start(), Point::new(0.0, 40.0));
+        assert_eq!(guide.end(), Point::new(100.0, 40.0));
+        assert_eq!(
+            guide.hit_test(Point::new(0.0, 40.0), 6.0, 8.0),
+            Some(GuideHit::StartHandle)
+        );
+        assert_eq!(
+            guide.hit_test(Point::new(100.0, 40.0), 6.0, 8.0),
+            Some(GuideHit::EndHandle)
+        );
+        assert_eq!(
+            guide.hit_test(Point::new(40.0, 44.0), 6.0, 8.0),
+            Some(GuideHit::Body)
+        );
+        assert_eq!(guide.project_view_position(Point::new(25.0, 50.0)), 25.0);
+        assert_eq!(
+            guide.signed_distance_to_baseline(Point::new(25.0, 50.0)),
+            10.0
+        );
+    }
+
+    #[test]
+    fn axis_guide_lifts_ruler_marks_into_2d() {
+        let mapping = AxisMapping1D::linear(0.0..200.0, 0.0..100.0);
+        let scale = AxisScale1D::from_mapping(
+            &mapping,
+            AxisScaleOptions {
+                target_major_spacing_px: 100.0,
+                min_major_step: 0.0,
+                medium_label_min_spacing_px: 220.0,
+                major_step_ladder: AxisMajorStepLadder::Decimal125,
+                subdivision_policy: AxisSubdivisionPolicy::Auto,
+            },
+        );
+        let ruler = AxisRuler1D::from_mapping(&mapping, &scale, AxisRulerOptions::default());
+        let line = LineGuide2D::new(Point::new(100.0, 100.0), 0.0, 200.0);
+        let guide = AxisGuide2D::from_ruler(&ruler, line, AxisGuideOptions::default());
+
+        let first_major = guide
+            .marks()
+            .iter()
+            .find(|mark| matches!(mark.kind, understory_axis::AxisTickKind::Major))
+            .expect("expected a major tick");
+        assert!((first_major.baseline_point.y - 100.0).abs() < 1e-6);
+        assert!(first_major.tip_point.y > first_major.baseline_point.y);
+        assert!(first_major.label_anchor.y > first_major.tip_point.y);
+    }
+}


### PR DESCRIPTION
This PR adds two new core crates plus one example:

* `understory_axis` for headless 1D mappings, ticks, and scalar ruler marks
* `understory_guide` for headless 2D guide geometry and lifting axis marks into 2D

The intended boundary is:

* understory_axis owns numeric mapping and tick policy
* understory_guide owns 2D guide geometry

This gives Understory a reusable foundation for rulers, guides, timelines, and similar measurement-oriented surfaces without baking rendering or widget policy into the core crates.
