### PR TITLE
workspace: centralize internal crate dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,45 @@ jobs:
       - name: cargo test --doc
         run: cargo test --doc --workspace --locked --all-features --no-fail-fast
 
+  package:
+    name: cargo package --list
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo package --list
+        shell: bash
+        run: |
+          set -euo pipefail
+          # This catches package-time manifest errors such as path dependencies
+          # without version requirements, while not requiring internal crates to
+          # already be published on crates.io.
+          read -ra package_args <<< "$RUST_MIN_VER_PKGS"
+          set -- "${package_args[@]}"
+          while [ "$#" -gt 0 ]; do
+            if [ "$1" != "-p" ]; then
+              echo "expected -p before package name, got: $1" >&2
+              exit 1
+            fi
+            shift
+            if [ "$#" -eq 0 ]; then
+              echo "missing package name after -p" >&2
+              exit 1
+            fi
+            cargo package -p "$1" --locked --list >/dev/null
+            shift
+          done
+
   test-stable-wasm:
     name: cargo test (wasm32)
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,26 @@ hashbrown = { version = "0.17.0", default-features = false, features = [
 invalidation = "0.2.0"
 smallvec = { version = "1.13.2", default-features = false }
 
+# Internal crate dependencies are centralized here so path dependencies carry
+# the version requirements needed for packaging.
+understory_axis = { version = "0.1.0", path = "understory_axis", default-features = false }
+understory_box_tree = { version = "0.0.1", path = "understory_box_tree", default-features = false }
+understory_event_state = { version = "0.1.0", path = "understory_event_state", default-features = false }
+understory_focus = { version = "0.1.0", path = "understory_focus", default-features = false }
+understory_guide = { version = "0.1.0", path = "understory_guide", default-features = false }
+understory_index = { version = "0.0.1", path = "understory_index", default-features = false }
+understory_inspector = { version = "0.1.0", path = "understory_inspector", default-features = false }
+understory_outline = { version = "0.1.0", path = "understory_outline", default-features = false }
+understory_precise_hit = { version = "0.1.0", path = "understory_precise_hit", default-features = false }
+understory_property = { version = "0.1.0", path = "understory_property", default-features = false }
+understory_responder = { version = "0.1.0", path = "understory_responder", default-features = false }
+understory_selection = { version = "0.1.0", path = "understory_selection", default-features = false }
+understory_style = { version = "0.1.0", path = "understory_style", default-features = false }
+understory_timing = { version = "0.1.2", path = "understory_timing", default-features = false }
+understory_transcript = { version = "0.1.0", path = "understory_transcript", default-features = false }
+understory_view2d = { version = "0.1.0", path = "understory_view2d", default-features = false }
+understory_virtual_list = { version = "0.1.1", path = "understory_virtual_list", default-features = false }
+
 [workspace.lints]
 # LINEBENDER LINT SET - Cargo.toml - v7
 rust.unsafe_code = "deny"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -6,12 +6,12 @@ publish = false
 autobenches = false
 
 [dependencies]
-understory_index = { path = "../understory_index" }
-understory_box_tree = { path = "../understory_box_tree" }
-understory_inspector = { path = "../understory_inspector" }
-understory_outline = { path = "../understory_outline" }
-understory_property = { path = "../understory_property" }
-understory_style = { path = "../understory_style" }
+understory_box_tree = { workspace = true, features = ["std"] }
+understory_index = { workspace = true, features = ["backend_grid"] }
+understory_inspector = { workspace = true, features = ["std"] }
+understory_outline = { workspace = true, features = ["std"] }
+understory_property.workspace = true
+understory_style.workspace = true
 kurbo.workspace = true
 rstar = { version = "0.11", optional = true }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,19 +5,23 @@ edition = "2024"
 publish = false
 
 [dependencies]
-understory_responder = { path = "../understory_responder", features = [
+understory_responder = { workspace = true, features = [
   "box_tree_adapter",
   "hit2d_adapter",
   "std",
 ] }
 kurbo = { workspace = true, default-features = true }
-understory_box_tree = { path = "../understory_box_tree" }
-understory_focus = { path = "../understory_focus" }
-understory_index = { path = "../understory_index" }
-understory_precise_hit = { path = "../understory_precise_hit" }
-understory_event_state = { path = "../understory_event_state" }
-understory_inspector = { path = "../understory_inspector" }
-understory_outline = { path = "../understory_outline" }
-understory_timing = { path = "../understory_timing" }
-understory_transcript = { path = "../understory_transcript" }
-understory_virtual_list = { path = "../understory_virtual_list" }
+understory_box_tree = { workspace = true, features = ["std"] }
+understory_event_state = { workspace = true, features = [
+  "click",
+  "drag",
+  "std",
+] }
+understory_focus = { workspace = true, features = ["std"] }
+understory_index = { workspace = true, features = ["backend_grid"] }
+understory_inspector = { workspace = true, features = ["std"] }
+understory_outline = { workspace = true, features = ["std"] }
+understory_precise_hit = { workspace = true, features = ["std"] }
+understory_timing.workspace = true
+understory_transcript = { workspace = true, features = ["std"] }
+understory_virtual_list = { workspace = true, features = ["std"] }

--- a/understory_box_tree/Cargo.toml
+++ b/understory_box_tree/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["data-structures", "graphics", "no-std"]
 [dependencies]
 kurbo.workspace = true
 bitflags.workspace = true
-understory_index = { path = "../understory_index" }
+understory_index = { workspace = true, features = ["backend_grid"] }
 
 [lints]
 workspace = true

--- a/understory_event_state/Cargo.toml
+++ b/understory_event_state/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["ui", "events", "state", "no_std", "understory"]
 categories = ["gui", "no-std"]
 
 [dependencies]
-kurbo = { workspace = true, default-features = false, optional = true }
+kurbo = { workspace = true, optional = true }
 
 
 [lints]

--- a/understory_focus/Cargo.toml
+++ b/understory_focus/Cargo.toml
@@ -10,8 +10,10 @@ categories = ["gui", "data-structures"]
 
 [dependencies]
 kurbo.workspace = true
-understory_box_tree = { path = "../understory_box_tree", default-features = false, optional = true }
-understory_index = { path = "../understory_index", optional = true }
+understory_box_tree = { workspace = true, optional = true }
+understory_index = { workspace = true, features = [
+  "backend_grid",
+], optional = true }
 
 [lints]
 workspace = true

--- a/understory_guide/Cargo.toml
+++ b/understory_guide/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["gui", "graphics", "no-std"]
 
 [dependencies]
 kurbo.workspace = true
-understory_axis = { path = "../understory_axis", default-features = false }
+understory_axis.workspace = true
 
 [lints]
 workspace = true

--- a/understory_inspector/Cargo.toml
+++ b/understory_inspector/Cargo.toml
@@ -9,9 +9,9 @@ keywords = ["ui", "inspector", "outline", "no_std", "understory"]
 categories = ["gui", "data-structures", "no-std"]
 
 [dependencies]
-understory_outline = { path = "../understory_outline", default-features = false }
-understory_selection = { path = "../understory_selection", default-features = false }
-understory_virtual_list = { path = "../understory_virtual_list", default-features = false }
+understory_outline.workspace = true
+understory_selection.workspace = true
+understory_virtual_list.workspace = true
 
 [lints]
 workspace = true

--- a/understory_responder/Cargo.toml
+++ b/understory_responder/Cargo.toml
@@ -24,9 +24,9 @@ box_tree_adapter = ["dep:understory_box_tree", "dep:kurbo", "libm"]
 hit2d_adapter = ["dep:understory_precise_hit", "dep:kurbo"]
 
 [dependencies]
-understory_box_tree = { path = "../understory_box_tree", default-features = false, optional = true }
-kurbo = { workspace = true, default-features = false, optional = true }
-understory_precise_hit = { path = "../understory_precise_hit", default-features = false, optional = true }
+understory_box_tree = { workspace = true, optional = true }
+kurbo = { workspace = true, optional = true }
+understory_precise_hit = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/understory_style/Cargo.toml
+++ b/understory_style/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["style", "theme", "ui", "framework", "no_std"]
 categories = ["data-structures", "no-std"]
 
 [dependencies]
-understory_property = { path = "../understory_property" }
+understory_property.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Move internal workspace crates into the root workspace dependency table with both path and version requirements, so publishable crates inherit packaging-ready dependency metadata from one place.

Switch member crates, examples, and benches to workspace dependencies while preserving explicit std/backend feature choices where plain path dependencies previously enabled defaults.

Add a CI package-list check over the publishable crate list to catch missing path dependency versions before release.