### PR TITLE
understory_virtual_list: tighten tail and strip behavior

### DIFF
--- a/examples/examples/transcript_tail_anchored.rs
+++ b/examples/examples/transcript_tail_anchored.rs
@@ -56,9 +56,7 @@ fn sync_tail_anchored(
     list.model_mut()
         .inner_mut()
         .rebuild(transcript.iter().cloned(), &entry_extent);
-    if was_at_tail {
-        list.scroll_to_tail();
-    }
+    list.restore_tail_anchor(was_at_tail);
 }
 
 fn entry_extent(entry: &TranscriptEntry) -> f32 {

--- a/understory_virtual_list/CHANGELOG.md
+++ b/understory_virtual_list/CHANGELOG.md
@@ -13,11 +13,31 @@ You can find its changes [documented below](#010-2026-05-14).
 
 ## [Unreleased]
 
+### Added
+
+- Added `VirtualList::restore_tail_anchor`, a convenience helper for applying a
+  tail-anchor state captured before mutating the model. ([#165][] by [@waywardmonkeys][])
+
+### Deprecated
+
+- Deprecated `VirtualList::stick_to_tail_if_anchored`; it checks anchoring after
+  the model has changed, which can miss append/update cases that were anchored
+  before mutation. ([#165][] by [@waywardmonkeys][])
+
+### Fixed
+
+- Fixed empty visible-strip spacer metadata when the requested range is at or
+  beyond the end of the content. ([#165][] by [@waywardmonkeys][])
+
 ## [0.1.0][] (2026-05-14)
 
 This release has an [MSRV][] of 1.88.
 
 This is the initial release.
+
+[@waywardmonkeys]: https://github.com/waywardmonkeys
+
+[#165]: https://github.com/forest-rs/understory/pull/165
 
 [Unreleased]: https://github.com/forest-rs/understory/compare/understory_virtual_list-v0.1.0...HEAD
 [0.1.0]: https://github.com/forest-rs/understory/releases/tag/understory_virtual_list-v0.1.0

--- a/understory_virtual_list/src/model.rs
+++ b/understory_virtual_list/src/model.rs
@@ -180,11 +180,24 @@ where
 
     if max <= min {
         // Very small viewport / overscan, or near-zero content.
+        let anchor = min.min(content_extent);
+        if anchor >= content_extent {
+            return VisibleStrip {
+                start: len,
+                end: len,
+                before_extent: content_extent,
+                after_extent: S::<M>::zero(),
+                content_extent,
+            };
+        }
+
+        let index = cmp::min(model.index_at_offset(anchor), len.saturating_sub(1));
+        let before_extent = model.offset_of(index);
         return VisibleStrip {
-            start: 0,
-            end: 0,
-            before_extent: min,
-            after_extent: (content_extent - min).max(S::<M>::zero()),
+            start: index,
+            end: index,
+            before_extent,
+            after_extent: (content_extent - before_extent).max(S::<M>::zero()),
             content_extent,
         };
     }
@@ -318,6 +331,32 @@ mod tests {
         assert_eq!(strip.len(), 0);
         assert!(strip.is_empty());
         assert!((strip.visible_extent() - 0.0_f32).abs() < 1e-5);
+    }
+
+    #[test]
+    fn empty_visible_range_beyond_content_has_coherent_spacers() {
+        let mut model = SimpleModel::new(&[10.0, 10.0, 10.0]);
+        let strip = compute_visible_strip(&mut model, 100.0, 0.0, 0.0, 0.0);
+
+        assert_eq!(strip.start, 3);
+        assert_eq!(strip.end, 3);
+        assert_eq!(strip.before_extent, 30.0);
+        assert_eq!(strip.after_extent, 0.0);
+        assert_eq!(strip.content_extent, 30.0);
+        assert_eq!(strip.visible_extent(), 0.0);
+    }
+
+    #[test]
+    fn empty_visible_range_inside_content_has_coherent_spacers() {
+        let mut model = SimpleModel::new(&[10.0, 10.0, 10.0]);
+        let strip = compute_visible_strip(&mut model, 15.0, 0.0, 0.0, 0.0);
+
+        assert_eq!(strip.start, 1);
+        assert_eq!(strip.end, 1);
+        assert_eq!(strip.before_extent, 10.0);
+        assert_eq!(strip.after_extent, 20.0);
+        assert_eq!(strip.content_extent, 30.0);
+        assert_eq!(strip.visible_extent(), 0.0);
     }
 
     #[test]

--- a/understory_virtual_list/src/tail_anchored.rs
+++ b/understory_virtual_list/src/tail_anchored.rs
@@ -51,9 +51,7 @@
 //! }
 //!
 //! // If we were at the tail before, keep the view pinned after the update.
-//! if was_at_tail {
-//!     list.scroll_to_tail();
-//! }
+//! list.restore_tail_anchor(was_at_tail);
 //! assert!(list.is_at_tail());
 //! ```
 

--- a/understory_virtual_list/src/virtual_list.rs
+++ b/understory_virtual_list/src/virtual_list.rs
@@ -318,12 +318,32 @@ impl<M: ExtentModel> VirtualList<TailAnchoredExtentModel<M>> {
         self.set_scroll_offset(tail);
     }
 
-    /// If the list is currently anchored to the tail, re-aligns the scroll offset
-    /// to the current tail position. Otherwise, leaves the scroll offset unchanged.
+    /// Convenience helper for applying a tail-anchor state captured before
+    /// mutating the model.
     ///
-    /// This is useful when item extents change or items are appended: call this
-    /// after updating the underlying model to keep the view pinned to the tail
-    /// only when the user was already at (or near) the end of the list.
+    /// Call [`VirtualList::is_at_tail`] before appending items or changing
+    /// extents, update the model, then pass the captured value here. This is
+    /// equivalent to calling [`VirtualList::scroll_to_tail`] when
+    /// `was_at_tail` is `true`.
+    pub fn restore_tail_anchor(&mut self, was_at_tail: bool) {
+        if was_at_tail {
+            self.scroll_to_tail();
+        }
+    }
+
+    /// If the list is currently anchored to the tail, re-aligns the scroll
+    /// offset to the current tail position. Otherwise, leaves the scroll offset
+    /// unchanged.
+    ///
+    /// This checks anchoring against the current model state, which is wrong
+    /// for the common append/update path: after the model changes, a scroll
+    /// offset that was previously anchored may no longer be near the new tail.
+    /// Capture [`VirtualList::is_at_tail`] before the mutation and call
+    /// [`VirtualList::restore_tail_anchor`] after the mutation instead.
+    #[deprecated(
+        since = "0.1.1",
+        note = "checks anchoring after the model has changed; capture is_at_tail() before mutation and call restore_tail_anchor() afterward"
+    )]
     pub fn stick_to_tail_if_anchored(&mut self) {
         if self.is_at_tail() {
             self.scroll_to_tail();
@@ -473,13 +493,54 @@ mod tests {
         // should pull us back to the exact tail offset.
         list.set_scroll_offset(69.5_f32);
         assert!(list.is_at_tail());
+        #[allow(
+            deprecated,
+            reason = "verify compatibility behavior for deprecated method"
+        )]
         list.stick_to_tail_if_anchored();
         assert!((list.scroll_offset() - 70.0_f32).abs() < 1e-5);
 
         // Move far from tail; stick_to_tail_if_anchored should leave offset unchanged.
         list.set_scroll_offset(10.0_f32);
         assert!(!list.is_at_tail());
+        #[allow(
+            deprecated,
+            reason = "verify compatibility behavior for deprecated method"
+        )]
         list.stick_to_tail_if_anchored();
         assert!((list.scroll_offset() - 10.0_f32).abs() < 1e-5);
+    }
+
+    #[test]
+    fn restore_tail_anchor_uses_state_captured_before_append() {
+        let inner = FixedExtentModel::new(10, 10.0_f32);
+        let ta = TailAnchoredExtentModel::with_default_epsilon(inner);
+        let mut list = VirtualList::new(ta, 30.0_f32, 0.0);
+
+        list.scroll_to_tail();
+        assert!((list.scroll_offset() - 70.0_f32).abs() < 1e-5);
+        let was_at_tail = list.is_at_tail();
+
+        list.model_mut().inner_mut().set_len(11);
+        list.restore_tail_anchor(was_at_tail);
+
+        assert!((list.scroll_offset() - 80.0_f32).abs() < 1e-5);
+        assert!(list.is_at_tail());
+    }
+
+    #[test]
+    fn restore_tail_anchor_keeps_scroll_when_not_previously_anchored() {
+        let inner = FixedExtentModel::new(10, 10.0_f32);
+        let ta = TailAnchoredExtentModel::with_default_epsilon(inner);
+        let mut list = VirtualList::new(ta, 30.0_f32, 0.0);
+
+        list.set_scroll_offset(10.0_f32);
+        let was_at_tail = list.is_at_tail();
+
+        list.model_mut().inner_mut().set_len(11);
+        list.restore_tail_anchor(was_at_tail);
+
+        assert!((list.scroll_offset() - 10.0_f32).abs() < 1e-5);
+        assert!(!list.is_at_tail());
     }
 }


### PR DESCRIPTION
Deprecate stick_to_tail_if_anchored because it checks tail anchoring against the current model state. That is the wrong shape for append/update paths: after the model changes, a scroll offset that was anchored before mutation may no longer be near the new tail.

Keep compatibility by leaving the method in place, and add restore_tail_anchor as a small helper for applying a captured is_at_tail() result after mutation. Also make empty visible strips report coherent spacers when the requested range is at or beyond the end of content.