### PR TITLE
transcript: add generic interaction log crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "understory_outline",
  "understory_precise_hit",
  "understory_responder",
+ "understory_transcript",
  "understory_virtual_list",
 ]
 
@@ -626,6 +627,13 @@ name = "understory_style"
 version = "0.1.0"
 dependencies = [
  "understory_property",
+]
+
+[[package]]
+name = "understory_transcript"
+version = "0.1.0"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "understory_responder",
   "understory_selection",
   "understory_style",
+  "understory_transcript",
   "understory_view2d",
   "understory_virtual_list",
   "understory_event_state",

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Generic over the key type `T` (no `Hash`/`Ord` requirement; only `PartialEq`), suitable for list selections, canvases, and other selection UIs.
   - Intended to pair with `understory_box_tree` / `understory_precise_hit` for hit testing and `understory_responder` for event routing.
 
+- `understory_transcript`
+  - Append-order interaction log primitives with generic payloads and explicit updates for chat, shell, and agent-style systems.
+  - Provides stable entry ids, typed entry kinds, `EntryBody` as a built-in text/bytes default payload, explicit parent/cause links, and explicit status/chunk updates to existing entries.
+  - Designed to sit below transcript/chat/console UIs without taking on text layout, rendering, or persistence policy.
+
 - `understory_view2d`
   - 2D and 1D view/viewport primitives:
     - `Viewport2D` for canvas/CAD‑style views: camera state (pan + zoom), coordinate conversion between world and device space, view fitting (center vs align‑min), and simple clamping against optional world bounds.
@@ -117,6 +122,7 @@ For example, a canvas or DWG or DXF viewer can reuse the box and index layers wi
   - `understory_inspector/README.md` documents the host-side controller for outline-backed inspection UIs.
   - `understory_outline/README.md` documents hierarchical visible-row projection, expansion state, and grouped/tree-style usage.
   - `understory_selection/README.md` documents the selection container, anchor/revision semantics, and click helpers.
+  - `understory_transcript/README.md` documents append-order transcript storage, generic payloads, explicit update semantics, typed entry kinds, and chat/tool/process-style usage.
   - `understory_view2d/README.md` documents the 2D and 1D viewport types, clamping/fit modes, and examples of using visible regions for culling.
 - Run examples.
   - `cargo run -p understory_examples --example index_basics`
@@ -125,6 +131,9 @@ For example, a canvas or DWG or DXF viewer can reuse the box and index layers wi
   - `cargo run -p understory_examples --example outline_property_grid`
   - `cargo run -p understory_examples --example outline_virtual_list`
   - `cargo run -p understory_examples --example outline_inspector`
+  - `cargo run -p understory_examples --example transcript_agent_run`
+  - `cargo run -p understory_examples --example transcript_virtual_list`
+  - `cargo run -p understory_examples --example transcript_tail_anchored`
   - `cargo run -p understory_examples --example responder_basics`
   - `cargo run -p understory_examples --example responder_hover`
   - `cargo run -p understory_examples --example responder_box_tree`

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,4 +18,5 @@ understory_precise_hit = { path = "../understory_precise_hit" }
 understory_event_state = { path = "../understory_event_state" }
 understory_inspector = { path = "../understory_inspector" }
 understory_outline = { path = "../understory_outline" }
+understory_transcript = { path = "../understory_transcript" }
 understory_virtual_list = { path = "../understory_virtual_list" }

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,18 @@ These examples form a short, progressive walkthrough from routing basics to inte
   - Drive `understory_inspector` over a property-grid-style domain model, then inspect expansion sync, visible-row focus, range selection, and collapse pruning.
   - Run: `cargo run -p understory_examples --example outline_inspector`
 
+- transcript_agent_run
+  - Record a small agent-style run with user input, tool lifecycle, streamed stdout, and annotation entries using `understory_transcript`.
+  - Run: `cargo run -p understory_examples --example transcript_agent_run`
+
+- transcript_virtual_list
+  - Virtualize a variable-height transcript with `PrefixSumExtentModel`, then scroll to interesting entries with `VirtualList`.
+  - Run: `cargo run -p understory_examples --example transcript_virtual_list`
+
+- transcript_tail_anchored
+  - Keep a chat/log-style transcript pinned to the tail with `TailAnchoredExtentModel`, but only while the user is already anchored there.
+  - Run: `cargo run -p understory_examples --example transcript_tail_anchored`
+
 Notes
 - Examples live in a separate crate (`understory_examples`) so that published crates stay free of example-only dependencies.
 - Output is formatted with section headers to make sequences easy to follow.

