### PR TITLE
understory_virtual_list: support sparse grid resizing

### DIFF
--- a/understory_virtual_list/CHANGELOG.md
+++ b/understory_virtual_list/CHANGELOG.md
@@ -17,6 +17,7 @@ You can find its changes [documented below](#010-2026-05-14).
 
 - Added `VirtualList::restore_tail_anchor`, a convenience helper for applying a
   tail-anchor state captured before mutating the model. ([#165][] by [@waywardmonkeys][])
+- Implemented `ResizableExtentModel` for `SparsePrefixSumExtentModel`. ([#166][] by [@waywardmonkeys][])
 
 ### Deprecated
 
@@ -38,6 +39,7 @@ This is the initial release.
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 
 [#165]: https://github.com/forest-rs/understory/pull/165
+[#166]: https://github.com/forest-rs/understory/pull/166
 
 [Unreleased]: https://github.com/forest-rs/understory/compare/understory_virtual_list-v0.1.0...HEAD
 [0.1.0]: https://github.com/forest-rs/understory/releases/tag/understory_virtual_list-v0.1.0

--- a/understory_virtual_list/src/grid_track.rs
+++ b/understory_virtual_list/src/grid_track.rs
@@ -193,7 +193,7 @@ impl<M: ResizableExtentModel> ExtentModel for GridTrackModel<M> {
 #[cfg(test)]
 mod tests {
     use super::GridTrackModel;
-    use crate::{ExtentModel, FixedExtentModel};
+    use crate::{ExtentModel, FixedExtentModel, SparsePrefixSumExtentModel};
     use core::num::NonZeroUsize;
 
     #[test]
@@ -230,6 +230,19 @@ mod tests {
         // Cells in track 2: offset 20 (partial track).
         assert_eq!(grid.offset_of(8), 20.0);
         assert_eq!(grid.offset_of(9), 20.0);
+    }
+
+    #[test]
+    fn sparse_track_model_resizes_for_grid_cells() {
+        let track_model = SparsePrefixSumExtentModel::new(12.0_f32, 0);
+        let mut grid = GridTrackModel::new(track_model, NonZeroUsize::new(4).unwrap(), 10);
+
+        assert_eq!(grid.track_model().len(), 3);
+        assert_eq!(grid.total_extent(), 36.0);
+
+        grid.set_len(4);
+        assert_eq!(grid.track_model().len(), 1);
+        assert_eq!(grid.total_extent(), 12.0);
     }
 
     #[test]

--- a/understory_virtual_list/src/model.rs
+++ b/understory_virtual_list/src/model.rs
@@ -115,13 +115,15 @@ pub trait ExtentModel {
 
 /// An [`ExtentModel`] whose logical length can be resized.
 ///
-/// Implementations are expected to ensure storage for `len` items and treat
-/// any newly added items as having extent `0.0` until explicitly updated.
+/// Implementations define their own policy for the extent of newly added
+/// items. Variable-size models commonly initialize new items to `0.0` until
+/// callers provide measurements, while fixed-size models keep using their
+/// uniform extent.
 pub trait ResizableExtentModel: ExtentModel {
     /// Ensures that the model can represent `len` items.
     ///
-    /// Implementations typically grow internal storage and treat new items as
-    /// zero-sized until their extents are set by the caller.
+    /// Implementations may grow internal storage, truncate stale state, or
+    /// update a logical length depending on how they represent extents.
     fn set_len(&mut self, len: usize);
 }
 

--- a/understory_virtual_list/src/sparse.rs
+++ b/understory_virtual_list/src/sparse.rs
@@ -6,7 +6,7 @@
 
 use alloc::collections::BTreeMap;
 
-use crate::{ExtentModel, Scalar};
+use crate::{ExtentModel, ResizableExtentModel, Scalar};
 
 /// An [`ExtentModel`] backed by per-item extents and a lazily-maintained prefix-sum cache with
 /// fixed-sized placeholders for un-materialized items.
@@ -271,6 +271,12 @@ impl<S: Scalar> ExtentModel for SparsePrefixSumExtentModel<S> {
 
     fn index_at_offset(&mut self, offset: S) -> usize {
         self.index_at_offset_for_len(offset, self.len)
+    }
+}
+
+impl<S: Scalar> ResizableExtentModel for SparsePrefixSumExtentModel<S> {
+    fn set_len(&mut self, len: usize) {
+        Self::set_len(self, len);
     }
 }
 


### PR DESCRIPTION
GridTrackModel already works with any ResizableExtentModel, and SparsePrefixSumExtentModel already exposes an inherent set_len method. Implement the trait so sparse track models can be used directly for grid virtualization.

Clarify the ResizableExtentModel docs at the same time: fixed-size and variable-size models have different policies for newly added items, so the trait should not promise zero-sized growth for every implementation.