### PR TITLE
virtual_list: add materialized range names

### DIFF
--- a/examples/examples/outline_virtual_list.rs
+++ b/examples/examples/outline_virtual_list.rs
@@ -152,7 +152,7 @@ fn print_visible_rows(
     outline: &mut Outline<InspectorModel<'_>>,
     list: &mut VirtualList<FixedExtentModel<f64>>,
 ) {
-    let strip = list.visible_strip();
+    let strip = list.materialized_strip();
     println!(
         "rows={} realized={}..{} scroll={} viewport={} overscan_before={} overscan_after={} before={} after={}",
         outline.visible_len(),

--- a/examples/examples/transcript_tail_anchored.rs
+++ b/examples/examples/transcript_tail_anchored.rs
@@ -71,7 +71,7 @@ fn print_tail_state(
     transcript: &Transcript,
     list: &mut VirtualList<TailAnchoredExtentModel<PrefixSumExtentModel<f32>>>,
 ) {
-    let strip = list.visible_strip();
+    let strip = list.materialized_strip();
     println!(
         "scroll={:.1} is_at_tail={} realized={}..{} before={:.1} after={:.1} content={:.1}",
         list.scroll_offset(),
@@ -83,7 +83,7 @@ fn print_tail_state(
         strip.content_extent
     );
 
-    for index in list.visible_indices() {
+    for index in list.materialized_indices() {
         let entry = &transcript.entries()[index];
         println!("- [{}] {:?}", index, entry.kind);
     }

--- a/examples/examples/transcript_virtual_list.rs
+++ b/examples/examples/transcript_virtual_list.rs
@@ -91,7 +91,7 @@ fn entry_extent(entry: &TranscriptEntry) -> f32 {
 }
 
 fn print_strip(transcript: &Transcript, list: &mut VirtualList<PrefixSumExtentModel<f32>>) {
-    let strip = list.visible_strip();
+    let strip = list.materialized_strip();
     println!(
         "scroll={:.1} viewport={:.1} overscan=({:.1},{:.1}) realized={}..{} before={:.1} after={:.1} content={:.1}",
         list.scroll_offset(),
@@ -105,7 +105,7 @@ fn print_strip(transcript: &Transcript, list: &mut VirtualList<PrefixSumExtentMo
         strip.content_extent
     );
 
-    for index in list.visible_indices() {
+    for index in list.materialized_indices() {
         let entry = &transcript.entries()[index];
         println!("- [{}] {:.1} {:?}", index, entry_extent(entry), entry.kind);
     }

--- a/understory_inspector/src/inspector.rs
+++ b/understory_inspector/src/inspector.rs
@@ -133,10 +133,10 @@ where
         self.outline.item(key)
     }
 
-    /// Returns the realized visible-row range for the current viewport and overscan.
+    /// Returns the realized row range for the current viewport and overscan.
     #[must_use]
     pub fn realized_range(&mut self) -> Range<usize> {
-        self.list.visible_range()
+        self.list.materialized_range()
     }
 
     /// Returns the current scroll offset.

--- a/understory_virtual_list/CHANGELOG.md
+++ b/understory_virtual_list/CHANGELOG.md
@@ -15,12 +15,27 @@ You can find its changes [documented below](#011-2026-05-17).
 
 ### Added
 
-- Added half-open range helpers for materialized and viewport ranges:
-  `VisibleStrip::range`, `VirtualList::visible_range`, `VirtualList::viewport_strip`,
-  and `VirtualList::viewport_range`. ([#169][] by [@waywardmonkeys][])
+- Added `IndexStrip`, `IndexStrip::range`, `IndexStrip::covered_extent`,
+  `compute_materialized_strip`, `VirtualList::viewport_strip`, and
+  `VirtualList::viewport_range` for half-open materialized and viewport ranges.
+  ([#169][] and [#171][] by [@waywardmonkeys][])
 - Added `VirtualList::set_len` for resizable models, `ResizableExtentModel` for
   `TailAnchoredExtentModel`, and model query wrappers on `VirtualList` that do
-  not invalidate its cached visible strip. ([#170][] by [@waywardmonkeys][])
+  not invalidate its cached materialized strip. ([#170][] by [@waywardmonkeys][])
+- Added `VirtualList::materialized_strip`, `VirtualList::materialized_range`,
+  `VirtualList::materialized_indices`, `VirtualList::first_materialized_index`,
+  and `VirtualList::last_materialized_index` for the overscanned range that host
+  code should instantiate. ([#171][] by [@waywardmonkeys][])
+
+### Deprecated
+
+- Deprecated `VirtualList::visible_strip`, `VirtualList::visible_indices`,
+  `VirtualList::first_visible_index`, and `VirtualList::last_visible_index`;
+  these names implied viewport visibility, but their results include overscan.
+  ([#171][] by [@waywardmonkeys][])
+- Deprecated `VisibleStrip`, `VisibleStrip::visible_extent`, and
+  `compute_visible_strip`; these names implied viewport visibility, but the
+  result may include overscan. ([#171][] by [@waywardmonkeys][])
 
 ## [0.1.1][] (2026-05-17)
 
@@ -55,6 +70,7 @@ This is the initial release.
 [#166]: https://github.com/forest-rs/understory/pull/166
 [#169]: https://github.com/forest-rs/understory/pull/169
 [#170]: https://github.com/forest-rs/understory/pull/170
+[#171]: https://github.com/forest-rs/understory/pull/171
 
 [Unreleased]: https://github.com/forest-rs/understory/compare/understory_virtual_list-v0.1.1...HEAD
 [0.1.1]: https://github.com/forest-rs/understory/compare/understory_virtual_list-v0.1.0...understory_virtual_list-v0.1.1

--- a/understory_virtual_list/README.md
+++ b/understory_virtual_list/README.md
@@ -33,12 +33,12 @@ The core concepts are:
   and scroll positions.
 - [`ExtentModel`]: a trait describing a 1D strip of items with per-item extents
   and prefix-sum-style queries.
-- [`compute_visible_strip`]: a helper that, given a scroll offset, viewport
+- [`compute_materialized_strip`]: a helper that, given a scroll offset, viewport
   extent, and asymmetric overscan distances, returns which indices should be
-  realized plus how much padding exists before and after them.
+  materialized plus how much padding exists before and after them.
 - [`VirtualList`]: a small controller that wraps an [`ExtentModel`] implementation,
   scroll state, viewport extent, and overscan, and caches the most recent
-  [`VisibleStrip`]. It also provides index-based scrolling via [`ScrollAlign`]
+  [`IndexStrip`]. It also provides index-based scrolling via [`ScrollAlign`]
   and convenience methods for visibility queries and scroll clamping.
 - [`GridTrackModel`]: an adapter that maps a per-track [`ExtentModel`] onto a
   per-cell view for grid-like layouts (tracks × cells).
@@ -49,9 +49,9 @@ This crate deliberately does **not** know about widgets, display trees, or any
 particular UI framework. Host frameworks are responsible for:
 
 - Owning the actual data and view/widget instances.
-- Calling [`VirtualList::visible_strip`] when scroll or viewport changes.
+- Calling [`VirtualList::materialized_strip`] when scroll or viewport changes.
 - Diffing the returned `[start, end)` index range to create/destroy children.
-  Use [`VirtualList::visible_range`] for the materialized range including
+  Use [`VirtualList::materialized_range`] for the materialized range including
   overscan, and [`VirtualList::viewport_range`] for the range that overlaps
   the viewport itself.
 - Calling [`VirtualList::set_len`] when the backing collection length changes
@@ -73,13 +73,13 @@ let mut list = VirtualList::new(model, 200.0, 40.0);
 // Scroll to 100px from the start.
 list.set_scroll_offset(100.0);
 
-let strip = list.visible_strip();
+let strip = list.materialized_strip();
 assert!(strip.start < strip.end);
 assert!(strip.content_extent > 0.0);
 
 // Host frameworks would now instantiate views for indices in `strip.range()`
 // and position them after `before_extent` worth of spacer.
-assert_eq!(strip.range(), list.visible_range());
+assert_eq!(strip.range(), list.materialized_range());
 
 // To report the non-overscanned range that overlaps the viewport:
 let range_in_viewport = list.viewport_range();
@@ -120,9 +120,9 @@ let columns = NonZeroUsize::new(3).unwrap();
 let grid_model = GridTrackModel::new(row_model, columns, 12);
 let mut list = VirtualList::new(grid_model, 40.0, 0.0);
 
-let strip = list.visible_strip();
+let strip = list.materialized_strip();
 assert!(strip.start < strip.end);
-// Host code can map each visible cell index `i` to:
+// Host code can map each materialized cell index `i` to:
 //   let track = list.model().track_of_cell(i);
 //   let cell_in_track = list.model().cell_in_track(i);
 ```
@@ -131,9 +131,10 @@ This crate is `no_std` and uses `alloc`.
 
 <!-- cargo-rdme end -->
 
-[`compute_visible_strip`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/fn.compute_visible_strip.html
+[`compute_materialized_strip`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/fn.compute_materialized_strip.html
 [`ExtentModel`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/trait.ExtentModel.html
 [`GridTrackModel`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.GridTrackModel.html
+[`IndexStrip`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.IndexStrip.html
 [`PrefixSumExtentModel`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.PrefixSumExtentModel.html
 [`PrefixSumExtentModel::index_at_offset_for_len`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.PrefixSumExtentModel.html#method.index_at_offset_for_len
 [`PrefixSumExtentModel::rebuild`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.PrefixSumExtentModel.html#method.rebuild
@@ -149,11 +150,10 @@ This crate is `no_std` and uses `alloc`.
 [`SparsePrefixSumExtentModel::total_extent_for_len`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.SparsePrefixSumExtentModel.html#method.total_extent_for_len
 [`TailAnchoredExtentModel`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.TailAnchoredExtentModel.html
 [`VirtualList`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html
+[`VirtualList::materialized_range`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.materialized_range
+[`VirtualList::materialized_strip`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.materialized_strip
 [`VirtualList::set_len`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.set_len
 [`VirtualList::viewport_range`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.viewport_range
-[`VirtualList::visible_range`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.visible_range
-[`VirtualList::visible_strip`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VirtualList.html#method.visible_strip
-[`VisibleStrip`]: https://docs.rs/understory_virtual_list/latest/understory_virtual_list/struct.VisibleStrip.html
 
 ## Minimum supported Rust Version (MSRV)
 

--- a/understory_virtual_list/src/lib.rs
+++ b/understory_virtual_list/src/lib.rs
@@ -16,12 +16,12 @@
 //!   and scroll positions.
 //! - [`ExtentModel`]: a trait describing a 1D strip of items with per-item extents
 //!   and prefix-sum-style queries.
-//! - [`compute_visible_strip`]: a helper that, given a scroll offset, viewport
+//! - [`compute_materialized_strip`]: a helper that, given a scroll offset, viewport
 //!   extent, and asymmetric overscan distances, returns which indices should be
-//!   realized plus how much padding exists before and after them.
+//!   materialized plus how much padding exists before and after them.
 //! - [`VirtualList`]: a small controller that wraps an [`ExtentModel`] implementation,
 //!   scroll state, viewport extent, and overscan, and caches the most recent
-//!   [`VisibleStrip`]. It also provides index-based scrolling via [`ScrollAlign`]
+//!   [`IndexStrip`]. It also provides index-based scrolling via [`ScrollAlign`]
 //!   and convenience methods for visibility queries and scroll clamping.
 //! - [`GridTrackModel`]: an adapter that maps a per-track [`ExtentModel`] onto a
 //!   per-cell view for grid-like layouts (tracks × cells).
@@ -32,9 +32,9 @@
 //! particular UI framework. Host frameworks are responsible for:
 //!
 //! - Owning the actual data and view/widget instances.
-//! - Calling [`VirtualList::visible_strip`] when scroll or viewport changes.
+//! - Calling [`VirtualList::materialized_strip`] when scroll or viewport changes.
 //! - Diffing the returned `[start, end)` index range to create/destroy children.
-//!   Use [`VirtualList::visible_range`] for the materialized range including
+//!   Use [`VirtualList::materialized_range`] for the materialized range including
 //!   overscan, and [`VirtualList::viewport_range`] for the range that overlaps
 //!   the viewport itself.
 //! - Calling [`VirtualList::set_len`] when the backing collection length changes
@@ -56,13 +56,13 @@
 //! // Scroll to 100px from the start.
 //! list.set_scroll_offset(100.0);
 //!
-//! let strip = list.visible_strip();
+//! let strip = list.materialized_strip();
 //! assert!(strip.start < strip.end);
 //! assert!(strip.content_extent > 0.0);
 //!
 //! // Host frameworks would now instantiate views for indices in `strip.range()`
 //! // and position them after `before_extent` worth of spacer.
-//! assert_eq!(strip.range(), list.visible_range());
+//! assert_eq!(strip.range(), list.materialized_range());
 //!
 //! // To report the non-overscanned range that overlaps the viewport:
 //! let range_in_viewport = list.viewport_range();
@@ -103,9 +103,9 @@
 //! let grid_model = GridTrackModel::new(row_model, columns, 12);
 //! let mut list = VirtualList::new(grid_model, 40.0, 0.0);
 //!
-//! let strip = list.visible_strip();
+//! let strip = list.materialized_strip();
 //! assert!(strip.start < strip.end);
-//! // Host code can map each visible cell index `i` to:
+//! // Host code can map each materialized cell index `i` to:
 //! //   let track = list.model().track_of_cell(i);
 //! //   let cell_in_track = list.model().cell_in_track(i);
 //! ```
@@ -127,7 +127,12 @@ mod virtual_list;
 
 pub use fixed::FixedExtentModel;
 pub use grid_track::GridTrackModel;
-pub use model::{ExtentModel, ResizableExtentModel, VisibleStrip, compute_visible_strip};
+pub use model::{ExtentModel, IndexStrip, ResizableExtentModel, compute_materialized_strip};
+#[allow(
+    deprecated,
+    reason = "deprecated public aliases are re-exported for compatibility"
+)]
+pub use model::{VisibleStrip, compute_visible_strip};
 pub use prefix_sum::PrefixSumExtentModel;
 pub use scalar::Scalar;
 pub use sparse::SparsePrefixSumExtentModel;

--- a/understory_virtual_list/src/model.rs
+++ b/understory_virtual_list/src/model.rs
@@ -7,12 +7,15 @@ use core::{cmp, ops::Range};
 
 use crate::Scalar;
 
-/// Result of a visibility query over a 1D strip.
+/// Result of an index-strip query over a 1D extent model.
+///
+/// Depending on the query that produced it, this may describe the overscanned
+/// materialized range or the non-overscanned viewport range.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct VisibleStrip<S: Scalar> {
-    /// First visible index (inclusive).
+pub struct IndexStrip<S: Scalar> {
+    /// First covered index (inclusive).
     pub start: usize,
-    /// One past the last visible index (exclusive).
+    /// One past the last covered index (exclusive).
     pub end: usize,
 
     /// Total extent of items before `start`.
@@ -23,7 +26,14 @@ pub struct VisibleStrip<S: Scalar> {
     pub content_extent: S,
 }
 
-impl<S: Scalar> VisibleStrip<S> {
+/// Deprecated name for [`IndexStrip`].
+#[deprecated(
+    since = "0.1.2",
+    note = "use `IndexStrip`; this type can describe materialized or viewport ranges"
+)]
+pub type VisibleStrip<S> = IndexStrip<S>;
+
+impl<S: Scalar> IndexStrip<S> {
     /// Returns the half-open index range covered by this strip.
     ///
     /// The returned range is always `start..end`, with `end` excluded. Empty
@@ -36,25 +46,35 @@ impl<S: Scalar> VisibleStrip<S> {
         }
     }
 
-    /// Returns `true` if there are no visible items.
+    /// Returns `true` if this strip covers no items.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.start == self.end
     }
 
-    /// Returns the number of visible items in this strip.
+    /// Returns the number of covered items in this strip.
     #[must_use]
     pub const fn len(&self) -> usize {
         self.end - self.start
     }
 
-    /// Returns the total extent of the visible items in this strip.
+    /// Returns the total extent of the covered items in this strip.
     ///
     /// This is `content_extent - before_extent - after_extent`, clamped to
     /// zero to guard against floating-point rounding.
     #[must_use]
-    pub fn visible_extent(&self) -> S {
+    pub fn covered_extent(&self) -> S {
         (self.content_extent - self.before_extent - self.after_extent).max(S::zero())
+    }
+
+    /// Returns the total extent of the covered items in this strip.
+    #[deprecated(
+        since = "0.1.2",
+        note = "use `covered_extent`; this strip may describe materialized or viewport ranges"
+    )]
+    #[must_use]
+    pub fn visible_extent(&self) -> S {
+        self.covered_extent()
     }
 }
 
@@ -143,31 +163,31 @@ pub trait ResizableExtentModel: ExtentModel {
     fn set_len(&mut self, len: usize);
 }
 
-/// Compute the visible slice of a strip, given scroll position, viewport size, and overscan.
+/// Computes the materialized strip for a scroll position, viewport size, and overscan.
 ///
 /// - `scroll_offset`: top of the viewport in strip coordinates (`>= 0`).
 /// - `viewport_extent`: size of the viewport in strip coordinates (`>= 0`).
 /// - `overscan_before`: extra margin *before* the viewport to reduce popping.
 /// - `overscan_after`: extra margin *after* the viewport to reduce popping.
 ///
-/// The returned [`VisibleStrip`] tells you:
+/// The returned [`IndexStrip`] tells you:
 /// - Which indices to materialize: `[start, end)`.
-/// - How much padding to place before/after the realized chunk.
+/// - How much padding to place before/after the materialized chunk.
 /// - The total content extent.
-pub fn compute_visible_strip<M>(
+pub fn compute_materialized_strip<M>(
     model: &mut M,
     scroll_offset: M::Scalar,
     viewport_extent: M::Scalar,
     overscan_before: M::Scalar,
     overscan_after: M::Scalar,
-) -> VisibleStrip<M::Scalar>
+) -> IndexStrip<M::Scalar>
 where
     M: ExtentModel,
 {
     type S<M> = <M as ExtentModel>::Scalar;
     let len = model.len();
     if len == 0 {
-        return VisibleStrip {
+        return IndexStrip {
             start: 0,
             end: 0,
             before_extent: S::<M>::zero(),
@@ -179,7 +199,7 @@ where
     let mut content_extent = model.total_extent().max(S::<M>::zero());
     if content_extent == S::<M>::zero() {
         // All items collapsed; treat as empty strip.
-        return VisibleStrip {
+        return IndexStrip {
             start: 0,
             end: 0,
             before_extent: S::<M>::zero(),
@@ -200,7 +220,7 @@ where
         // Very small viewport / overscan, or near-zero content.
         let anchor = min.min(content_extent);
         if anchor >= content_extent {
-            return VisibleStrip {
+            return IndexStrip {
                 start: len,
                 end: len,
                 before_extent: content_extent,
@@ -211,7 +231,7 @@ where
 
         let index = cmp::min(model.index_at_offset(anchor), len.saturating_sub(1));
         let before_extent = model.offset_of(index);
-        return VisibleStrip {
+        return IndexStrip {
             start: index,
             end: index,
             before_extent,
@@ -247,7 +267,7 @@ where
     };
     let after_extent = (content_extent - end_start).max(S::<M>::zero());
 
-    VisibleStrip {
+    IndexStrip {
         start,
         end,
         before_extent,
@@ -256,11 +276,35 @@ where
     }
 }
 
+/// Computes the materialized strip for a scroll position, viewport size, and overscan.
+#[deprecated(
+    since = "0.1.2",
+    note = "use `compute_materialized_strip`; this helper includes overscan and is not limited to the viewport"
+)]
+pub fn compute_visible_strip<M>(
+    model: &mut M,
+    scroll_offset: M::Scalar,
+    viewport_extent: M::Scalar,
+    overscan_before: M::Scalar,
+    overscan_after: M::Scalar,
+) -> IndexStrip<M::Scalar>
+where
+    M: ExtentModel,
+{
+    compute_materialized_strip(
+        model,
+        scroll_offset,
+        viewport_extent,
+        overscan_before,
+        overscan_after,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
 
-    use super::{ExtentModel, VisibleStrip, compute_visible_strip};
+    use super::{ExtentModel, IndexStrip, compute_materialized_strip};
     use crate::Scalar;
 
     #[derive(Clone, Debug)]
@@ -310,10 +354,10 @@ mod tests {
     #[test]
     fn empty_model_yields_empty_strip() {
         let mut model = SimpleModel::new(&[]);
-        let strip = compute_visible_strip(&mut model, 0.0, 100.0, 10.0, 10.0);
+        let strip = compute_materialized_strip(&mut model, 0.0, 100.0, 10.0, 10.0);
         assert_eq!(
             strip,
-            VisibleStrip {
+            IndexStrip {
                 start: 0,
                 end: 0,
                 before_extent: <f32 as Scalar>::zero(),
@@ -324,10 +368,10 @@ mod tests {
     }
 
     #[test]
-    fn simple_visible_range() {
+    fn simple_materialized_range() {
         // Three items, each 10 units tall.
         let mut model = SimpleModel::new(&[10.0, 10.0, 10.0]);
-        let strip = compute_visible_strip(&mut model, 5.0, 10.0, 0.0, 0.0);
+        let strip = compute_materialized_strip(&mut model, 5.0, 10.0, 0.0, 0.0);
         assert_eq!(strip.start, 0);
         assert_eq!(strip.end, 2);
         assert_eq!(strip.before_extent, 0.0);
@@ -336,48 +380,48 @@ mod tests {
     }
 
     #[test]
-    fn visible_strip_len_and_visible_extent() {
+    fn index_strip_len_and_covered_extent() {
         // Three items of 10 each, viewport at offset 5 with size 10 → items 0..2 visible.
         let mut model = SimpleModel::new(&[10.0, 10.0, 10.0]);
-        let strip = compute_visible_strip(&mut model, 5.0, 10.0, 0.0, 0.0);
+        let strip = compute_materialized_strip(&mut model, 5.0, 10.0, 0.0, 0.0);
         assert_eq!(strip.range(), 0..2);
         assert_eq!(strip.len(), 2);
-        assert!((strip.visible_extent() - 20.0_f32).abs() < 1e-5);
+        assert!((strip.covered_extent() - 20.0_f32).abs() < 1e-5);
 
-        // Empty model → len 0, visible_extent 0.
+        // Empty model → len 0, covered extent 0.
         let mut model = SimpleModel::new(&[]);
-        let strip = compute_visible_strip(&mut model, 0.0, 100.0, 0.0, 0.0);
+        let strip = compute_materialized_strip(&mut model, 0.0, 100.0, 0.0, 0.0);
         assert_eq!(strip.range(), 0..0);
         assert_eq!(strip.len(), 0);
         assert!(strip.is_empty());
-        assert!((strip.visible_extent() - 0.0_f32).abs() < 1e-5);
+        assert!((strip.covered_extent() - 0.0_f32).abs() < 1e-5);
     }
 
     #[test]
-    fn empty_visible_range_beyond_content_has_coherent_spacers() {
+    fn empty_materialized_range_beyond_content_has_coherent_spacers() {
         let mut model = SimpleModel::new(&[10.0, 10.0, 10.0]);
-        let strip = compute_visible_strip(&mut model, 100.0, 0.0, 0.0, 0.0);
+        let strip = compute_materialized_strip(&mut model, 100.0, 0.0, 0.0, 0.0);
 
         assert_eq!(strip.start, 3);
         assert_eq!(strip.end, 3);
         assert_eq!(strip.before_extent, 30.0);
         assert_eq!(strip.after_extent, 0.0);
         assert_eq!(strip.content_extent, 30.0);
-        assert_eq!(strip.visible_extent(), 0.0);
+        assert_eq!(strip.covered_extent(), 0.0);
         assert_eq!(strip.range(), 3..3);
     }
 
     #[test]
-    fn empty_visible_range_inside_content_has_coherent_spacers() {
+    fn empty_materialized_range_inside_content_has_coherent_spacers() {
         let mut model = SimpleModel::new(&[10.0, 10.0, 10.0]);
-        let strip = compute_visible_strip(&mut model, 15.0, 0.0, 0.0, 0.0);
+        let strip = compute_materialized_strip(&mut model, 15.0, 0.0, 0.0, 0.0);
 
         assert_eq!(strip.start, 1);
         assert_eq!(strip.end, 1);
         assert_eq!(strip.before_extent, 10.0);
         assert_eq!(strip.after_extent, 20.0);
         assert_eq!(strip.content_extent, 30.0);
-        assert_eq!(strip.visible_extent(), 0.0);
+        assert_eq!(strip.covered_extent(), 0.0);
         assert_eq!(strip.range(), 1..1);
     }
 
@@ -385,9 +429,26 @@ mod tests {
     fn asymmetric_overscan_extends_in_one_direction() {
         let mut model = SimpleModel::new(&[10.0, 10.0, 10.0, 10.0]);
         // Viewport covers roughly items 1 and 2 (offset 10..30). Overscan only after.
-        let strip = compute_visible_strip(&mut model, 10.0, 20.0, 0.0, 10.0);
+        let strip = compute_materialized_strip(&mut model, 10.0, 20.0, 0.0, 10.0);
         // We should still start at item 1, but extend end to include item 3.
         assert_eq!(strip.start, 1);
         assert_eq!(strip.end, 4);
+    }
+
+    #[test]
+    #[allow(
+        deprecated,
+        reason = "the test verifies deprecated visible names forward to the replacement API"
+    )]
+    fn deprecated_visible_names_forward_to_index_strip_names() {
+        let mut model = SimpleModel::new(&[10.0, 10.0, 10.0]);
+        let strip: super::VisibleStrip<f32> =
+            super::compute_visible_strip(&mut model, 5.0, 10.0, 0.0, 0.0);
+
+        assert_eq!(
+            strip,
+            compute_materialized_strip(&mut model, 5.0, 10.0, 0.0, 0.0)
+        );
+        assert_eq!(strip.visible_extent(), strip.covered_extent());
     }
 }

--- a/understory_virtual_list/src/sparse.rs
+++ b/understory_virtual_list/src/sparse.rs
@@ -282,7 +282,7 @@ impl<S: Scalar> ResizableExtentModel for SparsePrefixSumExtentModel<S> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{PrefixSumExtentModel, compute_visible_strip};
+    use crate::{PrefixSumExtentModel, compute_materialized_strip};
 
     use super::{ExtentModel, SparsePrefixSumExtentModel};
 
@@ -409,7 +409,7 @@ mod tests {
         for i in 0..100 {
             dense_model.set_extent(i, 51.);
         }
-        let dense_strip = compute_visible_strip(&mut dense_model, 0., 640., 320., 320.);
+        let dense_strip = compute_materialized_strip(&mut dense_model, 0., 640., 320., 320.);
 
         let mut sparse_model = SparsePrefixSumExtentModel::new(51., 100);
         assert_eq!(sparse_model.total_extent(), 5100.);
@@ -417,7 +417,7 @@ mod tests {
             sparse_model.set_extent(i, 51.);
         }
         assert_eq!(sparse_model.total_extent(), 5100.);
-        let sparse_strip = compute_visible_strip(&mut sparse_model, 0., 640., 320., 320.);
+        let sparse_strip = compute_materialized_strip(&mut sparse_model, 0., 640., 320., 320.);
 
         assert_eq!(dense_strip, sparse_strip);
     }

--- a/understory_virtual_list/src/virtual_list.rs
+++ b/understory_virtual_list/src/virtual_list.rs
@@ -6,8 +6,8 @@
 use core::ops::Range;
 
 use crate::{
-    ExtentModel, ResizableExtentModel, Scalar, TailAnchoredExtentModel, VisibleStrip,
-    compute_visible_strip,
+    ExtentModel, IndexStrip, ResizableExtentModel, Scalar, TailAnchoredExtentModel,
+    compute_materialized_strip,
 };
 
 /// Alignment mode when scrolling a specific index into view.
@@ -29,7 +29,7 @@ pub enum ScrollAlign {
 /// This type:
 /// - stores scroll offset, viewport extent, and asymmetric overscan,
 /// - owns an [`ExtentModel`],
-/// - caches the last computed [`VisibleStrip`],
+/// - caches the last computed materialized [`IndexStrip`],
 /// - exposes helpers for visibility queries and index-aligned scrolling.
 ///
 /// It does *not* know about any widget/view system; host frameworks are expected
@@ -43,7 +43,7 @@ pub struct VirtualList<M: ExtentModel> {
     overscan_after: M::Scalar,
 
     dirty: bool,
-    last_strip: VisibleStrip<M::Scalar>,
+    last_strip: IndexStrip<M::Scalar>,
 }
 
 impl<M: ExtentModel> VirtualList<M> {
@@ -57,7 +57,7 @@ impl<M: ExtentModel> VirtualList<M> {
             overscan_before: overscan.max(M::Scalar::zero()),
             overscan_after: overscan.max(M::Scalar::zero()),
             dirty: true,
-            last_strip: VisibleStrip {
+            last_strip: IndexStrip {
                 start: 0,
                 end: 0,
                 before_extent: M::Scalar::zero(),
@@ -202,9 +202,9 @@ impl<M: ExtentModel> VirtualList<M> {
     ///
     /// This strip includes the configured overscan before and after the viewport.
     #[must_use]
-    pub fn visible_strip(&mut self) -> VisibleStrip<M::Scalar> {
+    pub fn materialized_strip(&mut self) -> IndexStrip<M::Scalar> {
         if self.dirty {
-            self.last_strip = compute_visible_strip(
+            self.last_strip = compute_materialized_strip(
                 &mut self.model,
                 self.scroll_offset,
                 self.viewport_extent,
@@ -216,12 +216,24 @@ impl<M: ExtentModel> VirtualList<M> {
         self.last_strip
     }
 
+    /// Computes or returns the cached materialized strip.
+    ///
+    /// This strip includes the configured overscan before and after the viewport.
+    #[deprecated(
+        since = "0.1.2",
+        note = "use `materialized_strip`; this range includes overscan and is not limited to the viewport"
+    )]
+    #[must_use]
+    pub fn visible_strip(&mut self) -> IndexStrip<M::Scalar> {
+        self.materialized_strip()
+    }
+
     /// Returns the half-open materialized index range, including overscan.
     ///
-    /// This is equivalent to `self.visible_strip().range()`.
+    /// This is equivalent to `self.materialized_strip().range()`.
     #[must_use]
-    pub fn visible_range(&mut self) -> Range<usize> {
-        self.visible_strip().range()
+    pub fn materialized_range(&mut self) -> Range<usize> {
+        self.materialized_strip().range()
     }
 
     /// Computes the viewport strip without overscan.
@@ -229,10 +241,10 @@ impl<M: ExtentModel> VirtualList<M> {
     /// Use this when host code needs the indices that overlap the viewport
     /// itself, rather than the larger materialized range. The returned strip
     /// uses the same half-open `[start, end)` convention as
-    /// [`VirtualList::visible_strip`].
+    /// [`VirtualList::materialized_strip`].
     #[must_use]
-    pub fn viewport_strip(&mut self) -> VisibleStrip<M::Scalar> {
-        compute_visible_strip(
+    pub fn viewport_strip(&mut self) -> IndexStrip<M::Scalar> {
+        compute_materialized_strip(
             &mut self.model,
             self.scroll_offset,
             self.viewport_extent,
@@ -251,16 +263,27 @@ impl<M: ExtentModel> VirtualList<M> {
     }
 
     /// Convenience iterator over materialized indices, including overscan.
+    pub fn materialized_indices(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = usize> + ExactSizeIterator + use<M> {
+        self.materialized_range()
+    }
+
+    /// Convenience iterator over materialized indices, including overscan.
+    #[deprecated(
+        since = "0.1.2",
+        note = "use `materialized_indices`; these indices include overscan and are not limited to the viewport"
+    )]
     pub fn visible_indices(
         &mut self,
     ) -> impl DoubleEndedIterator<Item = usize> + ExactSizeIterator + use<M> {
-        self.visible_range()
+        self.materialized_indices()
     }
 
-    /// Returns the first visible index, if any.
+    /// Returns the first materialized index, if any.
     #[must_use]
-    pub fn first_visible_index(&mut self) -> Option<usize> {
-        let strip = self.visible_strip();
+    pub fn first_materialized_index(&mut self) -> Option<usize> {
+        let strip = self.materialized_strip();
         if strip.is_empty() {
             None
         } else {
@@ -268,15 +291,35 @@ impl<M: ExtentModel> VirtualList<M> {
         }
     }
 
-    /// Returns the last visible index, if any.
+    /// Returns the first materialized index, if any.
+    #[deprecated(
+        since = "0.1.2",
+        note = "use `first_materialized_index`; this index may be in overscan and outside the viewport"
+    )]
     #[must_use]
-    pub fn last_visible_index(&mut self) -> Option<usize> {
-        let strip = self.visible_strip();
+    pub fn first_visible_index(&mut self) -> Option<usize> {
+        self.first_materialized_index()
+    }
+
+    /// Returns the last materialized index, if any.
+    #[must_use]
+    pub fn last_materialized_index(&mut self) -> Option<usize> {
+        let strip = self.materialized_strip();
         if strip.is_empty() {
             None
         } else {
             Some(strip.end - 1)
         }
+    }
+
+    /// Returns the last materialized index, if any.
+    #[deprecated(
+        since = "0.1.2",
+        note = "use `last_materialized_index`; this index may be in overscan and outside the viewport"
+    )]
+    #[must_use]
+    pub fn last_visible_index(&mut self) -> Option<usize> {
+        self.last_materialized_index()
     }
 
     /// Returns `true` if the given index is fully visible within the viewport.
@@ -311,7 +354,7 @@ impl<M: ExtentModel> VirtualList<M> {
     ///
     /// This is useful for hosts that want to hard-cap scrolling at the start/end of content.
     pub fn clamp_scroll_to_content(&mut self) {
-        let strip = self.visible_strip();
+        let strip = self.materialized_strip();
         let content = strip.content_extent;
         let max_offset = if content > self.viewport_extent {
             content - self.viewport_extent
@@ -534,22 +577,22 @@ mod tests {
     }
 
     #[test]
-    fn visible_strip_tracks_scroll_and_viewport() {
+    fn materialized_strip_tracks_scroll_and_viewport() {
         let model = FixedExtentModel::new(100, 10.0_f32);
         let mut list = VirtualList::new(model, 50.0, 0.0);
 
         // At top: items 0..5.
-        let strip = list.visible_strip();
+        let strip = list.materialized_strip();
         assert_eq!(strip.start, 0);
         assert_eq!(strip.end, 5);
 
         // Scroll down by 10 units: items 1..6.
         list.scroll_by(10.0);
-        let strip = list.visible_strip();
+        let strip = list.materialized_strip();
         assert_eq!(strip.start, 1);
         assert_eq!(strip.end, 6);
-        assert_eq!(list.first_visible_index(), Some(1));
-        assert_eq!(list.last_visible_index(), Some(5));
+        assert_eq!(list.first_materialized_index(), Some(1));
+        assert_eq!(list.last_materialized_index(), Some(5));
     }
 
     #[test]
@@ -558,9 +601,9 @@ mod tests {
         let mut list = VirtualList::new(model, 20.0_f32, 10.0_f32);
         list.set_scroll_offset(10.0_f32);
 
-        assert_eq!(list.visible_range(), 0..4);
+        assert_eq!(list.materialized_range(), 0..4);
         assert_eq!(
-            list.visible_indices().collect::<alloc::vec::Vec<_>>(),
+            list.materialized_indices().collect::<alloc::vec::Vec<_>>(),
             alloc::vec![0, 1, 2, 3]
         );
         assert_eq!(list.viewport_range(), 1..3);
@@ -569,6 +612,25 @@ mod tests {
         assert_eq!(viewport.range(), 1..3);
         assert_eq!(viewport.start, 1);
         assert_eq!(viewport.end, 3);
+    }
+
+    #[test]
+    #[allow(
+        deprecated,
+        reason = "the test verifies deprecated aliases forward to the replacement API"
+    )]
+    fn deprecated_visible_helpers_forward_to_materialized_helpers() {
+        let model = FixedExtentModel::new(10, 10.0_f32);
+        let mut list = VirtualList::new(model, 20.0_f32, 10.0_f32);
+        list.set_scroll_offset(10.0_f32);
+
+        assert_eq!(list.visible_strip(), list.materialized_strip());
+        assert_eq!(
+            list.visible_indices().collect::<alloc::vec::Vec<_>>(),
+            list.materialized_indices().collect::<alloc::vec::Vec<_>>()
+        );
+        assert_eq!(list.first_visible_index(), list.first_materialized_index());
+        assert_eq!(list.last_visible_index(), list.last_materialized_index());
     }
 
     #[test]
@@ -660,16 +722,16 @@ mod tests {
         let model = FixedExtentModel::new(2, 10.0_f32);
         let mut list = VirtualList::new(model, 30.0_f32, 0.0);
 
-        assert_eq!(list.visible_range(), 0..2);
+        assert_eq!(list.materialized_range(), 0..2);
 
         list.set_len(5);
         assert_eq!(list.len(), 5);
         assert!(!list.is_empty());
-        assert_eq!(list.visible_range(), 0..3);
+        assert_eq!(list.materialized_range(), 0..3);
 
         list.set_len(0);
         assert!(list.is_empty());
-        assert_eq!(list.visible_range(), 0..0);
+        assert_eq!(list.materialized_range(), 0..0);
     }
 
     #[test]
@@ -681,7 +743,7 @@ mod tests {
         list.set_len(5);
 
         assert_eq!(list.len(), 5);
-        assert_eq!(list.visible_range(), 0..3);
+        assert_eq!(list.materialized_range(), 0..3);
     }
 
     #[test]
@@ -689,7 +751,7 @@ mod tests {
         let model = CountingModel::new(5, 10.0_f32);
         let mut list = VirtualList::new(model, 30.0_f32, 0.0);
 
-        assert_eq!(list.visible_range(), 0..3);
+        assert_eq!(list.materialized_range(), 0..3);
         let total_extent_calls = list.model().total_extent_calls;
 
         assert_eq!(list.total_extent(), 50.0_f32);
@@ -698,7 +760,7 @@ mod tests {
         assert_eq!(list.index_at_offset(25.0_f32), 2);
         assert_eq!(list.try_index_at_offset(45.0_f32), Some(4));
 
-        assert_eq!(list.visible_range(), 0..3);
+        assert_eq!(list.materialized_range(), 0..3);
         assert_eq!(list.model().total_extent_calls, total_extent_calls + 1);
     }
 
@@ -716,7 +778,7 @@ mod tests {
         // Viewport is 3 tracks tall → 3 * 10.
         let mut list = VirtualList::new(grid_model, 30.0_f32, 0.0);
 
-        let strip = list.visible_strip();
+        let strip = list.materialized_strip();
         // At scroll_offset = 0, we expect the first three tracks to be visible:
         // 3 tracks × 3 cells per track = 9 cells (indices 0..9).
         assert_eq!(strip.start, 0);


### PR DESCRIPTION
The cached strip and range include overscan, so `visible_*` reads too much like viewport visibility. Add `materialized_strip`, `materialized_range`, `materialized_indices`, `first_materialized_index`, and `last_materialized_index` as the preferred names for host code that instantiates children.

Keep the existing `visible_*` methods as deprecated aliases so current callers have a migration path. Update rustdoc, README examples, inspector, and workspace examples to use the materialized names, and cover the deprecated aliases with a forwarding test.