--- a/examples/examples/transcript_agent_run.rs
+++ b/examples/examples/transcript_agent_run.rs
@@ -1,0 +1,66 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use understory_transcript::{
+    AnnotationLevel, EntryBody, EntryStatus, MessageRole, NewEntry, ProcessStream, Timestamp,
+    ToolOutcome, Transcript,
+};
+
+fn main() {
+    let mut transcript = Transcript::new();
+
+    let user = transcript.append(
+        NewEntry::message(MessageRole::User, "run cargo test").with_timestamp(Timestamp(1)),
+    );
+    let tool = transcript.append(
+        NewEntry::tool_call("cargo test", EntryBody::Empty)
+            .with_cause(user)
+            .with_status(EntryStatus::InProgress)
+            .with_timestamp(Timestamp(2)),
+    );
+    let stdout = transcript.append(
+        NewEntry::process_output(ProcessStream::Stdout, "running")
+            .with_parent(tool)
+            .with_status(EntryStatus::InProgress)
+            .with_timestamp(Timestamp(3)),
+    );
+
+    transcript.append_chunk(stdout, " 58 tests").unwrap();
+    transcript.append_chunk(stdout, "\n").unwrap();
+    transcript
+        .set_status(stdout, EntryStatus::Complete)
+        .unwrap();
+
+    let note = transcript.append(
+        NewEntry::annotation(AnnotationLevel::Info, "tool output captured")
+            .with_parent(tool)
+            .with_timestamp(Timestamp(4)),
+    );
+
+    transcript.append(
+        NewEntry::tool_result("cargo test", ToolOutcome::Success, "58 passed")
+            .with_cause(tool)
+            .with_timestamp(Timestamp(5)),
+    );
+    transcript.set_status(tool, EntryStatus::Complete).unwrap();
+
+    println!("Transcript: {} entries", transcript.len());
+    println!("children(tool): {:?}", transcript.children_of(tool));
+    println!("children(note): {:?}", transcript.children_of(note));
+    println!();
+
+    for entry in transcript.iter() {
+        println!(
+            "#{} ts={:?} parent={:?} cause={:?} status={:?}",
+            entry.id.0,
+            entry.timestamp.map(|ts| ts.0),
+            entry.parent.map(|id| id.0),
+            entry.cause.map(|id| id.0),
+            entry.status
+        );
+        println!("  {:?}", entry.kind);
+        if let Some(body) = entry.body() {
+            println!("  body={:?}", body);
+        }
+    }
+}

--- a/examples/examples/transcript_tail_anchored.rs
+++ b/examples/examples/transcript_tail_anchored.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use understory_transcript::{MessageRole, NewEntry, Transcript, TranscriptEntry};
+use understory_virtual_list::{PrefixSumExtentModel, TailAnchoredExtentModel, VirtualList};
+
+fn main() {
+    let mut transcript = Transcript::new();
+    transcript.append(NewEntry::message(MessageRole::User, "hello"));
+    transcript.append(NewEntry::message(
+        MessageRole::Assistant,
+        "hi there\nhow can I help?",
+    ));
+    transcript.append(NewEntry::message(
+        MessageRole::User,
+        "show me the last three commits",
+    ));
+
+    let inner = PrefixSumExtentModel::<f32>::new();
+    let model = TailAnchoredExtentModel::with_default_epsilon(inner);
+    let mut list = VirtualList::new(model, 4.0_f32, 0.5_f32);
+
+    sync_tail_anchored(&transcript, &mut list);
+    list.scroll_to_tail();
+
+    println!("== Initially anchored to tail ==");
+    print_tail_state(&transcript, &mut list);
+
+    transcript.append(NewEntry::message(
+        MessageRole::Assistant,
+        "commit a1b2c3\ncommit d4e5f6\ncommit 123abc",
+    ));
+    sync_tail_anchored(&transcript, &mut list);
+
+    println!();
+    println!("== Appended while anchored ==");
+    print_tail_state(&transcript, &mut list);
+
+    list.set_scroll_offset(0.0_f32);
+    transcript.append(NewEntry::message(
+        MessageRole::Assistant,
+        "another line that should not yank the user's scroll position",
+    ));
+    sync_tail_anchored(&transcript, &mut list);
+
+    println!();
+    println!("== Appended while user was reading earlier entries ==");
+    print_tail_state(&transcript, &mut list);
+}
+
+fn sync_tail_anchored(
+    transcript: &Transcript,
+    list: &mut VirtualList<TailAnchoredExtentModel<PrefixSumExtentModel<f32>>>,
+) {
+    let was_at_tail = list.is_at_tail();
+    list.model_mut()
+        .inner_mut()
+        .rebuild(transcript.iter().cloned(), &entry_extent);
+    if was_at_tail {
+        list.scroll_to_tail();
+    }
+}
+
+fn entry_extent(entry: &TranscriptEntry) -> f32 {
+    let lines = entry
+        .body()
+        .and_then(|body| body.as_text())
+        .map_or(1, |text| text.lines().count().max(1));
+    1.0_f32 + ((lines.saturating_sub(1)) as f32 * 0.8_f32)
+}
+
+fn print_tail_state(
+    transcript: &Transcript,
+    list: &mut VirtualList<TailAnchoredExtentModel<PrefixSumExtentModel<f32>>>,
+) {
+    let strip = list.visible_strip();
+    println!(
+        "scroll={:.1} is_at_tail={} realized={}..{} before={:.1} after={:.1} content={:.1}",
+        list.scroll_offset(),
+        list.is_at_tail(),
+        strip.start,
+        strip.end,
+        strip.before_extent,
+        strip.after_extent,
+        strip.content_extent
+    );
+
+    for index in list.visible_indices() {
+        let entry = &transcript.entries()[index];
+        println!("- [{}] {:?}", index, entry.kind);
+    }
+}

