### PR TITLE
virtual_list: expose half-open viewport ranges

### DIFF
--- a/examples/examples/outline_virtual_list.rs
+++ b/examples/examples/outline_virtual_list.rs
@@ -166,7 +166,8 @@ fn print_visible_rows(
         strip.after_extent
     );
 
-    let visible_rows: Vec<_> = (strip.start..strip.end)
+    let visible_rows: Vec<_> = strip
+        .range()
         .filter_map(|index| outline.visible_row(index).map(|row| (row.key, row.depth)))
         .collect();
 

--- a/understory_inspector/src/inspector.rs
+++ b/understory_inspector/src/inspector.rs
@@ -136,8 +136,7 @@ where
     /// Returns the realized visible-row range for the current viewport and overscan.
     #[must_use]
     pub fn realized_range(&mut self) -> Range<usize> {
-        let strip = self.list.visible_strip();
-        strip.start..strip.end
+        self.list.visible_range()
     }
 
     /// Returns the current scroll offset.

--- a/understory_virtual_list/CHANGELOG.md
+++ b/understory_virtual_list/CHANGELOG.md
@@ -13,6 +13,12 @@ You can find its changes [documented below](#011-2026-05-17).
 
 ## [Unreleased]
 
+### Added
+
+- Added half-open range helpers for materialized and viewport ranges:
+  `VisibleStrip::range`, `VirtualList::visible_range`, `VirtualList::viewport_strip`,
+  and `VirtualList::viewport_range`. ([#169][] by [@waywardmonkeys][])
+
 ## [0.1.1][] (2026-05-17)
 
 This release has an [MSRV][] of 1.88.
@@ -44,6 +50,7 @@ This is the initial release.
 
 [#165]: https://github.com/forest-rs/understory/pull/165
 [#166]: https://github.com/forest-rs/understory/pull/166
+[#169]: https://github.com/forest-rs/understory/pull/169
 
 [Unreleased]: https://github.com/forest-rs/understory/compare/understory_virtual_list-v0.1.1...HEAD
 [0.1.1]: https://github.com/forest-rs/understory/compare/understory_virtual_list-v0.1.0...understory_virtual_list-v0.1.1

--- a/understory_virtual_list/README.md
+++ b/understory_virtual_list/README.md
@@ -51,6 +51,9 @@ particular UI framework. Host frameworks are responsible for:
 - Owning the actual data and view/widget instances.
 - Calling [`VirtualList::visible_strip`] when scroll or viewport changes.
 - Diffing the returned `[start, end)` index range to create/destroy children.
+  Use [`VirtualList::visible_range`] for the materialized range including
+  overscan, and [`VirtualList::viewport_range`] for the range that overlaps
+  the viewport itself.
 - Feeding measured item sizes back into an [`ExtentModel`] (for example via
   [`PrefixSumExtentModel`]).
 
@@ -72,8 +75,13 @@ let strip = list.visible_strip();
 assert!(strip.start < strip.end);
 assert!(strip.content_extent > 0.0);
 
-// Host frameworks would now instantiate views for indices `start..end`
+// Host frameworks would now instantiate views for indices in `strip.range()`
 // and position them after `before_extent` worth of spacer.
+assert_eq!(strip.range(), list.visible_range());
+
+// To report the non-overscanned range that overlaps the viewport:
+let range_in_viewport = list.viewport_range();
+assert!(range_in_viewport.start <= range_in_viewport.end);
 ```
 
 For non-uniform item sizes, use either [`PrefixSumExtentModel`] if all items are readily
@@ -138,6 +146,8 @@ This crate is `no_std` and uses `alloc`.
 [`SparsePrefixSumExtentModel::total_extent_for_len`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.SparsePrefixSumExtentModel.html#method.total_extent_for_len
 [`TailAnchoredExtentModel`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.TailAnchoredExtentModel.html
 [`VirtualList`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html
+[`VirtualList::viewport_range`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.viewport_range
+[`VirtualList::visible_range`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.visible_range
 [`VirtualList::visible_strip`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.visible_strip
 [`VisibleStrip`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VisibleStrip.html
 

--- a/understory_virtual_list/src/lib.rs
+++ b/understory_virtual_list/src/lib.rs
@@ -34,6 +34,9 @@
 //! - Owning the actual data and view/widget instances.
 //! - Calling [`VirtualList::visible_strip`] when scroll or viewport changes.
 //! - Diffing the returned `[start, end)` index range to create/destroy children.
+//!   Use [`VirtualList::visible_range`] for the materialized range including
+//!   overscan, and [`VirtualList::viewport_range`] for the range that overlaps
+//!   the viewport itself.
 //! - Feeding measured item sizes back into an [`ExtentModel`] (for example via
 //!   [`PrefixSumExtentModel`]).
 //!
@@ -55,8 +58,13 @@
 //! assert!(strip.start < strip.end);
 //! assert!(strip.content_extent > 0.0);
 //!
-//! // Host frameworks would now instantiate views for indices `start..end`
+//! // Host frameworks would now instantiate views for indices in `strip.range()`
 //! // and position them after `before_extent` worth of spacer.
+//! assert_eq!(strip.range(), list.visible_range());
+//!
+//! // To report the non-overscanned range that overlaps the viewport:
+//! let range_in_viewport = list.viewport_range();
+//! assert!(range_in_viewport.start <= range_in_viewport.end);
 //! ```
 //!
 //! For non-uniform item sizes, use either [`PrefixSumExtentModel`] if all items are readily

--- a/understory_virtual_list/src/model.rs
+++ b/understory_virtual_list/src/model.rs
@@ -3,7 +3,7 @@
 
 //! Core extent model traits and helpers.
 
-use core::cmp;
+use core::{cmp, ops::Range};
 
 use crate::Scalar;
 
@@ -24,6 +24,18 @@ pub struct VisibleStrip<S: Scalar> {
 }
 
 impl<S: Scalar> VisibleStrip<S> {
+    /// Returns the half-open index range covered by this strip.
+    ///
+    /// The returned range is always `start..end`, with `end` excluded. Empty
+    /// strips are represented as `idx..idx`, matching Rust collection APIs.
+    #[must_use]
+    pub const fn range(&self) -> Range<usize> {
+        Range {
+            start: self.start,
+            end: self.end,
+        }
+    }
+
     /// Returns `true` if there are no visible items.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
@@ -324,12 +336,14 @@ mod tests {
         // Three items of 10 each, viewport at offset 5 with size 10 → items 0..2 visible.
         let mut model = SimpleModel::new(&[10.0, 10.0, 10.0]);
         let strip = compute_visible_strip(&mut model, 5.0, 10.0, 0.0, 0.0);
+        assert_eq!(strip.range(), 0..2);
         assert_eq!(strip.len(), 2);
         assert!((strip.visible_extent() - 20.0_f32).abs() < 1e-5);
 
         // Empty model → len 0, visible_extent 0.
         let mut model = SimpleModel::new(&[]);
         let strip = compute_visible_strip(&mut model, 0.0, 100.0, 0.0, 0.0);
+        assert_eq!(strip.range(), 0..0);
         assert_eq!(strip.len(), 0);
         assert!(strip.is_empty());
         assert!((strip.visible_extent() - 0.0_f32).abs() < 1e-5);
@@ -346,6 +360,7 @@ mod tests {
         assert_eq!(strip.after_extent, 0.0);
         assert_eq!(strip.content_extent, 30.0);
         assert_eq!(strip.visible_extent(), 0.0);
+        assert_eq!(strip.range(), 3..3);
     }
 
     #[test]
@@ -359,6 +374,7 @@ mod tests {
         assert_eq!(strip.after_extent, 20.0);
         assert_eq!(strip.content_extent, 30.0);
         assert_eq!(strip.visible_extent(), 0.0);
+        assert_eq!(strip.range(), 1..1);
     }
 
     #[test]

--- a/understory_virtual_list/src/virtual_list.rs
+++ b/understory_virtual_list/src/virtual_list.rs
@@ -3,6 +3,8 @@
 
 //! A small controller that owns an [`ExtentModel`] and scroll state.
 
+use core::ops::Range;
+
 use crate::{ExtentModel, Scalar, TailAnchoredExtentModel, VisibleStrip, compute_visible_strip};
 
 /// Alignment mode when scrolling a specific index into view.
@@ -132,7 +134,9 @@ impl<M: ExtentModel> VirtualList<M> {
         self.overscan_after
     }
 
-    /// Computes or returns the cached visible strip.
+    /// Computes or returns the cached materialized strip.
+    ///
+    /// This strip includes the configured overscan before and after the viewport.
     #[must_use]
     pub fn visible_strip(&mut self) -> VisibleStrip<M::Scalar> {
         if self.dirty {
@@ -148,12 +152,45 @@ impl<M: ExtentModel> VirtualList<M> {
         self.last_strip
     }
 
-    /// Convenience iterator over visible indices.
+    /// Returns the half-open materialized index range, including overscan.
+    ///
+    /// This is equivalent to `self.visible_strip().range()`.
+    #[must_use]
+    pub fn visible_range(&mut self) -> Range<usize> {
+        self.visible_strip().range()
+    }
+
+    /// Computes the viewport strip without overscan.
+    ///
+    /// Use this when host code needs the indices that overlap the viewport
+    /// itself, rather than the larger materialized range. The returned strip
+    /// uses the same half-open `[start, end)` convention as
+    /// [`VirtualList::visible_strip`].
+    #[must_use]
+    pub fn viewport_strip(&mut self) -> VisibleStrip<M::Scalar> {
+        compute_visible_strip(
+            &mut self.model,
+            self.scroll_offset,
+            self.viewport_extent,
+            M::Scalar::zero(),
+            M::Scalar::zero(),
+        )
+    }
+
+    /// Returns the half-open index range that overlaps the viewport.
+    ///
+    /// This excludes overscan and includes partially visible items. Empty
+    /// viewports are represented as `idx..idx`, matching Rust collection APIs.
+    #[must_use]
+    pub fn viewport_range(&mut self) -> Range<usize> {
+        self.viewport_strip().range()
+    }
+
+    /// Convenience iterator over materialized indices, including overscan.
     pub fn visible_indices(
         &mut self,
     ) -> impl DoubleEndedIterator<Item = usize> + ExactSizeIterator + use<M> {
-        let strip = self.visible_strip();
-        strip.start..strip.end
+        self.visible_range()
     }
 
     /// Returns the first visible index, if any.
@@ -373,6 +410,41 @@ mod tests {
         assert_eq!(strip.end, 6);
         assert_eq!(list.first_visible_index(), Some(1));
         assert_eq!(list.last_visible_index(), Some(5));
+    }
+
+    #[test]
+    fn range_helpers_use_half_open_ranges() {
+        let model = FixedExtentModel::new(10, 10.0_f32);
+        let mut list = VirtualList::new(model, 20.0_f32, 10.0_f32);
+        list.set_scroll_offset(10.0_f32);
+
+        assert_eq!(list.visible_range(), 0..4);
+        assert_eq!(
+            list.visible_indices().collect::<alloc::vec::Vec<_>>(),
+            alloc::vec![0, 1, 2, 3]
+        );
+        assert_eq!(list.viewport_range(), 1..3);
+
+        let viewport = list.viewport_strip();
+        assert_eq!(viewport.range(), 1..3);
+        assert_eq!(viewport.start, 1);
+        assert_eq!(viewport.end, 3);
+    }
+
+    #[test]
+    fn viewport_range_handles_empty_and_single_item_ranges() {
+        let model = FixedExtentModel::new(5, 10.0_f32);
+        let mut list = VirtualList::new(model, 10.0_f32, 0.0);
+
+        list.set_scroll_offset(10.0_f32);
+        assert_eq!(list.viewport_range(), 1..2);
+
+        list.set_viewport_extent(0.0_f32);
+        list.set_scroll_offset(15.0_f32);
+        assert_eq!(list.viewport_range(), 1..1);
+
+        list.set_scroll_offset(50.0_f32);
+        assert_eq!(list.viewport_range(), 5..5);
     }
 
     #[test]


### PR DESCRIPTION
Host integrations need both the materialized range, including overscan, and the range that actually overlaps the viewport. Exposing both as half-open `Range<usize>` values keeps caller code aligned with Rust collection APIs and avoids inclusive-endpoint bugs around single-item and empty viewport cases.

Add `VisibleStrip::range`, `VirtualList::visible_range`, `VirtualList::viewport_strip`, and `VirtualList::viewport_range`, plus regression coverage for empty and single-item ranges.