### PR TITLE
virtual_list: add host model helpers

### DIFF
--- a/examples/examples/outline_virtual_list.rs
+++ b/examples/examples/outline_virtual_list.rs
@@ -144,7 +144,7 @@ fn sync_list_from_outline(
     list: &mut VirtualList<FixedExtentModel<f64>>,
 ) {
     let visible_len = outline.visible_len();
-    list.model_mut().set_len(visible_len);
+    list.set_len(visible_len);
     list.clamp_scroll_to_content();
 }
 

--- a/understory_inspector/src/inspector.rs
+++ b/understory_inspector/src/inspector.rs
@@ -179,7 +179,7 @@ where
     /// selection, and virtual-list length.
     pub fn sync(&mut self) {
         let visible_len = self.outline.visible_len();
-        self.list.model_mut().set_len(visible_len);
+        self.list.set_len(visible_len);
         self.reconcile_focus();
         self.prune_selection_to_visible();
         self.scroll_focus_into_view();

--- a/understory_virtual_list/CHANGELOG.md
+++ b/understory_virtual_list/CHANGELOG.md
@@ -18,6 +18,9 @@ You can find its changes [documented below](#011-2026-05-17).
 - Added half-open range helpers for materialized and viewport ranges:
   `VisibleStrip::range`, `VirtualList::visible_range`, `VirtualList::viewport_strip`,
   and `VirtualList::viewport_range`. ([#169][] by [@waywardmonkeys][])
+- Added `VirtualList::set_len` for resizable models, `ResizableExtentModel` for
+  `TailAnchoredExtentModel`, and model query wrappers on `VirtualList` that do
+  not invalidate its cached visible strip. ([#170][] by [@waywardmonkeys][])
 
 ## [0.1.1][] (2026-05-17)
 
@@ -51,6 +54,7 @@ This is the initial release.
 [#165]: https://github.com/forest-rs/understory/pull/165
 [#166]: https://github.com/forest-rs/understory/pull/166
 [#169]: https://github.com/forest-rs/understory/pull/169
+[#170]: https://github.com/forest-rs/understory/pull/170
 
 [Unreleased]: https://github.com/forest-rs/understory/compare/understory_virtual_list-v0.1.1...HEAD
 [0.1.1]: https://github.com/forest-rs/understory/compare/understory_virtual_list-v0.1.0...understory_virtual_list-v0.1.1

--- a/understory_virtual_list/README.md
+++ b/understory_virtual_list/README.md
@@ -54,6 +54,8 @@ particular UI framework. Host frameworks are responsible for:
   Use [`VirtualList::visible_range`] for the materialized range including
   overscan, and [`VirtualList::viewport_range`] for the range that overlaps
   the viewport itself.
+- Calling [`VirtualList::set_len`] when the backing collection length changes
+  and the model implements [`ResizableExtentModel`].
 - Feeding measured item sizes back into an [`ExtentModel`] (for example via
   [`PrefixSumExtentModel`]).
 
@@ -137,6 +139,7 @@ This crate is `no_std` and uses `alloc`.
 [`PrefixSumExtentModel::rebuild`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.PrefixSumExtentModel.html#method.rebuild
 [`PrefixSumExtentModel::set_extent`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.PrefixSumExtentModel.html#method.set_extent
 [`PrefixSumExtentModel::total_extent_for_len`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.PrefixSumExtentModel.html#method.total_extent_for_len
+[`ResizableExtentModel`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/trait.ResizableExtentModel.html
 [`Scalar`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/trait.Scalar.html
 [`ScrollAlign`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/enum.ScrollAlign.html
 [`SparsePrefixSumExtentModel`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.SparsePrefixSumExtentModel.html
@@ -146,6 +149,7 @@ This crate is `no_std` and uses `alloc`.
 [`SparsePrefixSumExtentModel::total_extent_for_len`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.SparsePrefixSumExtentModel.html#method.total_extent_for_len
 [`TailAnchoredExtentModel`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.TailAnchoredExtentModel.html
 [`VirtualList`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html
+[`VirtualList::set_len`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.set_len
 [`VirtualList::viewport_range`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.viewport_range
 [`VirtualList::visible_range`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.visible_range
 [`VirtualList::visible_strip`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.visible_strip

--- a/understory_virtual_list/src/lib.rs
+++ b/understory_virtual_list/src/lib.rs
@@ -37,6 +37,8 @@
 //!   Use [`VirtualList::visible_range`] for the materialized range including
 //!   overscan, and [`VirtualList::viewport_range`] for the range that overlaps
 //!   the viewport itself.
+//! - Calling [`VirtualList::set_len`] when the backing collection length changes
+//!   and the model implements [`ResizableExtentModel`].
 //! - Feeding measured item sizes back into an [`ExtentModel`] (for example via
 //!   [`PrefixSumExtentModel`]).
 //!

--- a/understory_virtual_list/src/model.rs
+++ b/understory_virtual_list/src/model.rs
@@ -66,6 +66,10 @@ impl<S: Scalar> VisibleStrip<S> {
 /// Methods that logically consult prefix sums take `&mut self` so implementations
 /// are free to maintain internal caches without exposing interior mutability at
 /// the call site.
+///
+/// Query methods may update derived caches, but should not change the logical
+/// item count or item extents. Use model-specific mutation APIs or
+/// [`ResizableExtentModel::set_len`] for changes that alter the strip geometry.
 pub trait ExtentModel {
     /// Scalar type used for extents and offsets.
     type Scalar: Scalar;

--- a/understory_virtual_list/src/tail_anchored.rs
+++ b/understory_virtual_list/src/tail_anchored.rs
@@ -45,8 +45,8 @@
 //!
 //! // Append a new item and give it an extent.
 //! {
+//!     list.set_len(4);
 //!     let inner = list.model_mut().inner_mut();
-//!     inner.set_len(4);
 //!     inner.set_extent(3, 10.0);
 //! }
 //!
@@ -55,7 +55,7 @@
 //! assert!(list.is_at_tail());
 //! ```
 
-use crate::{ExtentModel, Scalar};
+use crate::{ExtentModel, ResizableExtentModel, Scalar};
 
 /// Wraps an [`ExtentModel`] with tail-anchoring helpers.
 ///
@@ -180,6 +180,12 @@ impl<M: ExtentModel> ExtentModel for TailAnchoredExtentModel<M> {
 
     fn index_at_offset(&mut self, offset: Self::Scalar) -> usize {
         self.inner.index_at_offset(offset)
+    }
+}
+
+impl<M: ResizableExtentModel> ResizableExtentModel for TailAnchoredExtentModel<M> {
+    fn set_len(&mut self, len: usize) {
+        self.inner.set_len(len);
     }
 }
 

--- a/understory_virtual_list/src/virtual_list.rs
+++ b/understory_virtual_list/src/virtual_list.rs
@@ -5,7 +5,10 @@
 
 use core::ops::Range;
 
-use crate::{ExtentModel, Scalar, TailAnchoredExtentModel, VisibleStrip, compute_visible_strip};
+use crate::{
+    ExtentModel, ResizableExtentModel, Scalar, TailAnchoredExtentModel, VisibleStrip,
+    compute_visible_strip,
+};
 
 /// Alignment mode when scrolling a specific index into view.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,6 +77,67 @@ impl<M: ExtentModel> VirtualList<M> {
     pub fn model_mut(&mut self) -> &mut M {
         self.dirty = true;
         &mut self.model
+    }
+
+    /// Returns the number of items in the underlying model.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.model.len()
+    }
+
+    /// Returns `true` if the underlying model contains no items.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.model.is_empty()
+    }
+
+    /// Returns the total extent of the underlying model.
+    ///
+    /// Unlike [`VirtualList::model_mut`], this may update model-internal
+    /// caches without marking the cached materialized strip dirty.
+    #[must_use]
+    pub fn total_extent(&mut self) -> M::Scalar {
+        self.model.total_extent()
+    }
+
+    /// Returns the extent of `index` in the underlying model.
+    ///
+    /// Unlike [`VirtualList::model_mut`], this may update model-internal
+    /// caches without marking the cached materialized strip dirty.
+    #[must_use]
+    pub fn extent_of(&mut self, index: usize) -> M::Scalar {
+        self.model.extent_of(index)
+    }
+
+    /// Returns the offset of `index` in the underlying model.
+    ///
+    /// Unlike [`VirtualList::model_mut`], this may update model-internal
+    /// caches without marking the cached materialized strip dirty.
+    #[must_use]
+    pub fn offset_of(&mut self, index: usize) -> M::Scalar {
+        self.model.offset_of(index)
+    }
+
+    /// Finds the greatest index whose item starts at or before `offset`.
+    ///
+    /// This mirrors [`ExtentModel::index_at_offset`], including returning `0`
+    /// as a sentinel when the model is empty. Prefer
+    /// [`VirtualList::try_index_at_offset`] when the model may be empty.
+    ///
+    /// Unlike [`VirtualList::model_mut`], this may update model-internal
+    /// caches without marking the cached materialized strip dirty.
+    #[must_use]
+    pub fn index_at_offset(&mut self, offset: M::Scalar) -> usize {
+        self.model.index_at_offset(offset)
+    }
+
+    /// Like [`VirtualList::index_at_offset`], but returns `None` when the model is empty.
+    ///
+    /// Unlike [`VirtualList::model_mut`], this may update model-internal
+    /// caches without marking the cached materialized strip dirty.
+    #[must_use]
+    pub fn try_index_at_offset(&mut self, offset: M::Scalar) -> Option<usize> {
+        self.model.try_index_at_offset(offset)
     }
 
     /// Returns the current scroll offset.
@@ -333,6 +397,18 @@ impl<M: ExtentModel> VirtualList<M> {
     }
 }
 
+impl<M: ResizableExtentModel> VirtualList<M> {
+    /// Sets the logical length of the underlying model and invalidates the cached strip.
+    ///
+    /// This is a convenience wrapper for hosts whose backing collection length
+    /// changes, avoiding a broad [`VirtualList::model_mut`] borrow when only
+    /// the model length needs to change.
+    pub fn set_len(&mut self, len: usize) {
+        self.model.set_len(len);
+        self.dirty = true;
+    }
+}
+
 impl<M: ExtentModel> VirtualList<TailAnchoredExtentModel<M>> {
     /// Returns `true` if the current scroll offset is considered anchored to the tail.
     ///
@@ -391,7 +467,71 @@ impl<M: ExtentModel> VirtualList<TailAnchoredExtentModel<M>> {
 #[cfg(test)]
 mod tests {
     use super::ScrollAlign;
-    use crate::{FixedExtentModel, GridTrackModel, TailAnchoredExtentModel, VirtualList};
+    use crate::{
+        ExtentModel, FixedExtentModel, GridTrackModel, TailAnchoredExtentModel, VirtualList,
+    };
+
+    #[derive(Debug, Clone)]
+    struct CountingModel {
+        len: usize,
+        extent: f32,
+        total_extent_calls: usize,
+        offset_of_calls: usize,
+        extent_of_calls: usize,
+        index_at_offset_calls: usize,
+    }
+
+    impl CountingModel {
+        fn new(len: usize, extent: f32) -> Self {
+            Self {
+                len,
+                extent,
+                total_extent_calls: 0,
+                offset_of_calls: 0,
+                extent_of_calls: 0,
+                index_at_offset_calls: 0,
+            }
+        }
+    }
+
+    impl ExtentModel for CountingModel {
+        type Scalar = f32;
+
+        fn len(&self) -> usize {
+            self.len
+        }
+
+        fn total_extent(&mut self) -> Self::Scalar {
+            self.total_extent_calls += 1;
+            self.len as f32 * self.extent
+        }
+
+        fn extent_of(&mut self, index: usize) -> Self::Scalar {
+            self.extent_of_calls += 1;
+            if index < self.len { self.extent } else { 0.0 }
+        }
+
+        fn offset_of(&mut self, index: usize) -> Self::Scalar {
+            self.offset_of_calls += 1;
+            index.min(self.len) as f32 * self.extent
+        }
+
+        fn index_at_offset(&mut self, offset: Self::Scalar) -> usize {
+            self.index_at_offset_calls += 1;
+            if self.len == 0 {
+                return 0;
+            }
+
+            let mut item_offset = 0.0;
+            for index in 0..self.len {
+                if item_offset + self.extent > offset {
+                    return index;
+                }
+                item_offset += self.extent;
+            }
+            self.len - 1
+        }
+    }
 
     #[test]
     fn visible_strip_tracks_scroll_and_viewport() {
@@ -516,6 +656,53 @@ mod tests {
     }
 
     #[test]
+    fn set_len_resizes_model_and_invalidates_cached_strip() {
+        let model = FixedExtentModel::new(2, 10.0_f32);
+        let mut list = VirtualList::new(model, 30.0_f32, 0.0);
+
+        assert_eq!(list.visible_range(), 0..2);
+
+        list.set_len(5);
+        assert_eq!(list.len(), 5);
+        assert!(!list.is_empty());
+        assert_eq!(list.visible_range(), 0..3);
+
+        list.set_len(0);
+        assert!(list.is_empty());
+        assert_eq!(list.visible_range(), 0..0);
+    }
+
+    #[test]
+    fn set_len_works_through_tail_anchored_models() {
+        let inner = FixedExtentModel::new(2, 10.0_f32);
+        let ta = TailAnchoredExtentModel::with_default_epsilon(inner);
+        let mut list = VirtualList::new(ta, 30.0_f32, 0.0);
+
+        list.set_len(5);
+
+        assert_eq!(list.len(), 5);
+        assert_eq!(list.visible_range(), 0..3);
+    }
+
+    #[test]
+    fn model_query_wrappers_do_not_dirty_cached_strip() {
+        let model = CountingModel::new(5, 10.0_f32);
+        let mut list = VirtualList::new(model, 30.0_f32, 0.0);
+
+        assert_eq!(list.visible_range(), 0..3);
+        let total_extent_calls = list.model().total_extent_calls;
+
+        assert_eq!(list.total_extent(), 50.0_f32);
+        assert_eq!(list.offset_of(2), 20.0_f32);
+        assert_eq!(list.extent_of(2), 10.0_f32);
+        assert_eq!(list.index_at_offset(25.0_f32), 2);
+        assert_eq!(list.try_index_at_offset(45.0_f32), Some(4));
+
+        assert_eq!(list.visible_range(), 0..3);
+        assert_eq!(list.model().total_extent_calls, total_extent_calls + 1);
+    }
+
+    #[test]
     fn grid_virtual_list_covers_all_cells_in_visible_tracks() {
         // 1000 cells, 3 cells per track, enough tracks to cover all cells.
         let total_cells: usize = 1000;
@@ -593,7 +780,7 @@ mod tests {
         assert!((list.scroll_offset() - 70.0_f32).abs() < 1e-5);
         let was_at_tail = list.is_at_tail();
 
-        list.model_mut().inner_mut().set_len(11);
+        list.set_len(11);
         list.restore_tail_anchor(was_at_tail);
 
         assert!((list.scroll_offset() - 80.0_f32).abs() < 1e-5);
@@ -609,7 +796,7 @@ mod tests {
         list.set_scroll_offset(10.0_f32);
         let was_at_tail = list.is_at_tail();
 
-        list.model_mut().inner_mut().set_len(11);
+        list.set_len(11);
         list.restore_tail_anchor(was_at_tail);
 
         assert!((list.scroll_offset() - 10.0_f32).abs() < 1e-5);


### PR DESCRIPTION
Host integrations should not need to call `VirtualList::model_mut` just to resize a resizable list or consult prefix-sum-backed model queries. `VirtualList::model_mut` invalidates the cached materialized strip because arbitrary mutation may change layout; read-only model queries only update model-internal caches.

Add `VirtualList::set_len` for `ResizableExtentModel`, forward `ResizableExtentModel` through `TailAnchoredExtentModel`, and expose `VirtualList` wrappers for `len`, `is_empty`, `total_extent`, `extent_of`, `offset_of`, `index_at_offset`, and `try_index_at_offset`.

Update `Inspector::sync` and the `outline_virtual_list` example to use `VirtualList::set_len`.