--- a/examples/examples/transcript_virtual_list.rs
+++ b/examples/examples/transcript_virtual_list.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use understory_transcript::{
+    AnnotationLevel, EntryBody, EntryKind, EntryStatus, MessageRole, NewEntry, ProcessStream,
+    Timestamp, ToolOutcome, Transcript, TranscriptEntry,
+};
+use understory_virtual_list::{PrefixSumExtentModel, ScrollAlign, VirtualList};
+
+fn main() {
+    let transcript = build_transcript();
+    let mut model = PrefixSumExtentModel::<f32>::new();
+    model.rebuild(transcript.iter().cloned(), &entry_extent);
+
+    let mut list = VirtualList::new(model, 5.0_f32, 1.0_f32);
+
+    println!("== Transcript as variable-height virtual list ==");
+    print_strip(&transcript, &mut list);
+
+    println!();
+    println!("== Scroll to tool output ==");
+    list.scroll_to_index(2, ScrollAlign::Start);
+    print_strip(&transcript, &mut list);
+
+    println!();
+    println!("== Center final result ==");
+    list.scroll_to_index(transcript.len() - 1, ScrollAlign::Center);
+    print_strip(&transcript, &mut list);
+}
+
+fn build_transcript() -> Transcript {
+    let mut transcript = Transcript::new();
+
+    let user = transcript.append(
+        NewEntry::message(MessageRole::User, "run cargo test --workspace")
+            .with_timestamp(Timestamp(1)),
+    );
+    let tool = transcript.append(
+        NewEntry::tool_call("cargo test", EntryBody::Empty)
+            .with_cause(user)
+            .with_status(EntryStatus::InProgress)
+            .with_timestamp(Timestamp(2)),
+    );
+    let stdout = transcript.append(
+        NewEntry::process_output(
+            ProcessStream::Stdout,
+            "running 58 tests\nall green\nmerged doctests compilation took 0.24s",
+        )
+        .with_parent(tool)
+        .with_status(EntryStatus::Complete)
+        .with_timestamp(Timestamp(3)),
+    );
+    transcript.append(
+        NewEntry::annotation(
+            AnnotationLevel::Info,
+            "workspace pass finished without warnings",
+        )
+        .with_parent(tool)
+        .with_timestamp(Timestamp(4)),
+    );
+    transcript.append(
+        NewEntry::tool_result("cargo test", ToolOutcome::Success, "58 passed")
+            .with_cause(tool)
+            .with_timestamp(Timestamp(5)),
+    );
+
+    transcript
+        .append_chunk(stdout, "\nartifacts up to date")
+        .unwrap();
+    transcript.set_status(tool, EntryStatus::Complete).unwrap();
+
+    transcript
+}
+
+fn entry_extent(entry: &TranscriptEntry) -> f32 {
+    let base = match entry.kind {
+        EntryKind::Message(_) => 1.4_f32,
+        EntryKind::ToolCall(_) | EntryKind::ToolResult(_) => 1.2_f32,
+        EntryKind::ProcessOutput(_) => 1.0_f32,
+        EntryKind::Annotation(_) => 0.9_f32,
+        EntryKind::State(_) => 1.0_f32,
+    };
+
+    let body_lines = match entry.body() {
+        Some(EntryBody::Text(text)) => text.lines().count().max(1),
+        Some(EntryBody::Bytes(_)) => 1,
+        Some(EntryBody::Empty) | None => 1,
+    };
+
+    base + ((body_lines.saturating_sub(1)) as f32 * 0.8_f32)
+}
+
+fn print_strip(transcript: &Transcript, list: &mut VirtualList<PrefixSumExtentModel<f32>>) {
+    let strip = list.visible_strip();
+    println!(
+        "scroll={:.1} viewport={:.1} overscan=({:.1},{:.1}) realized={}..{} before={:.1} after={:.1} content={:.1}",
+        list.scroll_offset(),
+        list.viewport_extent(),
+        list.overscan_before(),
+        list.overscan_after(),
+        strip.start,
+        strip.end,
+        strip.before_extent,
+        strip.after_extent,
+        strip.content_extent
+    );
+
+    for index in list.visible_indices() {
+        let entry = &transcript.entries()[index];
+        println!("- [{}] {:.1} {:?}", index, entry_extent(entry), entry.kind);
+    }
+}

--- a/plans/understory_transcript_plan.md
+++ b/plans/understory_transcript_plan.md
@@ -1,0 +1,47 @@
+# understory_transcript plan
+
+## Goal
+
+Add a small `understory_transcript` crate for append-oriented interaction logs
+with stable entry ids, explicit status, typed entries, and projection-friendly
+links for chat, shell, and agent-style systems.
+
+## Non-goals
+
+- text layout or attributed text
+- widgets or rendering
+- persistence backends
+- transport/protocol integration
+- terminal emulation
+
+## First slice
+
+1. Add `understory_transcript` as a `no_std` + `alloc` core crate in the workspace.
+2. Implement the core model:
+   - `EntryId`
+   - `Timestamp`
+   - `EntryBody`
+   - `EntryStatus`
+   - `EntryKind`
+   - `TranscriptEntry`
+   - `NewEntry`
+   - `Transcript`
+3. Support practical append/update flows:
+   - append new entries
+   - append text/bytes chunks to an existing entry
+   - set status
+   - query by id and in append order
+   - query children by parent
+4. Add rustdoc and a runnable example in `understory_examples`.
+5. Keep the surface calm and leave richer projections for later.
+
+## Risks
+
+- Overfitting to “chat messages” instead of a general interaction log.
+- Making the content model too rich too early.
+- Letting streaming/update semantics become clever or implicit.
+
+## Design fence
+
+This crate owns append-oriented interaction records and their structural links;
+it explicitly does not own layout, rendering, protocol semantics, or text styling.

--- a/understory_transcript/Cargo.toml
+++ b/understory_transcript/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "understory_transcript"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "Append-order transcript primitives with generic payloads and explicit updates for chat, shell, and agent-style interaction logs."
+keywords = ["transcript", "chat", "agent", "shell", "no_std"]
+categories = ["data-structures", "no-std"]
+
+[dependencies]
+hashbrown.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+std = []
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_transcript/README.md
+++ b/understory_transcript/README.md
@@ -1,0 +1,70 @@
+# Understory Transcript
+
+Append-order interaction log primitives with generic payloads and explicit
+updates for chat, shell, and agent-style systems.
+
+`understory_transcript` provides a small core for recording ordered interaction
+entries with stable ids, typed payloads, explicit parent/cause links, and
+explicit streaming/status updates.
+
+It is intended to sit below chat views, shell panes, and agent harness UIs.
+
+## Scope
+
+This crate owns:
+
+- append-order transcript storage
+- stable entry ids
+- typed entry kinds
+- explicit parent/cause relationships
+- generic payloads, with `EntryBody` as the built-in text/bytes/empty default
+- explicit status and chunk updates to existing entries
+
+This is append-oriented, not a strict append-only event log. Entry order is
+stable after append, but hosts may explicitly update an entry's body or status
+as streaming output arrives.
+
+`Transcript<P = EntryBody>` is generic over payload type, so richer hosts can
+store fragment ids, structured objects, or other presentation-layer handles
+without pulling layout or widget policy into the crate.
+
+This crate does not own:
+
+- text layout or styling
+- rendering
+- persistence backends
+- transport/protocol semantics
+- terminal emulation
+
+## Minimal example
+
+```rust
+use understory_transcript::{
+    EntryBody, EntryStatus, MessageRole, NewEntry, ProcessStream, ToolOutcome, Transcript,
+};
+
+let mut transcript = Transcript::new();
+
+let user = transcript.append(NewEntry::message(MessageRole::User, "run tests"));
+let tool = transcript.append(
+    NewEntry::tool_call("cargo test", EntryBody::Empty)
+        .with_cause(user)
+        .with_status(EntryStatus::InProgress),
+);
+let stdout = transcript.append(
+    NewEntry::process_output(ProcessStream::Stdout, "running")
+        .with_parent(tool)
+        .with_status(EntryStatus::InProgress),
+);
+
+transcript.append_chunk(stdout, " 58 tests").unwrap();
+transcript.set_status(stdout, EntryStatus::Complete).unwrap();
+transcript.append(
+    NewEntry::tool_result("cargo test", ToolOutcome::Success, "ok")
+        .with_cause(tool),
+);
+transcript.set_status(tool, EntryStatus::Complete).unwrap();
+
+assert_eq!(transcript.children_of(tool), &[stdout]);
+assert_eq!(transcript.entries().len(), 4);
+```

--- a/understory_transcript/src/body.rs
+++ b/understory_transcript/src/body.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Transcript payload bodies.
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+/// Payload body stored by a transcript entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EntryBody {
+    /// UTF-8 text content.
+    Text(String),
+    /// Opaque bytes.
+    Bytes(Vec<u8>),
+    /// No payload.
+    Empty,
+}
+
+impl EntryBody {
+    /// Returns the body as text when it is stored as UTF-8 text.
+    #[must_use]
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            Self::Text(text) => Some(text.as_str()),
+            Self::Bytes(_) | Self::Empty => None,
+        }
+    }
+
+    /// Returns the body as bytes when it is stored as raw bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Bytes(bytes) => Some(bytes.as_slice()),
+            Self::Text(_) | Self::Empty => None,
+        }
+    }
+
+    pub(crate) fn append(&mut self, chunk: Self) -> Result<(), BodyAppendError> {
+        match (self, chunk) {
+            (body @ Self::Empty, Self::Text(text)) => {
+                *body = Self::Text(text);
+                Ok(())
+            }
+            (body @ Self::Empty, Self::Bytes(bytes)) => {
+                *body = Self::Bytes(bytes);
+                Ok(())
+            }
+            (Self::Text(text), Self::Text(chunk)) => {
+                text.push_str(&chunk);
+                Ok(())
+            }
+            (Self::Bytes(bytes), Self::Bytes(chunk)) => {
+                bytes.extend_from_slice(&chunk);
+                Ok(())
+            }
+            (Self::Text(_), Self::Bytes(_)) | (Self::Bytes(_), Self::Text(_)) => {
+                Err(BodyAppendError::KindMismatch)
+            }
+            (_, Self::Empty) => Ok(()),
+        }
+    }
+}
+
+impl From<&str> for EntryBody {
+    fn from(value: &str) -> Self {
+        Self::Text(value.into())
+    }
+}
+
+impl From<String> for EntryBody {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<Vec<u8>> for EntryBody {
+    fn from(value: Vec<u8>) -> Self {
+        Self::Bytes(value)
+    }
+}
+
+/// Error returned when appending chunk payloads to an existing body.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BodyAppendError {
+    /// The existing body and the new chunk use incompatible storage kinds.
+    KindMismatch,
+}

--- a/understory_transcript/src/entry.rs
+++ b/understory_transcript/src/entry.rs
@@ -1,0 +1,295 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Transcript entry types and constructors.
+
+extern crate alloc;
+
+use alloc::string::String;
+
+use crate::body::EntryBody;
+use crate::ids::{EntryId, Timestamp};
+use crate::status::EntryStatus;
+
+/// One stored transcript entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TranscriptEntry<P = EntryBody> {
+    /// Stable identifier assigned by the transcript.
+    pub id: EntryId,
+    /// Optional host-defined timestamp.
+    pub timestamp: Option<Timestamp>,
+    /// Structural parent link, when the entry is nested under another entry.
+    pub parent: Option<EntryId>,
+    /// Causal link, when the entry was produced because of another entry.
+    pub cause: Option<EntryId>,
+    /// Current lifecycle status.
+    pub status: EntryStatus,
+    /// Typed entry payload.
+    pub kind: EntryKind<P>,
+}
+
+/// Append-time description of a new transcript entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NewEntry<P = EntryBody> {
+    pub(crate) timestamp: Option<Timestamp>,
+    pub(crate) parent: Option<EntryId>,
+    pub(crate) cause: Option<EntryId>,
+    pub(crate) status: EntryStatus,
+    pub(crate) kind: EntryKind<P>,
+}
+
+impl<P> NewEntry<P> {
+    /// Creates a message entry with a role and body.
+    #[must_use]
+    pub fn message(role: MessageRole, body: impl Into<P>) -> Self {
+        Self::new(EntryKind::Message(MessageEntry {
+            role,
+            body: body.into(),
+        }))
+    }
+
+    /// Creates a tool-call entry.
+    #[must_use]
+    pub fn tool_call(tool_name: impl Into<String>, input: impl Into<P>) -> Self {
+        Self::new(EntryKind::ToolCall(ToolCallEntry {
+            tool_name: tool_name.into(),
+            input: input.into(),
+        }))
+    }
+
+    /// Creates a tool-result entry.
+    #[must_use]
+    pub fn tool_result(
+        tool_name: impl Into<String>,
+        outcome: ToolOutcome,
+        output: impl Into<P>,
+    ) -> Self {
+        Self::new(EntryKind::ToolResult(ToolResultEntry {
+            tool_name: tool_name.into(),
+            outcome,
+            output: output.into(),
+        }))
+    }
+
+    /// Creates a process-output entry.
+    #[must_use]
+    pub fn process_output(stream: ProcessStream, body: impl Into<P>) -> Self {
+        Self::new(EntryKind::ProcessOutput(ProcessOutputEntry {
+            stream,
+            body: body.into(),
+        }))
+    }
+
+    /// Creates an annotation entry.
+    #[must_use]
+    pub fn annotation(level: AnnotationLevel, body: impl Into<P>) -> Self {
+        Self::new(EntryKind::Annotation(AnnotationEntry {
+            level,
+            body: body.into(),
+        }))
+    }
+
+    /// Creates a state entry.
+    #[must_use]
+    pub fn state(label: impl Into<String>, body: impl Into<P>) -> Self {
+        Self::new(EntryKind::State(StateEntry {
+            label: label.into(),
+            body: body.into(),
+        }))
+    }
+
+    /// Adds a structural parent link.
+    #[must_use]
+    pub fn with_parent(mut self, parent: EntryId) -> Self {
+        self.parent = Some(parent);
+        self
+    }
+
+    /// Adds a causal link.
+    #[must_use]
+    pub fn with_cause(mut self, cause: EntryId) -> Self {
+        self.cause = Some(cause);
+        self
+    }
+
+    /// Sets an explicit entry status.
+    #[must_use]
+    pub fn with_status(mut self, status: EntryStatus) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Sets a host-defined timestamp.
+    #[must_use]
+    pub fn with_timestamp(mut self, timestamp: Timestamp) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    fn new(kind: EntryKind<P>) -> Self {
+        Self {
+            timestamp: None,
+            parent: None,
+            cause: None,
+            status: EntryStatus::Complete,
+            kind,
+        }
+    }
+}
+
+/// Typed payload for one transcript entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EntryKind<P = EntryBody> {
+    /// Conversational or user/system-style message.
+    Message(MessageEntry<P>),
+    /// Tool invocation request.
+    ToolCall(ToolCallEntry<P>),
+    /// Tool invocation result.
+    ToolResult(ToolResultEntry<P>),
+    /// Process or terminal output.
+    ProcessOutput(ProcessOutputEntry<P>),
+    /// Host annotation such as warnings, notes, or status lines.
+    Annotation(AnnotationEntry<P>),
+    /// Named state change or checkpoint entry.
+    State(StateEntry<P>),
+}
+
+impl<P> EntryKind<P> {
+    /// Returns the payload body for entry kinds that store one.
+    #[must_use]
+    pub fn body(&self) -> Option<&P> {
+        match self {
+            Self::Message(entry) => Some(&entry.body),
+            Self::ToolCall(entry) => Some(&entry.input),
+            Self::ToolResult(entry) => Some(&entry.output),
+            Self::ProcessOutput(entry) => Some(&entry.body),
+            Self::Annotation(entry) => Some(&entry.body),
+            Self::State(entry) => Some(&entry.body),
+        }
+    }
+}
+
+impl EntryKind<EntryBody> {
+    pub(crate) fn body_mut(&mut self) -> Option<&mut EntryBody> {
+        match self {
+            Self::Message(entry) => Some(&mut entry.body),
+            Self::ToolCall(entry) => Some(&mut entry.input),
+            Self::ToolResult(entry) => Some(&mut entry.output),
+            Self::ProcessOutput(entry) => Some(&mut entry.body),
+            Self::Annotation(entry) => Some(&mut entry.body),
+            Self::State(entry) => Some(&mut entry.body),
+        }
+    }
+}
+
+/// Message-style entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MessageEntry<P = EntryBody> {
+    /// Semantic role of the message.
+    pub role: MessageRole,
+    /// Message payload body.
+    pub body: P,
+}
+
+/// Role associated with a message entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MessageRole {
+    /// System instruction or setup.
+    System,
+    /// End-user input.
+    User,
+    /// Assistant or model output.
+    Assistant,
+    /// Tool-originated message.
+    Tool,
+    /// Unclassified message role.
+    Other,
+}
+
+/// Tool invocation request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolCallEntry<P = EntryBody> {
+    /// Tool name or operation identifier.
+    pub tool_name: String,
+    /// Tool input payload.
+    pub input: P,
+}
+
+/// Tool invocation result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolResultEntry<P = EntryBody> {
+    /// Tool name or operation identifier.
+    pub tool_name: String,
+    /// Tool completion status.
+    pub outcome: ToolOutcome,
+    /// Tool output payload.
+    pub output: P,
+}
+
+/// Outcome reported by a tool result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ToolOutcome {
+    /// The tool completed successfully.
+    Success,
+    /// The tool reported failure.
+    Failure,
+    /// The tool was cancelled.
+    Cancelled,
+}
+
+/// Process or terminal output entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProcessOutputEntry<P = EntryBody> {
+    /// Logical output stream.
+    pub stream: ProcessStream,
+    /// Output payload body.
+    pub body: P,
+}
+
+/// Stream classification for process output.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ProcessStream {
+    /// Standard input.
+    Stdin,
+    /// Standard output.
+    Stdout,
+    /// Standard error.
+    Stderr,
+}
+
+/// Annotation entry for notes, warnings, and similar host-generated records.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnnotationEntry<P = EntryBody> {
+    /// Annotation severity or tone.
+    pub level: AnnotationLevel,
+    /// Annotation payload body.
+    pub body: P,
+}
+
+/// Severity or tone for annotation entries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AnnotationLevel {
+    /// Informational note.
+    Info,
+    /// Non-fatal warning.
+    Warning,
+    /// Error or failure note.
+    Error,
+}
+
+/// Named state change or checkpoint entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StateEntry<P = EntryBody> {
+    /// Host-defined label for the state update.
+    pub label: String,
+    /// Additional state payload.
+    pub body: P,
+}
+
+impl<P> TranscriptEntry<P> {
+    /// Returns the payload body for entry kinds that store one.
+    #[must_use]
+    pub fn body(&self) -> Option<&P> {
+        self.kind.body()
+    }
+}

--- a/understory_transcript/src/ids.rs
+++ b/understory_transcript/src/ids.rs
@@ -1,0 +1,16 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Transcript identifier and timestamp types.
+
+/// Stable identifier for one transcript entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EntryId(pub u64);
+
+/// Host-defined timestamp associated with a transcript entry.
+///
+/// This crate treats timestamps as opaque monotonic labels rather than wall
+/// clock time. Hosts may interpret them as milliseconds, microseconds, ticks,
+/// or another stable recorded-at unit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Timestamp(pub u64);

--- a/understory_transcript/src/lib.rs
+++ b/understory_transcript/src/lib.rs
@@ -1,0 +1,143 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=understory_transcript --heading-base-level=0
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! Understory Transcript: append-order interaction log primitives.
+//!
+//! This crate provides a small, renderer-agnostic core for recording chat,
+//! shell, and agent-style interactions as a stable transcript.
+//!
+//! The core concepts are:
+//!
+//! - [`Transcript`]: append-order storage with id and parent-child indices.
+//! - [`EntryId`]: stable identity for one recorded entry.
+//! - [`TranscriptEntry`]: stored normalized entry record.
+//! - [`NewEntry`]: append-time constructor for a new entry.
+//! - [`EntryKind`]: typed entry payloads for messages, tools, process output,
+//!   annotations, and state changes.
+//! - [`EntryBody`]: the built-in text/bytes/empty payload type used by default.
+//!
+//! This crate deliberately does **not** know about:
+//!
+//! - text layout or styling,
+//! - rendering or widgets,
+//! - transport or protocol semantics,
+//! - persistence backends,
+//! - terminal emulation.
+//!
+//! ## Overview
+//!
+//! Goal:
+//! provide a calm append-order interaction substrate for chat, shell, and
+//! agent-style systems.
+//!
+//! Non-goals:
+//! own layout, rendering, persistence, or text styling.
+//!
+//! ## Fence
+//!
+//! This crate owns append-order interaction records, their explicit update
+//! semantics, and their structural links; it explicitly does not own layout,
+//! rendering, protocol semantics, or text styling.
+//!
+//! ## Invariants
+//!
+//! - Entry ids are assigned by the transcript and remain stable afterward.
+//! - Entries preserve append order even when later statuses or chunks are added.
+//! - Bodies and statuses may be updated in place through explicit mutation APIs;
+//!   this crate is append-oriented, not a strict append-only event log.
+//! - Transcript payloads are generic. [`EntryBody`] is the built-in default,
+//!   but hosts may store fragment ids, object handles, or other structured
+//!   payloads instead.
+//! - `parent` and `cause` are explicit links; they are never inferred from
+//!   position alone.
+//! - The built-in [`EntryBody`] payload is intentionally simple: text, bytes,
+//!   or empty.
+//! - Chunk appends are only available for the built-in [`EntryBody`] payload
+//!   today and reject text/byte kind mismatches.
+//!
+//! ## Why not just use a message list?
+//!
+//! Because agent and shell systems quickly need more than plain messages:
+//!
+//! - tool calls and results,
+//! - stdout/stderr-like output,
+//! - status transitions,
+//! - structural nesting,
+//! - causal links.
+//!
+//! A transcript is a better center than a chat-only message model.
+//!
+//! ## Payloads
+//!
+//! `Transcript` is generic over payload type and defaults to [`EntryBody`]:
+//!
+//! ```rust
+//! use understory_transcript::{MessageRole, NewEntry, Transcript};
+//!
+//! #[derive(Clone, Debug, PartialEq, Eq)]
+//! enum Payload {
+//!     Fragment(u32),
+//!     PresentedObject(&'static str),
+//! }
+//!
+//! let mut transcript = Transcript::<Payload>::new();
+//! let entry = transcript.append(NewEntry::message(MessageRole::Assistant, Payload::Fragment(7)));
+//!
+//! assert_eq!(transcript.entry(entry).unwrap().body(), Some(&Payload::Fragment(7)));
+//! ```
+//!
+//! ## Minimal example
+//!
+//! ```rust
+//! use understory_transcript::{
+//!     EntryBody, EntryStatus, MessageRole, NewEntry, ProcessStream, ToolOutcome, Transcript,
+//! };
+//!
+//! let mut transcript = Transcript::new();
+//!
+//! let user = transcript.append(NewEntry::message(MessageRole::User, "run tests"));
+//! let tool = transcript.append(
+//!     NewEntry::tool_call("cargo test", EntryBody::Empty)
+//!         .with_cause(user)
+//!         .with_status(EntryStatus::InProgress),
+//! );
+//! let stdout = transcript.append(
+//!     NewEntry::process_output(ProcessStream::Stdout, "running")
+//!         .with_parent(tool)
+//!         .with_status(EntryStatus::InProgress),
+//! );
+//!
+//! transcript.append_chunk(stdout, " 58 tests").unwrap();
+//! transcript.set_status(stdout, EntryStatus::Complete).unwrap();
+//! transcript.append(
+//!     NewEntry::tool_result("cargo test", ToolOutcome::Success, "ok")
+//!         .with_cause(tool),
+//! );
+//! transcript.set_status(tool, EntryStatus::Complete).unwrap();
+//!
+//! assert_eq!(transcript.children_of(tool), &[stdout]);
+//! assert_eq!(transcript.entries().len(), 4);
+//! ```
+
+extern crate alloc;
+
+pub mod body;
+pub mod entry;
+pub mod ids;
+pub mod status;
+pub mod transcript;
+
+pub use body::{BodyAppendError, EntryBody};
+pub use entry::{
+    AnnotationEntry, AnnotationLevel, EntryKind, MessageEntry, MessageRole, NewEntry,
+    ProcessOutputEntry, ProcessStream, StateEntry, ToolCallEntry, ToolOutcome, ToolResultEntry,
+    TranscriptEntry,
+};
+pub use ids::{EntryId, Timestamp};
+pub use status::EntryStatus;
+pub use transcript::{Transcript, TranscriptError};

--- a/understory_transcript/src/status.rs
+++ b/understory_transcript/src/status.rs
@@ -1,0 +1,17 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Entry lifecycle states.
+
+/// Lifecycle state for a transcript entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum EntryStatus {
+    /// The entry is still being produced or updated.
+    InProgress,
+    /// The entry completed successfully.
+    Complete,
+    /// The entry ended in failure.
+    Failed,
+    /// The entry was cancelled before completing.
+    Cancelled,
+}

--- a/understory_transcript/src/transcript.rs
+++ b/understory_transcript/src/transcript.rs
@@ -1,0 +1,278 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Transcript storage and mutation APIs.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use hashbrown::HashMap;
+
+use crate::body::{BodyAppendError, EntryBody};
+use crate::entry::{NewEntry, TranscriptEntry};
+use crate::ids::EntryId;
+use crate::status::EntryStatus;
+
+/// Append-order transcript storage with explicit in-place updates.
+///
+/// `Transcript` stores entries in append order and keeps lightweight indices
+/// for id lookup and parent-child traversal. It supports explicit chunk and
+/// status updates for streaming or long-running entries without taking on UI,
+/// persistence, or append-only event-log policy.
+#[derive(Clone, Debug, Default)]
+pub struct Transcript<P = EntryBody> {
+    entries: Vec<TranscriptEntry<P>>,
+    indices: HashMap<EntryId, usize>,
+    children: HashMap<EntryId, Vec<EntryId>>,
+    next_id: u64,
+}
+
+impl<P> Transcript<P> {
+    /// Creates an empty transcript.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            indices: HashMap::new(),
+            children: HashMap::new(),
+            next_id: 0,
+        }
+    }
+
+    /// Returns the number of stored entries.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` when the transcript has no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Appends a new entry and returns its assigned id.
+    pub fn append(&mut self, entry: NewEntry<P>) -> EntryId {
+        let id = EntryId(self.next_id);
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .expect("transcript entry id overflow");
+
+        let stored = TranscriptEntry {
+            id,
+            timestamp: entry.timestamp,
+            parent: entry.parent,
+            cause: entry.cause,
+            status: entry.status,
+            kind: entry.kind,
+        };
+
+        let index = self.entries.len();
+        self.entries.push(stored);
+        self.indices.insert(id, index);
+
+        if let Some(parent) = self.entries[index].parent {
+            self.children.entry(parent).or_default().push(id);
+        }
+
+        id
+    }
+
+    /// Sets the lifecycle status for an entry.
+    pub fn set_status(
+        &mut self,
+        id: EntryId,
+        status: EntryStatus,
+    ) -> Result<bool, TranscriptError> {
+        let entry = self.entry_mut(id)?;
+        if entry.status == status {
+            return Ok(false);
+        }
+        entry.status = status;
+        Ok(true)
+    }
+
+    /// Returns one entry by id.
+    #[must_use]
+    pub fn entry(&self, id: EntryId) -> Option<&TranscriptEntry<P>> {
+        self.indices
+            .get(&id)
+            .and_then(|index| self.entries.get(*index))
+    }
+
+    /// Returns the append-order index for an entry id.
+    #[must_use]
+    pub fn index_of(&self, id: EntryId) -> Option<usize> {
+        self.indices.get(&id).copied()
+    }
+
+    /// Returns all transcript entries in append order.
+    #[must_use]
+    pub fn entries(&self) -> &[TranscriptEntry<P>] {
+        self.entries.as_slice()
+    }
+
+    /// Iterates over transcript entries in append order.
+    pub fn iter(&self) -> impl Iterator<Item = &TranscriptEntry<P>> {
+        self.entries.iter()
+    }
+
+    /// Returns the direct children of a parent entry in append order.
+    #[must_use]
+    pub fn children_of(&self, id: EntryId) -> &[EntryId] {
+        self.children.get(&id).map_or(&[], Vec::as_slice)
+    }
+
+    fn entry_mut(&mut self, id: EntryId) -> Result<&mut TranscriptEntry<P>, TranscriptError> {
+        let Some(index) = self.indices.get(&id).copied() else {
+            return Err(TranscriptError::UnknownEntry { entry: id });
+        };
+        Ok(&mut self.entries[index])
+    }
+}
+
+impl Transcript<EntryBody> {
+    /// Appends a text or byte chunk to an existing entry body.
+    pub fn append_chunk(
+        &mut self,
+        id: EntryId,
+        chunk: impl Into<EntryBody>,
+    ) -> Result<(), TranscriptError> {
+        let entry = self.entry_mut(id)?;
+        let body = entry
+            .kind
+            .body_mut()
+            .ok_or(TranscriptError::BodyKindMismatch { entry: id })?;
+        body.append(chunk.into())
+            .map_err(
+                |BodyAppendError::KindMismatch| TranscriptError::BodyKindMismatch { entry: id },
+            )
+    }
+}
+
+/// Errors returned by transcript mutation APIs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TranscriptError {
+    /// No entry exists for the provided id.
+    UnknownEntry {
+        /// Missing entry id.
+        entry: EntryId,
+    },
+    /// The targeted entry body cannot accept the provided chunk type.
+    BodyKindMismatch {
+        /// Entry whose stored body kind rejected the chunk append.
+        entry: EntryId,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::entry::{AnnotationLevel, MessageRole, NewEntry, ProcessStream, ToolOutcome};
+
+    use super::*;
+
+    #[test]
+    fn append_assigns_ids_and_parent_children() {
+        let mut transcript = Transcript::<EntryBody>::new();
+
+        let parent = transcript.append(NewEntry::message(MessageRole::User, "run tests"));
+        let child = transcript
+            .append(NewEntry::annotation(AnnotationLevel::Info, "queued").with_parent(parent));
+
+        assert_eq!(parent, EntryId(0));
+        assert_eq!(child, EntryId(1));
+        assert_eq!(transcript.children_of(parent), &[child]);
+        assert_eq!(transcript.index_of(child), Some(1));
+    }
+
+    #[test]
+    fn append_chunk_extends_text_entries() {
+        let mut transcript = Transcript::<EntryBody>::new();
+        let entry = transcript.append(
+            NewEntry::process_output(ProcessStream::Stdout, "running")
+                .with_status(EntryStatus::InProgress),
+        );
+
+        transcript.append_chunk(entry, " tests").unwrap();
+        transcript.append_chunk(entry, EntryBody::Empty).unwrap();
+
+        let stored = transcript.entry(entry).unwrap();
+        let EntryBody::Text(text) = stored.body().cloned().unwrap_or(EntryBody::Empty) else {
+            panic!("expected text body");
+        };
+        assert_eq!(text, "running tests");
+    }
+
+    #[test]
+    fn append_chunk_rejects_body_kind_mismatch() {
+        let mut transcript = Transcript::<EntryBody>::new();
+        let entry = transcript.append(NewEntry::tool_call("cargo", "test"));
+
+        let error = transcript
+            .append_chunk(entry, vec![1_u8, 2, 3])
+            .unwrap_err();
+        assert_eq!(error, TranscriptError::BodyKindMismatch { entry });
+    }
+
+    #[test]
+    fn set_status_reports_change() {
+        let mut transcript = Transcript::<EntryBody>::new();
+        let entry = transcript.append(
+            NewEntry::tool_result("cargo", ToolOutcome::Success, "ok")
+                .with_status(EntryStatus::InProgress),
+        );
+
+        assert!(transcript.set_status(entry, EntryStatus::Complete).unwrap());
+        assert!(!transcript.set_status(entry, EntryStatus::Complete).unwrap());
+        assert_eq!(
+            transcript.entry(entry).unwrap().status,
+            EntryStatus::Complete
+        );
+    }
+
+    #[test]
+    fn unknown_entry_errors_are_explicit() {
+        let mut transcript = Transcript::<EntryBody>::new();
+        let id = EntryId(77);
+
+        assert_eq!(
+            transcript.append_chunk(id, "hello").unwrap_err(),
+            TranscriptError::UnknownEntry { entry: id }
+        );
+        assert_eq!(
+            transcript.set_status(id, EntryStatus::Failed).unwrap_err(),
+            TranscriptError::UnknownEntry { entry: id }
+        );
+    }
+
+    #[test]
+    fn transcript_can_store_host_defined_payloads() {
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        enum Payload {
+            Fragment(u32),
+            Object(&'static str),
+        }
+
+        let mut transcript = Transcript::<Payload>::new();
+        let entry = transcript.append(NewEntry::message(
+            MessageRole::Assistant,
+            Payload::Fragment(7),
+        ));
+        let annotation = transcript.append(
+            NewEntry::annotation(AnnotationLevel::Info, Payload::Object("commit:abc123"))
+                .with_parent(entry),
+        );
+
+        assert_eq!(
+            transcript.entry(entry).unwrap().body(),
+            Some(&Payload::Fragment(7))
+        );
+        assert_eq!(transcript.children_of(entry), &[annotation]);
+        assert_eq!(
+            transcript.entry(annotation).unwrap().body(),
+            Some(&Payload::Object("commit:abc123"))
+        );
+    }
+}


### PR DESCRIPTION
Add a new `understory_transcript` crate as a structural interaction-log substrate for chat, shell, and agent-style systems.

The crate owns append-order entry storage, stable ids, typed entry kinds, parent/cause links, and explicit in-place status/body updates. It is generic over payload type, with `EntryBody` as the built-in text/bytes default, so hosts can carry richer fragment or object handles without pulling display or widget policy into the core.

This also adds transcript examples in `understory_examples`, including regular variable-height virtualization and tail-anchored chat/log behavior over `understory_virtual_list`, plus the accompanying workspace and README updates.