### PR TITLE
understory_property: layer local-value sources for templated workflows

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,7 @@ These examples form a short, progressive walkthrough from routing basics to inte
   - Run: `cargo run -p understory_examples --example index_basics`
 
 - property_binding_loop
-  - Drive the canonical `understory_property_binding` host loop: mark source endpoints, drain bindings, apply successful and partial reports to app invalidation, and tear down retained owners.
+  - Drive the canonical `understory_property_binding` host loop over `understory_property` source slots: bindings write `TemplateBinding`, user `Local` values mask and reveal those writes, template teardown clears retained bindings, and partial reports still feed app invalidation.
   - Run: `cargo run -p understory_examples --example property_binding_loop`
 
 - box_tree_basics

--- a/examples/examples/property_binding_loop.rs
+++ b/examples/examples/property_binding_loop.rs
@@ -4,13 +4,15 @@
 //! Canonical property binding host loop.
 //!
 //! This example shows the intended host-side shape for
-//! `understory_property_binding`:
+//! `understory_property_binding` with `understory_property` source slots:
 //!
-//! 1. Register bindings between host-owned property endpoints.
-//! 2. Mark source endpoints dirty when host state changes.
-//! 3. Drain bindings.
-//! 4. Apply both successful and partial drain reports to app invalidation.
-//! 5. Tear down bindings by owner when a retained object goes away.
+//! 1. Host elements store values in [`PropertyStore`].
+//! 2. Bindings write target values into [`LocalValueSource::TemplateBinding`].
+//! 3. User [`LocalValueSource::Local`] values can mask binding updates without
+//!    deleting them.
+//! 4. Clearing `Local` reveals the latest binding value.
+//! 5. Template teardown removes bindings and clears template-installed source
+//!    slots, revealing [`LocalValueSource::TemplateDefault`].
 //!
 //! Run:
 //! - `cargo run -p understory_examples --example property_binding_loop`
@@ -18,7 +20,10 @@
 use std::collections::BTreeMap;
 
 use invalidation::{Channel, ChannelSet};
-use understory_property::{ErasedValue, PropertyId, PropertyMetadataBuilder, PropertyRegistry};
+use understory_property::{
+    DependencyObject, DependencyObjectExt, ErasedValue, LocalValueSource, Property,
+    PropertyMetadataBuilder, PropertyRegistry, PropertyStore,
+};
 use understory_property_binding::{
     BindingDrainError, BindingHost, BindingReport, BindingSet, BindingWrite, EndpointKey,
     PropertyEndpoint,
@@ -30,6 +35,38 @@ const LAYOUT: Channel = Channel::new(1);
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct ElementId(u32);
 
+struct Element {
+    key: ElementId,
+    store: PropertyStore<ElementId>,
+}
+
+impl Element {
+    fn new(key: ElementId) -> Self {
+        Self {
+            key,
+            store: PropertyStore::new(key),
+        }
+    }
+}
+
+impl DependencyObject<ElementId> for Element {
+    fn property_store(&self) -> &PropertyStore<ElementId> {
+        &self.store
+    }
+
+    fn property_store_mut(&mut self) -> &mut PropertyStore<ElementId> {
+        &mut self.store
+    }
+
+    fn key(&self) -> ElementId {
+        self.key
+    }
+
+    fn parent_key(&self) -> Option<ElementId> {
+        None
+    }
+}
+
 #[derive(Default)]
 struct AppInvalidation {
     channels: ChannelSet,
@@ -37,7 +74,7 @@ struct AppInvalidation {
 
 impl AppInvalidation {
     fn apply_report(&mut self, report: BindingReport) {
-        self.channels |= report.affected_channels();
+        self.apply_channels(report.affected_channels());
         println!(
             "  report: evaluated={} changed={} affected={:?}",
             report.evaluated_bindings(),
@@ -45,64 +82,132 @@ impl AppInvalidation {
             report.affected_channels()
         );
     }
+
+    fn apply_channels(&mut self, channels: ChannelSet) {
+        self.channels |= channels;
+    }
 }
 
-#[derive(Default)]
 struct Host {
-    values: BTreeMap<EndpointKey<ElementId>, ErasedValue>,
-    affects: BTreeMap<PropertyId, ChannelSet>,
+    registry: PropertyRegistry,
+    width: Property<u32>,
+    elements: BTreeMap<ElementId, Element>,
 }
 
 impl Host {
-    fn set_initial<T: Clone + 'static>(
-        &mut self,
-        endpoint: PropertyEndpoint<ElementId, T>,
-        value: T,
-    ) {
-        self.values.insert(endpoint.key(), ErasedValue::new(value));
-    }
-
-    fn set_affects<T>(&mut self, endpoint: PropertyEndpoint<ElementId, T>, channels: ChannelSet) {
-        self.affects.insert(endpoint.property().id(), channels);
-    }
-
-    fn value<T: 'static>(&self, endpoint: PropertyEndpoint<ElementId, T>) -> Option<&T> {
-        self.values
-            .get(&endpoint.key())
-            .and_then(ErasedValue::downcast_ref)
-    }
-
-    fn erased_equal(left: &ErasedValue, right: &ErasedValue) -> bool {
-        if left.type_id() != right.type_id() {
-            return false;
+    fn new(registry: PropertyRegistry, width: Property<u32>) -> Self {
+        Self {
+            registry,
+            width,
+            elements: BTreeMap::new(),
         }
+    }
 
-        left.downcast_ref::<u32>() == right.downcast_ref::<u32>()
+    fn insert_element(&mut self, id: ElementId) {
+        self.elements.insert(id, Element::new(id));
+    }
+
+    fn set_model_width(&mut self, endpoint: PropertyEndpoint<ElementId, u32>, value: u32) {
+        self.element_mut(endpoint.owner())
+            .set_local(endpoint.property(), value);
+    }
+
+    fn set_template_default(&mut self, endpoint: PropertyEndpoint<ElementId, u32>, value: u32) {
+        self.element_mut(endpoint.owner()).set_local_with_source(
+            endpoint.property(),
+            value,
+            LocalValueSource::TemplateDefault,
+        );
+    }
+
+    fn set_user_width(&mut self, endpoint: PropertyEndpoint<ElementId, u32>, value: u32) {
+        self.element_mut(endpoint.owner())
+            .set_local(endpoint.property(), value);
+    }
+
+    fn clear_user_width(&mut self, endpoint: PropertyEndpoint<ElementId, u32>) -> ChannelSet {
+        let registry = &self.registry;
+        self.elements
+            .get_mut(&endpoint.owner())
+            .expect("example element should exist")
+            .clear_local_notifying(endpoint.property(), registry)
+    }
+
+    fn clear_template_bindings_for(&mut self, owner: ElementId) -> ChannelSet {
+        let registry = &self.registry;
+        self.elements
+            .get_mut(&owner)
+            .expect("example element should exist")
+            .clear_local_by_source_notifying(LocalValueSource::TemplateBinding, registry)
+    }
+
+    fn width_value(&self, endpoint: PropertyEndpoint<ElementId, u32>) -> Option<u32> {
+        self.elements
+            .get(&endpoint.owner())
+            .map(|element| element.get_effective_local(endpoint.property(), &self.registry))
+    }
+
+    fn width_source(&self, endpoint: PropertyEndpoint<ElementId, u32>) -> Option<LocalValueSource> {
+        self.elements
+            .get(&endpoint.owner())
+            .and_then(|element| element.get_local_source(endpoint.property()))
+    }
+
+    fn width_at_source(
+        &self,
+        endpoint: PropertyEndpoint<ElementId, u32>,
+        source: LocalValueSource,
+    ) -> Option<&u32> {
+        self.elements.get(&endpoint.owner()).and_then(|element| {
+            element
+                .property_store()
+                .get_local_at_source(endpoint.property(), source)
+        })
+    }
+
+    fn element_mut(&mut self, id: ElementId) -> &mut Element {
+        self.elements
+            .get_mut(&id)
+            .expect("example element should exist")
     }
 }
 
 impl BindingHost<ElementId> for Host {
     fn get_erased(&self, endpoint: EndpointKey<ElementId>) -> Option<ErasedValue> {
-        self.values.get(&endpoint).cloned()
+        if endpoint.property() != self.width.id() {
+            return None;
+        }
+
+        self.elements.get(&endpoint.owner()).map(|element| {
+            ErasedValue::new(element.get_effective_local(self.width, &self.registry))
+        })
     }
 
     fn set_erased(&mut self, endpoint: EndpointKey<ElementId>, value: ErasedValue) -> BindingWrite {
-        let changed = self
-            .values
-            .get(&endpoint)
-            .is_none_or(|old| !Self::erased_equal(old, &value));
-        self.values.insert(endpoint, value);
+        if endpoint.property() != self.width.id() {
+            return BindingWrite::unchanged();
+        }
 
-        let channels = if changed {
-            self.affects
-                .get(&endpoint.property())
-                .copied()
-                .unwrap_or_else(ChannelSet::empty)
-        } else {
-            ChannelSet::empty()
+        let Some(value) = value.downcast_ref::<u32>().copied() else {
+            return BindingWrite::unchanged();
         };
 
-        BindingWrite::new(changed, channels)
+        let width = self.width;
+        let registry = &self.registry;
+        let Some(element) = self.elements.get_mut(&endpoint.owner()) else {
+            return BindingWrite::unchanged();
+        };
+
+        let old_effective = element.get_effective_local(width, registry);
+        let channels = element.set_local_with_source_notifying(
+            width,
+            value,
+            LocalValueSource::TemplateBinding,
+            registry,
+        );
+        let new_effective = element.get_effective_local(width, registry);
+
+        BindingWrite::new(old_effective != new_effective, channels)
     }
 }
 
@@ -130,6 +235,16 @@ fn print_drain_error(error: &BindingDrainError<ElementId>) {
     println!("  completed writes still need app invalidation");
 }
 
+fn print_width(host: &Host, label: &str, endpoint: PropertyEndpoint<ElementId, u32>) {
+    println!(
+        "  {label}: effective={:?} source={:?} template_binding={:?} template_default={:?}",
+        host.width_value(endpoint),
+        host.width_source(endpoint),
+        host.width_at_source(endpoint, LocalValueSource::TemplateBinding),
+        host.width_at_source(endpoint, LocalValueSource::TemplateDefault)
+    );
+}
+
 fn main() {
     let model = ElementId(1);
     let button = ElementId(2);
@@ -137,17 +252,25 @@ fn main() {
     let delayed_model = ElementId(4);
 
     let mut registry = PropertyRegistry::new();
-    let width = registry.register("Width", PropertyMetadataBuilder::new(0_u32).build());
+    let width = registry.register(
+        "Width",
+        PropertyMetadataBuilder::new(0_u32)
+            .affects_channels(LAYOUT.into_set())
+            .build(),
+    );
 
     let model_width = PropertyEndpoint::new(model, width);
     let button_width = PropertyEndpoint::new(button, width);
     let delayed_width = PropertyEndpoint::new(delayed_model, width);
     let panel_width = PropertyEndpoint::new(panel, width);
 
-    let mut host = Host::default();
-    host.set_affects(button_width, LAYOUT.into_set());
-    host.set_affects(panel_width, LAYOUT.into_set());
-    host.set_initial(model_width, 320_u32);
+    let mut host = Host::new(registry, width);
+    host.insert_element(model);
+    host.insert_element(button);
+    host.insert_element(panel);
+    host.set_model_width(model_width, 320);
+    host.set_template_default(button_width, 100);
+    host.set_template_default(panel_width, 200);
 
     let mut invalidation = AppInvalidation::default();
     let mut bindings = BindingSet::new(BINDING);
@@ -155,7 +278,7 @@ fn main() {
     bindings.bind(delayed_width, panel_width).unwrap();
 
     println!("== first frame ==");
-    println!("external changes: model width and delayed model width");
+    println!("external changes: model width and missing delayed model width");
     bindings.mark_source_changed(model_width);
     bindings.mark_source_changed(delayed_width);
 
@@ -168,43 +291,68 @@ fn main() {
         "  app invalidated layout={}",
         invalidation.channels.contains(LAYOUT)
     );
-    println!("  button width={:?}", host.value(button_width));
-    println!("  panel width={:?}", host.value(panel_width));
+    print_width(&host, "button", button_width);
+    print_width(&host, "panel", panel_width);
 
     println!();
     println!("== repair and retry ==");
-    host.set_initial(delayed_width, 480_u32);
+    host.insert_element(delayed_model);
+    host.set_model_width(delayed_width, 480);
     let clean = drain_frame(&mut bindings, &mut host, &mut invalidation);
     println!(
         "  clean={clean} dirty={}",
         bindings.stats().dirty_bindings()
     );
-    println!("  panel width={:?}", host.value(panel_width));
+    print_width(&host, "panel", panel_width);
 
     println!();
     println!("== normal update ==");
     println!("external change: model width");
-    host.set_initial(model_width, 640_u32);
+    host.set_model_width(model_width, 640);
     bindings.mark_source_changed(model_width);
     let clean = drain_frame(&mut bindings, &mut host, &mut invalidation);
     println!(
         "  clean={clean} dirty={}",
         bindings.stats().dirty_bindings()
     );
-    println!("  button width={:?}", host.value(button_width));
+    print_width(&host, "button", button_width);
 
     println!();
-    println!("== teardown ==");
-    let removed = bindings.clear_owner(button) + bindings.clear_owner(panel);
-    println!("removed bindings for retained owners: {removed}");
-    println!("active bindings={}", bindings.stats().active_bindings());
+    println!("== user local masks binding ==");
+    host.set_user_width(button_width, 700);
+    print_width(&host, "button after user local", button_width);
+    host.set_model_width(model_width, 800);
+    bindings.mark_source_changed(model_width);
+    let clean = drain_frame(&mut bindings, &mut host, &mut invalidation);
+    println!(
+        "  clean={clean} dirty={}",
+        bindings.stats().dirty_bindings()
+    );
+    print_width(&host, "button after masked binding", button_width);
 
-    host.set_initial(model_width, 960_u32);
+    println!();
+    println!("== clear local reveals binding ==");
+    let channels = host.clear_user_width(button_width);
+    invalidation.apply_channels(channels);
+    println!("  clear Local affected={channels:?}");
+    print_width(&host, "button", button_width);
+
+    println!();
+    println!("== template teardown ==");
+    let removed = bindings.clear_owner(button) + bindings.clear_owner(panel);
+    let channels =
+        host.clear_template_bindings_for(button) | host.clear_template_bindings_for(panel);
+    invalidation.apply_channels(channels);
+    println!("removed bindings for retained owners: {removed}");
+    println!("cleared TemplateBinding affected={channels:?}");
+    println!("active bindings={}", bindings.stats().active_bindings());
+    print_width(&host, "button", button_width);
+    print_width(&host, "panel", panel_width);
+
+    host.set_model_width(model_width, 960);
     let marked = bindings.mark_source_changed(model_width);
     println!("mark after teardown: {marked}");
     let clean = drain_frame(&mut bindings, &mut host, &mut invalidation);
-    println!(
-        "  clean={clean} button width={:?}",
-        host.value(button_width)
-    );
+    println!("  clean={clean}");
+    print_width(&host, "button", button_width);
 }

--- a/understory_property/README.md
+++ b/understory_property/README.md
@@ -33,11 +33,23 @@ support, and full precedence handling are provided by `understory_style`.
 
 [`PropertyStore`] holds Local and Animation values per-object:
 
-- **Local** - explicitly set values
-- **Animation** - temporary animation overrides (highest precedence)
+- **Local** — explicitly set values, layered by [`LocalValueSource`]
+- **Animation** — temporary animation overrides (highest precedence)
 
 Inheritance is handled by [`DependencyObjectExt::get_inherited`].
 Style and theme resolution are handled externally by `understory_style`.
+
+### Layered Local Values
+
+The local layer is split into one sparse slot per [`LocalValueSource`]:
+`Local`, `TemplateBinding`, `TemplateDefault`. A write goes to its source's
+own slot; reads resolve the highest source that currently has a value.
+Clearing the winning source therefore reveals whatever a lower source had
+previously written. The
+[`clear_local_by_source`](PropertyStore::clear_local_by_source) hook empties
+exactly one source's slot — useful when a template tears down and should
+drop only the values it installed. See [`LocalValueSource`] for the
+precedence order.
 
 ### Key Operations
 

--- a/understory_property/src/lib.rs
+++ b/understory_property/src/lib.rs
@@ -16,11 +16,23 @@
 //!
 //! [`PropertyStore`] holds Local and Animation values per-object:
 //!
-//! - **Local** - explicitly set values
-//! - **Animation** - temporary animation overrides (highest precedence)
+//! - **Local** — explicitly set values, layered by [`LocalValueSource`]
+//! - **Animation** — temporary animation overrides (highest precedence)
 //!
 //! Inheritance is handled by [`DependencyObjectExt::get_inherited`].
 //! Style and theme resolution are handled externally by `understory_style`.
+//!
+//! ### Layered Local Values
+//!
+//! The local layer is split into one sparse slot per [`LocalValueSource`]:
+//! `Local`, `TemplateBinding`, `TemplateDefault`. A write goes to its source's
+//! own slot; reads resolve the highest source that currently has a value.
+//! Clearing the winning source therefore reveals whatever a lower source had
+//! previously written. The
+//! [`clear_local_by_source`](PropertyStore::clear_local_by_source) hook empties
+//! exactly one source's slot — useful when a template tears down and should
+//! drop only the values it installed. See [`LocalValueSource`] for the
+//! precedence order.
 //!
 //! ### Key Operations
 //!
@@ -118,5 +130,5 @@ pub use object::{
     DependencyObject, DependencyObjectExt, ParentLookup, walk_inherited, walk_inherited_ref,
 };
 pub use registry::{PropertyRegistration, PropertyRegistry};
-pub use store::PropertyStore;
+pub use store::{LocalValueSource, PropertyStore};
 pub use value::ErasedValue;

--- a/understory_property/src/object.rs
+++ b/understory_property/src/object.rs
@@ -11,7 +11,7 @@ use invalidation::ChannelSet;
 
 use crate::id::Property;
 use crate::registry::PropertyRegistry;
-use crate::store::PropertyStore;
+use crate::store::{LocalValueSource, PropertyStore};
 
 /// A lookup mechanism for walking parent chains for inheritance.
 ///
@@ -457,25 +457,186 @@ pub trait DependencyObjectExt<K: Copy + Eq>: DependencyObject<K> {
         ChannelSet::empty()
     }
 
-    /// Clears the local value.
+    /// Writes a value into the slot for `source`.
+    ///
+    /// Each source has its own sparse slot, so the write never overwrites a
+    /// value held by another source. The newly-written value becomes the
+    /// winning local value only if `source` has the highest precedence among
+    /// the sources that currently have an entry for `property`. See
+    /// [`LocalValueSource`].
+    fn set_local_with_source<T: Clone + 'static>(
+        &mut self,
+        property: Property<T>,
+        value: T,
+        source: LocalValueSource,
+    ) {
+        self.property_store_mut()
+            .set_local_with_source(property, value, source);
+    }
+
+    /// Sets the source-tagged value with coercion and notification.
+    ///
+    /// Mirrors [`DependencyObjectExt::set_local_notifying`]: coerces the value,
+    /// writes it to `source`'s slot, then fires the changed callback and
+    /// returns affected channels only if the effective local value actually
+    /// changed. A write that lands in a slot shadowed by a higher-precedence
+    /// source returns an empty `ChannelSet` (the effective value didn't move).
+    fn set_local_with_source_notifying<T: Clone + PartialEq + 'static>(
+        &mut self,
+        property: Property<T>,
+        value: T,
+        source: LocalValueSource,
+        registry: &PropertyRegistry,
+    ) -> ChannelSet {
+        let metadata = registry.get_metadata(property);
+        let old_effective = metadata.map(|_| {
+            self.property_store()
+                .get_effective_local(property, registry)
+        });
+
+        let value = match metadata {
+            Some(m) => m.coerce(value),
+            None => value,
+        };
+
+        self.property_store_mut()
+            .set_local_with_source(property, value, source);
+
+        if let Some((m, old_effective)) = metadata.zip(old_effective) {
+            let new_effective = self
+                .property_store()
+                .get_effective_local(property, registry);
+            if old_effective != new_effective {
+                m.on_changed(Some(&old_effective), &new_effective);
+                return m.affects_channels();
+            }
+        }
+
+        ChannelSet::empty()
+    }
+
+    /// Returns the [`LocalValueSource`] currently winning the local-layer
+    /// resolution for `property`, if any source has a value.
+    fn get_local_source<T: Clone + 'static>(
+        &self,
+        property: Property<T>,
+    ) -> Option<LocalValueSource> {
+        self.property_store().get_local_source(property)
+    }
+
+    /// Clears every value stored under `source`.
+    ///
+    /// Returns the number of entries removed. See
+    /// [`PropertyStore::clear_local_by_source`] and
+    /// [`Self::clear_local_by_source_notifying`] for the channel-returning
+    /// variant.
+    fn clear_local_by_source(&mut self, source: LocalValueSource) -> usize {
+        self.property_store_mut().clear_local_by_source(source)
+    }
+
+    /// Bulk-clears every value stored under `source` and returns a conservative
+    /// union of channels that *may* have changed.
+    ///
+    /// A property contributes its `affects_channels` to the result whenever
+    /// (a) `source` is the current winning local-layer source for it, and
+    /// (b) no animation value is masking it. This is the correct conservative
+    /// answer to "which application channels did this teardown potentially
+    /// invalidate?" — note that if the value at the next-lower source happens
+    /// to equal the cleared value (e.g. `TemplateBinding(10)` shadowing
+    /// `TemplateDefault(10)`), the effective value didn't actually move but
+    /// this method still returns its channel. That's fine for invalidation
+    /// (extra dirty-marks are safe) but means callers should not treat the
+    /// return as a precise value-change signal.
+    ///
+    /// Per-property `on_changed` callbacks are **not** invoked by this method:
+    /// the bulk-clear path doesn't have typed values for the post-clear
+    /// effective on each property. If you need callbacks, use the per-property
+    /// [`clear_local_at_source_notifying`](Self::clear_local_at_source_notifying)
+    /// method instead.
+    fn clear_local_by_source_notifying(
+        &mut self,
+        source: LocalValueSource,
+        registry: &PropertyRegistry,
+    ) -> ChannelSet {
+        let mut affected = ChannelSet::empty();
+        let store = self.property_store();
+        // Collect ids potentially affected: those where `source` is the current
+        // winner and no animation is masking the layer. If a lower source
+        // shadowed by `source` happens to hold an equal value, this still
+        // contributes channels — bulk-clear doesn't compare typed values.
+        let ids_affected: alloc::vec::Vec<crate::id::PropertyId> = store
+            .local_property_ids_at_source(source)
+            .filter(|id| {
+                // Animation masks the local layer entirely.
+                if store.animation_entries_has(*id) {
+                    return false;
+                }
+                // `source` must currently be the winner; clearing a shadowed
+                // slot can't move the effective value.
+                store.winning_local_source_for_id(*id) == Some(source)
+            })
+            .collect();
+
+        for id in ids_affected {
+            affected |= registry.affects_channels(id);
+        }
+
+        self.property_store_mut().clear_local_by_source(source);
+
+        affected
+    }
+
+    /// Clears the value in the [`LocalValueSource::Local`] slot.
+    ///
+    /// Lower-precedence slots (`TemplateBinding`, `TemplateDefault`) are
+    /// untouched and may become the new winning value. Use
+    /// [`clear_local_at_source`](Self::clear_local_at_source) to target a
+    /// different slot, or [`clear_all`](Self::clear_all) to drop every value
+    /// (every local source plus animation) for one property.
     ///
     /// Returns `true` if a value was removed.
     fn clear_local<T: Clone + 'static>(&mut self, property: Property<T>) -> bool {
         self.property_store_mut().clear_local(property)
     }
 
-    /// Clears the local value and notifies if the effective local value changed.
+    /// Clears the value at a specific local-layer source for `property`.
     ///
-    /// This mirrors [`DependencyObjectExt::set_local_notifying`]: it compares
-    /// the effective local value (`Animation -> Local -> default`) before and
-    /// after the clear and only returns dirty channels when that observable
-    /// value changed.
+    /// Returns `true` if a value was removed.
+    fn clear_local_at_source<T: Clone + 'static>(
+        &mut self,
+        property: Property<T>,
+        source: LocalValueSource,
+    ) -> bool {
+        self.property_store_mut()
+            .clear_local_at_source(property, source)
+    }
+
+    /// Clears every value (every local source and animation) for `property`.
+    ///
+    /// Returns `true` if any value was removed.
+    fn clear_all<T: Clone + 'static>(&mut self, property: Property<T>) -> bool {
+        self.property_store_mut().clear_all(property)
+    }
+
+    /// Clears the [`LocalValueSource::Local`] slot and notifies if the
+    /// effective value changed.
+    ///
+    /// Only the `Local` slot is touched — to clear a different source slot
+    /// with notification, use
+    /// [`clear_local_at_source_notifying`](Self::clear_local_at_source_notifying).
+    ///
+    /// Compares the effective local value (`Animation -> winning local layer ->
+    /// default`) before and after the clear and only returns dirty channels +
+    /// fires the `on_changed` callback when that observable value moved.
     fn clear_local_notifying<T: Clone + PartialEq + 'static>(
         &mut self,
         property: Property<T>,
         registry: &PropertyRegistry,
     ) -> ChannelSet {
-        if !self.property_store().has_local(property) {
+        if !self
+            .property_store()
+            .has_local_at_source(property, LocalValueSource::Local)
+        {
             return ChannelSet::empty();
         }
 
@@ -486,6 +647,52 @@ pub trait DependencyObjectExt<K: Copy + Eq>: DependencyObject<K> {
         });
 
         self.property_store_mut().clear_local(property);
+
+        if let Some((m, old_effective)) = metadata.zip(old_effective) {
+            let new_effective = self
+                .property_store()
+                .get_effective_local(property, registry);
+            if old_effective != new_effective {
+                m.on_changed(Some(&old_effective), &new_effective);
+                return m.affects_channels();
+            }
+        }
+
+        ChannelSet::empty()
+    }
+
+    /// Clears the value at `source` for `property` and notifies if the
+    /// effective value changed.
+    ///
+    /// Mirrors [`clear_local_notifying`](Self::clear_local_notifying) but
+    /// targets an arbitrary local-layer source. Compares effective values
+    /// (`Animation -> winning local layer -> default`) before and after the
+    /// clear and only returns dirty channels + fires the `on_changed` callback
+    /// when that observable value moved.
+    ///
+    /// Clearing a slot that isn't currently winning (e.g. clearing
+    /// `TemplateBinding` while `Local` shadows it) is correctly reported as
+    /// a no-op: empty channels, no callback. Clearing a slot whose value
+    /// happens to equal the next-lower source's value is also a no-op
+    /// (effective didn't actually move).
+    fn clear_local_at_source_notifying<T: Clone + PartialEq + 'static>(
+        &mut self,
+        property: Property<T>,
+        source: LocalValueSource,
+        registry: &PropertyRegistry,
+    ) -> ChannelSet {
+        if !self.property_store().has_local_at_source(property, source) {
+            return ChannelSet::empty();
+        }
+
+        let metadata = registry.get_metadata(property);
+        let old_effective = metadata.map(|_| {
+            self.property_store()
+                .get_effective_local(property, registry)
+        });
+
+        self.property_store_mut()
+            .clear_local_at_source(property, source);
 
         if let Some((m, old_effective)) = metadata.zip(old_effective) {
             let new_effective = self
@@ -1045,5 +1252,526 @@ mod tests {
         assert!(element.get_animation_value(width).is_none());
         assert_eq!(element.get_effective_local(width, &registry), 20.0);
         assert_eq!(callback_count.load(Ordering::Relaxed), 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Source-tagged Local writes
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn ext_set_local_with_source_writes_to_slot() {
+        let (_, width) = setup_registry();
+        let mut element = TestElement::new(1, None);
+
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+        assert_eq!(
+            element.get_local_source(width),
+            Some(LocalValueSource::TemplateDefault)
+        );
+
+        // Writing a higher source takes over the winning value but leaves the
+        // lower slot intact.
+        element.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+        assert_eq!(element.get_local_value(width), Some(&20.0));
+        assert_eq!(
+            element.get_local_source(width),
+            Some(LocalValueSource::TemplateBinding)
+        );
+        assert_eq!(
+            element
+                .property_store()
+                .get_local_at_source(width, LocalValueSource::TemplateDefault),
+            Some(&10.0)
+        );
+    }
+
+    #[test]
+    fn ext_set_local_with_source_notifying_returns_channels_on_effective_change() {
+        use invalidation::Channel;
+
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        let channels = element.set_local_with_source_notifying(
+            width,
+            10.0,
+            LocalValueSource::TemplateDefault,
+            &registry,
+        );
+
+        assert!(channels.contains(LAYOUT));
+        assert_eq!(element.get_local_value(width), Some(&10.0));
+        assert_eq!(
+            element.get_local_source(width),
+            Some(LocalValueSource::TemplateDefault)
+        );
+    }
+
+    #[test]
+    fn ext_set_local_with_source_notifying_shadowed_write_returns_empty() {
+        use alloc::sync::Arc;
+        use core::sync::atomic::{AtomicUsize, Ordering};
+        use invalidation::Channel;
+
+        let mut registry = PropertyRegistry::new();
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(Channel::new(0).into_set())
+                .on_changed({
+                    let callback_count = Arc::clone(&callback_count);
+                    move |_, _| {
+                        callback_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        // Seed with Local (highest precedence).
+        let _ = element.set_local_notifying(width, 100.0, &registry);
+        let cb_before = callback_count.load(Ordering::Relaxed);
+
+        // Writing to a lower slot writes the value but doesn't move the
+        // effective value, so no channels and no callback.
+        let channels = element.set_local_with_source_notifying(
+            width,
+            7.0,
+            LocalValueSource::TemplateBinding,
+            &registry,
+        );
+
+        assert!(channels.is_empty());
+        assert_eq!(element.get_local_value(width), Some(&100.0));
+        assert_eq!(
+            element.get_local_source(width),
+            Some(LocalValueSource::Local)
+        );
+        assert_eq!(callback_count.load(Ordering::Relaxed), cb_before);
+        // The shadowed write still landed in its slot.
+        assert_eq!(
+            element
+                .property_store()
+                .get_local_at_source(width, LocalValueSource::TemplateBinding),
+            Some(&7.0)
+        );
+    }
+
+    #[test]
+    fn ext_set_local_with_source_notifying_no_effective_change_returns_empty() {
+        use invalidation::Channel;
+
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+
+        // Promote to a higher source with the same value: effective value
+        // didn't move, so no channels.
+        let channels = element.set_local_with_source_notifying(
+            width,
+            10.0,
+            LocalValueSource::TemplateBinding,
+            &registry,
+        );
+
+        assert!(channels.is_empty());
+        assert_eq!(
+            element.get_local_source(width),
+            Some(LocalValueSource::TemplateBinding),
+            "the higher slot should still have been written"
+        );
+    }
+
+    #[test]
+    fn ext_clear_local_by_source_drops_only_matching_entries() {
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register("Width", PropertyMetadataBuilder::new(0.0_f64).build());
+        let height = registry.register("Height", PropertyMetadataBuilder::new(0.0_f64).build());
+
+        let mut element = TestElement::new(1, None);
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+        element.set_local_with_source(height, 20.0, LocalValueSource::TemplateBinding);
+        element.set_local(width, 99.0); // Adds a Local on top of width's TemplateDefault.
+
+        let removed = element.clear_local_by_source(LocalValueSource::TemplateBinding);
+        assert_eq!(removed, 1);
+        assert!(element.has_local(width));
+        assert!(!element.has_local(height));
+        assert_eq!(
+            element.get_local_source(width),
+            Some(LocalValueSource::Local)
+        );
+        // Width's TemplateDefault is still there, masked by Local.
+        assert_eq!(
+            element
+                .property_store()
+                .get_local_at_source(width, LocalValueSource::TemplateDefault),
+            Some(&10.0)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // clear_local_by_source_notifying — channel reporting for bulk teardown
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn ext_clear_local_by_source_notifying_returns_channels_on_visible_change() {
+        use invalidation::Channel;
+
+        const LAYOUT: Channel = Channel::new(0);
+        const PAINT: Channel = Channel::new(1);
+
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .build(),
+        );
+        let height = registry.register(
+            "Height",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(PAINT.into_set())
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        // TemplateBinding is the winner for both properties.
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateBinding);
+        element.set_local_with_source(height, 20.0, LocalValueSource::TemplateBinding);
+
+        let channels =
+            element.clear_local_by_source_notifying(LocalValueSource::TemplateBinding, &registry);
+
+        // Both properties had visible changes; both contribute channels.
+        assert!(channels.contains(LAYOUT));
+        assert!(channels.contains(PAINT));
+        assert!(!element.has_local(width));
+        assert!(!element.has_local(height));
+    }
+
+    #[test]
+    fn ext_clear_local_by_source_notifying_skips_masked_lower_source() {
+        use invalidation::Channel;
+
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        // TemplateBinding is below the user's Local; the visible value is the
+        // Local, so clearing TemplateBinding should *not* report channels.
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateBinding);
+        element.set_local(width, 99.0);
+
+        let channels =
+            element.clear_local_by_source_notifying(LocalValueSource::TemplateBinding, &registry);
+
+        assert!(channels.is_empty());
+        // Local is still there.
+        assert_eq!(element.get_local_value(width), Some(&99.0));
+        // The TemplateBinding slot was emptied.
+        assert!(
+            !element
+                .property_store()
+                .has_local_at_source(width, LocalValueSource::TemplateBinding)
+        );
+    }
+
+    #[test]
+    fn ext_clear_local_by_source_notifying_skips_animation_masked() {
+        use invalidation::Channel;
+
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateBinding);
+        element.set_animation(width, 50.0); // Animation masks the entire local layer.
+
+        let channels =
+            element.clear_local_by_source_notifying(LocalValueSource::TemplateBinding, &registry);
+
+        // Animation still wins; visible value didn't change.
+        assert!(channels.is_empty());
+        assert_eq!(element.get_effective_local(width, &registry), 50.0);
+    }
+
+    // -------------------------------------------------------------------------
+    // clear_local_at_source_notifying — per-property, per-source, with callback
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn ext_clear_local_at_source_notifying_reveals_lower_source() {
+        use alloc::sync::Arc;
+        use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+        use invalidation::Channel;
+
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let last_old = Arc::new(AtomicU64::new(f64::NAN.to_bits()));
+        let last_new = Arc::new(AtomicU64::new(f64::NAN.to_bits()));
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .on_changed({
+                    let callback_count = Arc::clone(&callback_count);
+                    let last_old = Arc::clone(&last_old);
+                    let last_new = Arc::clone(&last_new);
+                    move |old, new| {
+                        callback_count.fetch_add(1, Ordering::Relaxed);
+                        last_old.store(
+                            old.copied().unwrap_or(f64::NAN).to_bits(),
+                            Ordering::Relaxed,
+                        );
+                        last_new.store(new.to_bits(), Ordering::Relaxed);
+                    }
+                })
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+        element.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+
+        let channels = element.clear_local_at_source_notifying(
+            width,
+            LocalValueSource::TemplateBinding,
+            &registry,
+        );
+
+        assert!(channels.contains(LAYOUT));
+        assert_eq!(element.get_effective_local(width, &registry), 10.0);
+        assert_eq!(callback_count.load(Ordering::Relaxed), 1);
+        assert_eq!(f64::from_bits(last_old.load(Ordering::Relaxed)), 20.0);
+        assert_eq!(f64::from_bits(last_new.load(Ordering::Relaxed)), 10.0);
+    }
+
+    #[test]
+    fn ext_clear_local_at_source_notifying_masked_by_local_no_notify() {
+        use alloc::sync::Arc;
+        use core::sync::atomic::{AtomicUsize, Ordering};
+        use invalidation::Channel;
+
+        let mut registry = PropertyRegistry::new();
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(Channel::new(0).into_set())
+                .on_changed({
+                    let callback_count = Arc::clone(&callback_count);
+                    move |_, _| {
+                        callback_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        element.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+        element.set_local(width, 99.0); // Local masks the TemplateBinding.
+
+        let channels = element.clear_local_at_source_notifying(
+            width,
+            LocalValueSource::TemplateBinding,
+            &registry,
+        );
+
+        assert!(channels.is_empty());
+        assert_eq!(callback_count.load(Ordering::Relaxed), 0);
+        // Local is unchanged; the TemplateBinding slot was emptied.
+        assert_eq!(element.get_effective_local(width, &registry), 99.0);
+        assert!(
+            !element
+                .property_store()
+                .has_local_at_source(width, LocalValueSource::TemplateBinding)
+        );
+    }
+
+    #[test]
+    fn ext_clear_local_at_source_notifying_equal_underneath_no_notify() {
+        use alloc::sync::Arc;
+        use core::sync::atomic::{AtomicUsize, Ordering};
+        use invalidation::Channel;
+
+        let mut registry = PropertyRegistry::new();
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(Channel::new(0).into_set())
+                .on_changed({
+                    let callback_count = Arc::clone(&callback_count);
+                    move |_, _| {
+                        callback_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        // TemplateDefault(10) shadowed by TemplateBinding(10): clearing the
+        // binding reveals the same value beneath, so effective doesn't move.
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateBinding);
+
+        let channels = element.clear_local_at_source_notifying(
+            width,
+            LocalValueSource::TemplateBinding,
+            &registry,
+        );
+
+        assert!(
+            channels.is_empty(),
+            "exact value comparison: effective didn't change"
+        );
+        assert_eq!(callback_count.load(Ordering::Relaxed), 0);
+        assert_eq!(element.get_effective_local(width, &registry), 10.0);
+        // TemplateDefault is now the winner.
+        assert_eq!(
+            element.get_local_source(width),
+            Some(LocalValueSource::TemplateDefault)
+        );
+    }
+
+    #[test]
+    fn ext_clear_local_at_source_notifying_empty_slot_returns_empty() {
+        use invalidation::Channel;
+
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(Channel::new(0).into_set())
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        // No value at TemplateBinding to clear.
+        let channels = element.clear_local_at_source_notifying(
+            width,
+            LocalValueSource::TemplateBinding,
+            &registry,
+        );
+
+        assert!(channels.is_empty());
+    }
+
+    #[test]
+    fn ext_clear_local_by_source_notifying_is_conservative_on_equal_shadow() {
+        // Pin the intentional conservative bulk behavior: clearing
+        // TemplateBinding(10) when TemplateDefault(10) is underneath still
+        // returns the channel even though the effective value didn't move.
+        // Bulk clear doesn't do typed value comparison; callers should use
+        // `clear_local_at_source_notifying` if they need exact detection.
+        use invalidation::Channel;
+
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+        element.set_local_with_source(width, 10.0, LocalValueSource::TemplateBinding);
+
+        let channels =
+            element.clear_local_by_source_notifying(LocalValueSource::TemplateBinding, &registry);
+
+        assert!(
+            channels.contains(LAYOUT),
+            "bulk clear is conservative: returns the channel even with equal shadowed value"
+        );
+        // TemplateDefault is now the winner.
+        assert_eq!(element.get_effective_local(width, &registry), 10.0);
+        assert_eq!(
+            element.get_local_source(width),
+            Some(LocalValueSource::TemplateDefault)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // clear_all — full per-property wipe across all slots
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn ext_clear_all_drops_every_slot_for_one_property() {
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register("Width", PropertyMetadataBuilder::new(0.0_f64).build());
+        let count = registry.register("Count", PropertyMetadataBuilder::new(0_i32).build());
+
+        let mut element = TestElement::new(1, None);
+        // Width has every slot populated.
+        element.set_local_with_source(width, 1.0, LocalValueSource::TemplateDefault);
+        element.set_local_with_source(width, 2.0, LocalValueSource::TemplateBinding);
+        element.set_local(width, 3.0);
+        element.set_animation(width, 4.0);
+        // Count is a different property that should be untouched.
+        element.set_local(count, 99);
+
+        let removed = element.clear_all(width);
+        assert!(removed);
+
+        // Every slot for `width` is gone.
+        assert!(!element.property_store().has_value(width));
+        assert!(
+            !element
+                .property_store()
+                .has_local_at_source(width, LocalValueSource::Local)
+        );
+        assert!(
+            !element
+                .property_store()
+                .has_local_at_source(width, LocalValueSource::TemplateBinding)
+        );
+        assert!(
+            !element
+                .property_store()
+                .has_local_at_source(width, LocalValueSource::TemplateDefault)
+        );
+        assert!(!element.has_animation(width));
+
+        // `count` is untouched.
+        assert_eq!(element.get_local_value(count), Some(&99));
     }
 }

--- a/understory_property/src/store.rs
+++ b/understory_property/src/store.rs
@@ -18,8 +18,27 @@
 //!
 //! # Scope
 //!
-//! `PropertyStore` handles **local storage only** - just Local and Animation values.
-//! Style resolution and inheritance belong to higher-level layers (see `understory_style`).
+//! `PropertyStore` handles **local storage only** — Local and Animation values.
+//! Style resolution, theme resolution, and inheritance live in higher-level
+//! crates (see `understory_style`); this store is intentionally narrower.
+//!
+//! # Layered Local Storage
+//!
+//! Within the local layer, each [`LocalValueSource`] is a *separate sparse
+//! store*. A write goes to its source's slot and leaves the other slots
+//! untouched, so clearing a higher source reveals any lower source that was
+//! previously installed. See [`LocalValueSource`] for the precedence order.
+//!
+//! # Memory Footprint
+//!
+//! A [`PropertyStore`] carries one `SmallVec` (the `Local` slot, with inline
+//! capacity for the common case) plus three `Vec`s (`TemplateBinding`,
+//! `TemplateDefault`, and `Animation`). The three `Vec`s do not allocate until
+//! their respective source writes — non-templated objects with no animations
+//! pay only the size of three empty `Vec` headers, not three heap
+//! allocations. This is a real but small per-object cost increase over the
+//! pre-layering design; if it becomes load-bearing we can revisit (e.g. lazy
+//! `Option<Box<...>>` for the template slots).
 
 use alloc::vec::Vec;
 use smallvec::SmallVec;
@@ -30,9 +49,108 @@ use crate::value::ErasedValue;
 
 /// Default inline capacity for property entries.
 ///
-/// Most UI objects have fewer than 8 non-default properties set,
-/// so this avoids heap allocation in the common case.
+/// Most UI objects have fewer than 8 non-default properties set, so this avoids
+/// heap allocation in the common case.
 const INLINE_CAPACITY: usize = 8;
+
+/// Identifies which writer installed a value in the local layer.
+///
+/// The local layer holds one value *per source per property*. When
+/// [`PropertyStore::get_local`] resolves, it walks sources in precedence order
+/// and returns the highest source that has a value. Clearing a higher source
+/// reveals whatever a lower source had previously written.
+///
+/// Precedence (highest to lowest):
+///
+/// 1. [`Local`](Self::Local) — explicit user write via `set_local`.
+/// 2. [`TemplateBinding`](Self::TemplateBinding) — a value pushed by a binding
+///    subscription from a templated parent.
+/// 3. [`TemplateDefault`](Self::TemplateDefault) — initial value written by a
+///    control template at instantiation time.
+///
+/// This enum is `#[non_exhaustive]` so we can add sources later without a
+/// breaking change.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum LocalValueSource {
+    /// Set by user code via [`PropertyStore::set_local`] or the notifying
+    /// variants on [`crate::DependencyObjectExt`].
+    Local,
+    /// Forwarded by a template binding subscription (e.g. a templated parent
+    /// pushed its property value to a template part).
+    TemplateBinding,
+    /// Written by a control template during instantiation as the part's initial
+    /// value.
+    TemplateDefault,
+}
+
+impl LocalValueSource {
+    /// Returns the ordinal precedence of this source.
+    ///
+    /// Higher values win when [`PropertyStore::get_local`] resolves. See the
+    /// [`LocalValueSource`] docs for the full order.
+    #[must_use]
+    #[inline]
+    pub const fn precedence(self) -> u8 {
+        match self {
+            Self::Local => 3,
+            Self::TemplateBinding => 2,
+            Self::TemplateDefault => 1,
+        }
+    }
+}
+
+type Entry = (PropertyId, ErasedValue);
+
+/// Shared helpers for the sorted sparse layouts of [`Entry`] used by every
+/// source's slot. Both `Vec<Entry>` and `SmallVec<[Entry; _]>` get the same
+/// API via the macro impl below.
+trait EntrySlice {
+    fn entry_find(&self, id: PropertyId) -> Result<usize, usize>;
+    fn entry_get(&self, id: PropertyId) -> Option<&ErasedValue>;
+}
+
+trait EntryStore: EntrySlice {
+    fn entry_write(&mut self, id: PropertyId, value: ErasedValue);
+    fn entry_clear(&mut self, id: PropertyId) -> bool;
+}
+
+macro_rules! impl_entry_store {
+    ($ty:ty) => {
+        impl EntrySlice for $ty {
+            #[inline]
+            fn entry_find(&self, id: PropertyId) -> Result<usize, usize> {
+                self.binary_search_by_key(&id, |(pid, _)| *pid)
+            }
+
+            #[inline]
+            fn entry_get(&self, id: PropertyId) -> Option<&ErasedValue> {
+                self.entry_find(id).ok().map(|idx| &self[idx].1)
+            }
+        }
+
+        impl EntryStore for $ty {
+            fn entry_write(&mut self, id: PropertyId, value: ErasedValue) {
+                match self.entry_find(id) {
+                    Ok(idx) => self[idx].1 = value,
+                    Err(idx) => self.insert(idx, (id, value)),
+                }
+            }
+
+            fn entry_clear(&mut self, id: PropertyId) -> bool {
+                if let Ok(idx) = self.entry_find(id) {
+                    self.remove(idx);
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    };
+}
+
+impl_entry_store!(Vec<Entry>);
+impl_entry_store!(SmallVec<[Entry; INLINE_CAPACITY]>);
 
 /// Per-object sparse storage for property values.
 ///
@@ -41,14 +159,16 @@ const INLINE_CAPACITY: usize = 8;
 ///
 /// # Storage Strategy
 ///
-/// Uses a sorted `SmallVec` with binary search, following the `WinUI` `vector_map`
-/// approach. This provides O(log n) lookup with excellent cache locality.
-/// The first 8 properties are stored inline without heap allocation.
+/// Uses sorted sparse stores with binary search, following the `WinUI`
+/// `vector_map` approach. This provides O(log n) lookup with excellent cache
+/// locality. Each store is independent so a write to one source slot does not
+/// touch any other.
 ///
 /// # Precedence
 ///
-/// Animation values take precedence over Local values:
-/// - `get_effective_local` returns: Animation → Local → registry default
+/// `get_effective_local` resolves in this order: **Animation** → **local layer**
+/// (highest source present) → registry default. Within the local layer, sources
+/// are ranked by [`LocalValueSource::precedence`].
 ///
 /// # Example
 ///
@@ -74,20 +194,18 @@ const INLINE_CAPACITY: usize = 8;
 /// ```
 #[derive(Debug)]
 pub struct PropertyStore<K> {
-    /// Local values, sorted by [`PropertyId`] for binary search lookup.
-    local_entries: SmallVec<[(PropertyId, ErasedValue); INLINE_CAPACITY]>,
-    /// Animation values, sorted by [`PropertyId`] for binary search lookup.
+    /// Local slot — user-driven; highest precedence within the local layer.
+    local_entries: SmallVec<[Entry; INLINE_CAPACITY]>,
+    /// Template-binding slot — pushed by binding subscriptions.
+    template_binding_entries: Vec<Entry>,
+    /// Template-default slot — written by control templates on instantiation.
+    template_default_entries: Vec<Entry>,
+    /// Animation slot — highest precedence overall.
     ///
     /// Stored out-of-line so that objects with no animation values pay minimal
     /// per-object overhead.
-    animation_entries: Vec<(PropertyId, ErasedValue)>,
+    animation_entries: Vec<Entry>,
     owner: K,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum Layer {
-    Local,
-    Animation,
 }
 
 impl<K: Copy + Eq> PropertyStore<K> {
@@ -96,6 +214,8 @@ impl<K: Copy + Eq> PropertyStore<K> {
     pub fn new(owner: K) -> Self {
         Self {
             local_entries: SmallVec::new(),
+            template_binding_entries: Vec::new(),
+            template_default_entries: Vec::new(),
             animation_entries: Vec::new(),
             owner,
         }
@@ -108,128 +228,282 @@ impl<K: Copy + Eq> PropertyStore<K> {
         self.owner
     }
 
-    /// Returns `true` if no properties have explicit values set.
+    /// Returns `true` if no properties have explicit values set in any slot.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.local_entries.is_empty() && self.animation_entries.is_empty()
+        self.local_entries.is_empty()
+            && self.template_binding_entries.is_empty()
+            && self.template_default_entries.is_empty()
+            && self.animation_entries.is_empty()
     }
 
-    /// Returns the number of properties with explicit values.
+    /// Returns the number of unique properties with at least one value set.
     #[must_use]
     pub fn len(&self) -> usize {
         self.property_ids().count()
     }
 
-    /// Returns the property IDs that have values set.
+    /// Returns the property IDs that have values set, deduplicated across all
+    /// source slots and the animation slot, in ascending order.
     pub fn property_ids(&self) -> impl Iterator<Item = PropertyId> + '_ {
-        PropertyIds {
-            local: self.local_entries.as_slice(),
-            animation: self.animation_entries.as_slice(),
-            local_i: 0,
-            animation_i: 0,
+        PropertyIds::new([
+            self.local_entries.as_slice(),
+            self.template_binding_entries.as_slice(),
+            self.template_default_entries.as_slice(),
+            self.animation_entries.as_slice(),
+        ])
+    }
+
+    // =========================================================================
+    // Local layer — internal helpers
+    // =========================================================================
+
+    /// Looks up the highest local-layer source that has a value for `id`.
+    fn local_layer_lookup(&self, id: PropertyId) -> Option<(LocalValueSource, &ErasedValue)> {
+        if let Some(v) = self.local_entries.entry_get(id) {
+            return Some((LocalValueSource::Local, v));
+        }
+        if let Some(v) = self.template_binding_entries.entry_get(id) {
+            return Some((LocalValueSource::TemplateBinding, v));
+        }
+        if let Some(v) = self.template_default_entries.entry_get(id) {
+            return Some((LocalValueSource::TemplateDefault, v));
+        }
+        None
+    }
+
+    /// Returns the value at a specific local-layer source, if any.
+    fn slot_get(&self, id: PropertyId, source: LocalValueSource) -> Option<&ErasedValue> {
+        match source {
+            LocalValueSource::Local => self.local_entries.entry_get(id),
+            LocalValueSource::TemplateBinding => self.template_binding_entries.entry_get(id),
+            LocalValueSource::TemplateDefault => self.template_default_entries.entry_get(id),
         }
     }
 
-    /// Binary search for a local entry by property ID.
-    #[inline]
-    fn find_local_entry(&self, id: PropertyId) -> Result<usize, usize> {
-        self.local_entries
-            .binary_search_by_key(&id, |(pid, _)| *pid)
-    }
-
-    /// Binary search for an animation entry by property ID.
-    #[inline]
-    fn find_animation_entry(&self, id: PropertyId) -> Result<usize, usize> {
-        self.animation_entries
-            .binary_search_by_key(&id, |(pid, _)| *pid)
-    }
-
-    /// Gets an erased value for a given layer.
-    #[inline]
-    fn get_layer_value(&self, id: PropertyId, layer: Layer) -> Option<&ErasedValue> {
-        match layer {
-            Layer::Local => self
-                .find_local_entry(id)
-                .ok()
-                .map(|idx| &self.local_entries[idx].1),
-            Layer::Animation => self
-                .find_animation_entry(id)
-                .ok()
-                .map(|idx| &self.animation_entries[idx].1),
-        }
-    }
-
-    #[inline]
-    fn set_layer_value(&mut self, id: PropertyId, layer: Layer, value: ErasedValue) {
-        match layer {
-            Layer::Local => match self.find_local_entry(id) {
-                Ok(idx) => self.local_entries[idx].1 = value,
-                Err(idx) => self.local_entries.insert(idx, (id, value)),
-            },
-            Layer::Animation => {
-                match self.find_animation_entry(id) {
-                    Ok(idx) => self.animation_entries[idx].1 = value,
-                    Err(idx) => self.animation_entries.insert(idx, (id, value)),
-                };
+    fn slot_write(&mut self, id: PropertyId, source: LocalValueSource, value: ErasedValue) {
+        match source {
+            LocalValueSource::Local => self.local_entries.entry_write(id, value),
+            LocalValueSource::TemplateBinding => {
+                self.template_binding_entries.entry_write(id, value);
+            }
+            LocalValueSource::TemplateDefault => {
+                self.template_default_entries.entry_write(id, value);
             }
         }
     }
 
-    #[inline]
-    fn clear_layer_value(&mut self, id: PropertyId, layer: Layer) -> bool {
-        match layer {
-            Layer::Local => {
-                if let Ok(idx) = self.find_local_entry(id) {
-                    self.local_entries.remove(idx);
-                    true
-                } else {
-                    false
-                }
-            }
-            Layer::Animation => {
-                if let Ok(idx) = self.find_animation_entry(id) {
-                    self.animation_entries.remove(idx);
-                    true
-                } else {
-                    false
-                }
-            }
+    fn slot_clear_id(&mut self, id: PropertyId, source: LocalValueSource) -> bool {
+        match source {
+            LocalValueSource::Local => self.local_entries.entry_clear(id),
+            LocalValueSource::TemplateBinding => self.template_binding_entries.entry_clear(id),
+            LocalValueSource::TemplateDefault => self.template_default_entries.entry_clear(id),
         }
+    }
+
+    fn slot_property_ids(&self, source: LocalValueSource) -> impl Iterator<Item = PropertyId> + '_ {
+        let slice: &[Entry] = match source {
+            LocalValueSource::Local => self.local_entries.as_slice(),
+            LocalValueSource::TemplateBinding => self.template_binding_entries.as_slice(),
+            LocalValueSource::TemplateDefault => self.template_default_entries.as_slice(),
+        };
+        slice.iter().map(|(id, _)| *id)
     }
 
     // =========================================================================
     // Local value methods
     // =========================================================================
 
-    /// Gets the local value, if set.
+    /// Gets the local value, resolving the winning source within the local layer.
     #[must_use]
     #[inline]
     pub fn get_local<T: Clone + 'static>(&self, property: Property<T>) -> Option<&T> {
-        self.get_layer_value(property.id(), Layer::Local)
+        self.local_layer_lookup(property.id())
+            .and_then(|(_, v)| v.downcast_ref())
+    }
+
+    /// Returns the [`LocalValueSource`] currently winning the local-layer
+    /// resolution for `property`, if any source has a value.
+    #[must_use]
+    #[inline]
+    pub fn get_local_source<T: Clone + 'static>(
+        &self,
+        property: Property<T>,
+    ) -> Option<LocalValueSource> {
+        self.local_layer_lookup(property.id()).map(|(s, _)| s)
+    }
+
+    /// Gets the value at a specific local-layer source, if that source has one.
+    #[must_use]
+    #[inline]
+    pub fn get_local_at_source<T: Clone + 'static>(
+        &self,
+        property: Property<T>,
+        source: LocalValueSource,
+    ) -> Option<&T> {
+        self.slot_get(property.id(), source)
             .and_then(ErasedValue::downcast_ref)
     }
 
-    /// Sets the local value.
-    ///
-    /// Returns a reference to the stored value.
-    pub fn set_local<T: Clone + 'static>(&mut self, property: Property<T>, value: T) -> &T {
-        let id = property.id();
-        self.set_layer_value(id, Layer::Local, ErasedValue::new(value));
-        self.get_local(property).unwrap()
-    }
-
-    /// Clears the local value.
-    ///
-    /// Returns `true` if a value was removed.
-    pub fn clear_local<T: Clone + 'static>(&mut self, property: Property<T>) -> bool {
-        self.clear_layer_value(property.id(), Layer::Local)
-    }
-
-    /// Returns `true` if the property has a local value.
+    /// Returns `true` if any local-layer source has a value for `property`.
     #[must_use]
     #[inline]
     pub fn has_local<T: Clone + 'static>(&self, property: Property<T>) -> bool {
-        self.find_local_entry(property.id()).is_ok()
+        self.local_layer_lookup(property.id()).is_some()
+    }
+
+    /// Returns `true` if the specific source has a value for `property`.
+    #[must_use]
+    #[inline]
+    pub fn has_local_at_source<T: Clone + 'static>(
+        &self,
+        property: Property<T>,
+        source: LocalValueSource,
+    ) -> bool {
+        self.slot_get(property.id(), source).is_some()
+    }
+
+    /// Sets the local value at [`LocalValueSource::Local`].
+    ///
+    /// This is the user-code entry point. To write to another source slot, use
+    /// [`set_local_with_source`](Self::set_local_with_source).
+    ///
+    /// Returns a reference to the stored value.
+    pub fn set_local<T: Clone + 'static>(&mut self, property: Property<T>, value: T) -> &T {
+        self.slot_write(
+            property.id(),
+            LocalValueSource::Local,
+            ErasedValue::new(value),
+        );
+        // `get_local` returns the highest-source value; with Local just written,
+        // that's the value we just stored.
+        self.get_local(property).unwrap()
+    }
+
+    /// Writes a value to the slot for `source`.
+    ///
+    /// Each source has its own sparse slot, so this write never overwrites a
+    /// value held by another source — it only replaces (or inserts) the entry
+    /// in this source's slot. The new value becomes the winning local value
+    /// only if `source` has the highest precedence among the sources that
+    /// currently have an entry for this property.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use understory_property::{
+    ///     LocalValueSource, Property, PropertyMetadataBuilder, PropertyRegistry, PropertyStore,
+    /// };
+    ///
+    /// let mut registry = PropertyRegistry::new();
+    /// let width: Property<f64> =
+    ///     registry.register("Width", PropertyMetadataBuilder::new(0.0_f64).build());
+    ///
+    /// let mut store = PropertyStore::<u32>::new(1);
+    ///
+    /// // Template installs a default.
+    /// store.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+    /// assert_eq!(store.get_local(width), Some(&10.0));
+    ///
+    /// // User writes a Local. Local wins.
+    /// store.set_local_with_source(width, 50.0, LocalValueSource::Local);
+    /// assert_eq!(store.get_local(width), Some(&50.0));
+    ///
+    /// // Clearing Local reveals TemplateDefault again.
+    /// store.clear_local(width);
+    /// assert_eq!(store.get_local(width), Some(&10.0));
+    /// ```
+    pub fn set_local_with_source<T: Clone + 'static>(
+        &mut self,
+        property: Property<T>,
+        value: T,
+        source: LocalValueSource,
+    ) {
+        self.slot_write(property.id(), source, ErasedValue::new(value));
+    }
+
+    /// Clears the value at [`LocalValueSource::Local`] only.
+    ///
+    /// Other source slots (e.g. `TemplateDefault`) are untouched and may become
+    /// the new winning value after this call. To remove a value at a different
+    /// source, use [`clear_local_at_source`](Self::clear_local_at_source); to
+    /// remove every source slot for one property, use
+    /// [`clear_all`](Self::clear_all).
+    ///
+    /// Returns `true` if a Local entry was removed.
+    pub fn clear_local<T: Clone + 'static>(&mut self, property: Property<T>) -> bool {
+        self.slot_clear_id(property.id(), LocalValueSource::Local)
+    }
+
+    /// Clears the value at a specific local-layer source for `property`.
+    ///
+    /// Returns `true` if a value was removed from that source's slot.
+    pub fn clear_local_at_source<T: Clone + 'static>(
+        &mut self,
+        property: Property<T>,
+        source: LocalValueSource,
+    ) -> bool {
+        self.slot_clear_id(property.id(), source)
+    }
+
+    /// Clears every value held by the given source.
+    ///
+    /// Returns the number of entries removed. This is the bulk cleanup hook —
+    /// e.g. a template tear-down calling
+    /// `clear_local_by_source(LocalValueSource::TemplateDefault)` (and
+    /// `TemplateBinding`) drops every value the template installed without
+    /// touching anything stored under `Local`.
+    ///
+    /// For change notification, see
+    /// [`DependencyObjectExt::clear_local_by_source_notifying`].
+    ///
+    /// [`DependencyObjectExt::clear_local_by_source_notifying`]:
+    /// crate::DependencyObjectExt::clear_local_by_source_notifying
+    pub fn clear_local_by_source(&mut self, source: LocalValueSource) -> usize {
+        match source {
+            LocalValueSource::Local => {
+                let n = self.local_entries.len();
+                self.local_entries.clear();
+                n
+            }
+            LocalValueSource::TemplateBinding => {
+                let n = self.template_binding_entries.len();
+                self.template_binding_entries.clear();
+                n
+            }
+            LocalValueSource::TemplateDefault => {
+                let n = self.template_default_entries.len();
+                self.template_default_entries.clear();
+                n
+            }
+        }
+    }
+
+    /// Returns the property ids that currently have an entry under `source`,
+    /// in ascending order.
+    pub fn local_property_ids_at_source(
+        &self,
+        source: LocalValueSource,
+    ) -> impl Iterator<Item = PropertyId> + '_ {
+        self.slot_property_ids(source)
+    }
+
+    /// Returns the winning local-layer source for `id`, if any source has a
+    /// value. This is the type-erased twin of [`get_local_source`].
+    ///
+    /// [`get_local_source`]: Self::get_local_source
+    #[must_use]
+    pub fn winning_local_source_for_id(&self, id: PropertyId) -> Option<LocalValueSource> {
+        self.local_layer_lookup(id).map(|(s, _)| s)
+    }
+
+    /// Returns `true` if the animation slot holds an entry for `id`. This is
+    /// the type-erased twin of [`has_animation`].
+    ///
+    /// [`has_animation`]: Self::has_animation
+    #[must_use]
+    pub fn animation_entries_has(&self, id: PropertyId) -> bool {
+        self.animation_entries.entry_find(id).is_ok()
     }
 
     // =========================================================================
@@ -240,7 +514,8 @@ impl<K: Copy + Eq> PropertyStore<K> {
     #[must_use]
     #[inline]
     pub fn get_animation<T: Clone + 'static>(&self, property: Property<T>) -> Option<&T> {
-        self.get_layer_value(property.id(), Layer::Animation)
+        self.animation_entries
+            .entry_get(property.id())
             .and_then(ErasedValue::downcast_ref)
     }
 
@@ -249,7 +524,8 @@ impl<K: Copy + Eq> PropertyStore<K> {
     /// Returns a reference to the stored value.
     pub fn set_animation<T: Clone + 'static>(&mut self, property: Property<T>, value: T) -> &T {
         let id = property.id();
-        self.set_layer_value(id, Layer::Animation, ErasedValue::new(value));
+        self.animation_entries
+            .entry_write(id, ErasedValue::new(value));
         self.get_animation(property).unwrap()
     }
 
@@ -257,25 +533,24 @@ impl<K: Copy + Eq> PropertyStore<K> {
     ///
     /// Returns `true` if a value was removed.
     pub fn clear_animation<T: Clone + 'static>(&mut self, property: Property<T>) -> bool {
-        self.clear_layer_value(property.id(), Layer::Animation)
+        self.animation_entries.entry_clear(property.id())
     }
 
     /// Returns `true` if the property has an animation value.
     #[must_use]
     #[inline]
     pub fn has_animation<T: Clone + 'static>(&self, property: Property<T>) -> bool {
-        self.find_animation_entry(property.id()).is_ok()
+        self.animation_entries.entry_find(property.id()).is_ok()
     }
 
     // =========================================================================
     // Effective value resolution
     // =========================================================================
 
-    /// Gets the effective local value (Animation → Local → registry default).
+    /// Gets the effective local value (Animation → local layer → registry default).
     ///
-    /// This resolves from this store's values and falls back to the registry
-    /// default. It does **not** handle style or inheritance—those belong to
-    /// higher-level APIs.
+    /// Resolves the local layer by walking sources from highest to lowest
+    /// precedence.
     ///
     /// # Panics
     ///
@@ -287,30 +562,23 @@ impl<K: Copy + Eq> PropertyStore<K> {
         registry: &PropertyRegistry,
     ) -> T {
         let id = property.id();
-        // Check our values (Animation > Local)
-        if let Some(v) = self.get_layer_value(id, Layer::Animation)
+        if let Some(v) = self.animation_entries.entry_get(id)
             && let Some(v) = v.downcast_ref::<T>()
         {
             return v.clone();
         }
-        if let Some(v) = self.get_layer_value(id, Layer::Local)
+        if let Some((_, v)) = self.local_layer_lookup(id)
             && let Some(v) = v.downcast_ref::<T>()
         {
             return v.clone();
         }
-
-        // Fall back to registry default
         if let Some(metadata) = registry.get_metadata::<T>(property) {
             return metadata.default_value().clone();
         }
-
         panic!("Property {:?} not found in registry", property.id());
     }
 
-    /// Gets the effective local value (Animation → Local → registry default), borrowed.
-    ///
-    /// This avoids cloning and returns a reference into either this store (Animation/Local)
-    /// or the registry's default value.
+    /// Gets the effective local value, borrowed.
     ///
     /// # Panics
     ///
@@ -323,41 +591,39 @@ impl<K: Copy + Eq> PropertyStore<K> {
         registry: &'a PropertyRegistry,
     ) -> &'a T {
         let id = property.id();
-        // Check our values (Animation > Local)
-        if let Some(v) = self.get_layer_value(id, Layer::Animation)
+        if let Some(v) = self.animation_entries.entry_get(id)
             && let Some(v) = v.downcast_ref::<T>()
         {
             return v;
         }
-        if let Some(v) = self.get_layer_value(id, Layer::Local)
+        if let Some((_, v)) = self.local_layer_lookup(id)
             && let Some(v) = v.downcast_ref::<T>()
         {
             return v;
         }
-
-        // Fall back to registry default
         if let Some(metadata) = registry.get_metadata::<T>(property) {
             return metadata.default_value();
         }
-
         panic!("Property {:?} not found in registry", property.id());
     }
 
-    /// Returns `true` if the property has any value (local or animation).
+    /// Returns `true` if any local-layer source or the animation slot has a
+    /// value for `property`.
     #[must_use]
     #[inline]
     pub fn has_value<T: Clone + 'static>(&self, property: Property<T>) -> bool {
-        self.find_local_entry(property.id()).is_ok()
-            || self.find_animation_entry(property.id()).is_ok()
+        self.has_local(property) || self.has_animation(property)
     }
 
-    /// Clears all values for a property.
+    /// Clears every value (every local source and animation) for `property`.
     ///
-    /// Returns `true` if any values were removed.
+    /// Returns `true` if any value was removed.
     pub fn clear_all<T: Clone + 'static>(&mut self, property: Property<T>) -> bool {
         let id = property.id();
-        let mut removed = self.clear_layer_value(id, Layer::Local);
-        removed |= self.clear_layer_value(id, Layer::Animation);
+        let mut removed = self.local_entries.entry_clear(id);
+        removed |= self.template_binding_entries.entry_clear(id);
+        removed |= self.template_default_entries.entry_clear(id);
+        removed |= self.animation_entries.entry_clear(id);
         removed
     }
 
@@ -375,50 +641,51 @@ impl<K: Copy + Eq> Clone for PropertyStore<K> {
     fn clone(&self) -> Self {
         Self {
             local_entries: self.local_entries.clone(),
+            template_binding_entries: self.template_binding_entries.clone(),
+            template_default_entries: self.template_default_entries.clone(),
             animation_entries: self.animation_entries.clone(),
             owner: self.owner,
         }
     }
 }
 
+/// Merging iterator over four sorted [`Entry`] slices that yields each
+/// `PropertyId` once, in ascending order.
 struct PropertyIds<'a> {
-    local: &'a [(PropertyId, ErasedValue)],
-    animation: &'a [(PropertyId, ErasedValue)],
-    local_i: usize,
-    animation_i: usize,
+    slices: [&'a [Entry]; 4],
+    cursors: [usize; 4],
+}
+
+impl<'a> PropertyIds<'a> {
+    fn new(slices: [&'a [Entry]; 4]) -> Self {
+        Self {
+            slices,
+            cursors: [0; 4],
+        }
+    }
 }
 
 impl Iterator for PropertyIds<'_> {
     type Item = PropertyId;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let local = self.local.get(self.local_i).map(|(id, _)| *id);
-        let animation = self.animation.get(self.animation_i).map(|(id, _)| *id);
-
-        match (local, animation) {
-            (None, None) => None,
-            (Some(id), None) => {
-                self.local_i += 1;
-                Some(id)
-            }
-            (None, Some(id)) => {
-                self.animation_i += 1;
-                Some(id)
-            }
-            (Some(local_id), Some(animation_id)) => {
-                if local_id < animation_id {
-                    self.local_i += 1;
-                    Some(local_id)
-                } else if animation_id < local_id {
-                    self.animation_i += 1;
-                    Some(animation_id)
-                } else {
-                    self.local_i += 1;
-                    self.animation_i += 1;
-                    Some(local_id)
-                }
+        let mut min: Option<PropertyId> = None;
+        for slot in 0..4 {
+            if let Some((id, _)) = self.slices[slot].get(self.cursors[slot]) {
+                min = Some(match min {
+                    Some(m) if m <= *id => m,
+                    _ => *id,
+                });
             }
         }
+        let next = min?;
+        // Advance every cursor that's currently at `next` (dedup across slots).
+        for slot in 0..4 {
+            if matches!(self.slices[slot].get(self.cursors[slot]), Some((id, _)) if *id == next) {
+                self.cursors[slot] += 1;
+            }
+        }
+        Some(next)
     }
 }
 
@@ -473,15 +740,12 @@ mod tests {
         let (registry, width, _) = setup_registry();
         let mut store = PropertyStore::<u32>::new(1);
 
-        // Set local value
         store.set_local(width, 100.0);
         assert_eq!(store.get_effective_local(width, &registry), 100.0);
 
-        // Animation overrides local
         store.set_animation(width, 200.0);
         assert_eq!(store.get_effective_local(width, &registry), 200.0);
 
-        // Clear animation, local becomes effective
         store.clear_animation(width);
         assert_eq!(store.get_effective_local(width, &registry), 100.0);
     }
@@ -491,17 +755,14 @@ mod tests {
         let (registry, width, _) = setup_registry();
         let mut store = PropertyStore::<u32>::new(1);
 
-        // Default comes from registry.
         let default_ref = store.get_effective_local_ref(width, &registry);
         let metadata_default = registry.get_metadata(width).unwrap().default_value();
         assert!(core::ptr::eq(default_ref, metadata_default));
 
-        // Local comes from store.
         store.set_local(width, 100.0);
         let local_ref = store.get_effective_local_ref(width, &registry);
         assert!(core::ptr::eq(local_ref, store.get_local(width).unwrap()));
 
-        // Animation overrides local.
         store.set_animation(width, 200.0);
         let anim_ref = store.get_effective_local_ref(width, &registry);
         assert!(core::ptr::eq(anim_ref, store.get_animation(width).unwrap()));
@@ -519,7 +780,6 @@ mod tests {
         assert!(!store.has_local(width));
         assert!(store.is_empty());
 
-        // Clearing non-existent returns false
         assert!(!store.clear_local(width));
     }
 
@@ -550,16 +810,14 @@ mod tests {
 
         assert!(!store.has_animation(width));
         assert!(!store.has_animation(count));
-        assert!(store.has_local(width)); // Local preserved
-        assert!(!store.has_value(count)); // Entry removed (was animation only)
+        assert!(store.has_local(width));
+        assert!(!store.has_value(count));
     }
 
     #[test]
     fn store_default_value() {
         let (registry, width, _) = setup_registry();
         let store = PropertyStore::<u32>::new(1);
-
-        // No value set, should return default from registry
         assert_eq!(store.get_effective_local(width, &registry), 0.0);
     }
 
@@ -591,23 +849,19 @@ mod tests {
     #[test]
     fn store_sorted_order() {
         let mut registry = PropertyRegistry::new();
-        // Register in reverse order to test sorting
         let c: Property<i32> = registry.register("C", PropertyMetadataBuilder::new(0).build());
         let a: Property<i32> = registry.register("A", PropertyMetadataBuilder::new(0).build());
         let b: Property<i32> = registry.register("B", PropertyMetadataBuilder::new(0).build());
 
         let mut store = PropertyStore::<u32>::new(1);
 
-        // Set in arbitrary order
         store.set_local(b, 2);
         store.set_local(c, 3);
         store.set_local(a, 1);
 
-        // Should maintain sorted order by PropertyId
         let ids: Vec<_> = store.property_ids().collect();
         assert_eq!(ids.len(), 3);
 
-        // IDs should be in ascending order
         for i in 1..ids.len() {
             assert!(ids[i - 1].index() < ids[i].index());
         }
@@ -627,7 +881,6 @@ mod tests {
 
         let mut store = PropertyStore::<u32>::new(1);
 
-        // Set every other property
         for (i, prop) in props.iter().enumerate() {
             if i % 2 == 0 {
                 let value = i32::try_from(i).unwrap();
@@ -635,7 +888,6 @@ mod tests {
             }
         }
 
-        // Verify lookups work correctly
         for (i, prop) in props.iter().enumerate() {
             if i % 2 == 0 {
                 let value = i32::try_from(i).unwrap();
@@ -651,23 +903,188 @@ mod tests {
         let (_, width, _) = setup_registry();
         let mut store = PropertyStore::<u32>::new(1);
 
-        // Set both
         store.set_local(width, 100.0);
         store.set_animation(width, 200.0);
 
-        // Both accessible individually
         assert_eq!(store.get_local(width), Some(&100.0));
         assert_eq!(store.get_animation(width), Some(&200.0));
 
-        // Clear local, animation still there
         store.clear_local(width);
         assert!(store.get_local(width).is_none());
         assert_eq!(store.get_animation(width), Some(&200.0));
-        assert!(store.has_value(width)); // Entry still exists
+        assert!(store.has_value(width));
 
-        // Clear animation, entry removed
         store.clear_animation(width);
         assert!(!store.has_value(width));
         assert!(store.is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // LocalValueSource — layered behavior
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn local_value_source_precedence_order() {
+        assert!(
+            LocalValueSource::Local.precedence() > LocalValueSource::TemplateBinding.precedence()
+        );
+        assert!(
+            LocalValueSource::TemplateBinding.precedence()
+                > LocalValueSource::TemplateDefault.precedence()
+        );
+    }
+
+    #[test]
+    fn set_local_records_local_source() {
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local(width, 100.0);
+        assert_eq!(store.get_local_source(width), Some(LocalValueSource::Local));
+    }
+
+    #[test]
+    fn set_local_with_source_records_source() {
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+        assert_eq!(store.get_local(width), Some(&10.0));
+        assert_eq!(
+            store.get_local_source(width),
+            Some(LocalValueSource::TemplateDefault)
+        );
+    }
+
+    #[test]
+    fn highest_source_wins_read() {
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+        store.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+        store.set_local(width, 30.0); // Local
+
+        assert_eq!(store.get_local(width), Some(&30.0));
+        assert_eq!(store.get_local_source(width), Some(LocalValueSource::Local));
+    }
+
+    #[test]
+    fn clear_template_binding_reveals_template_default() {
+        // Reviewer-requested: TemplateDefault → TemplateBinding → clear TemplateBinding
+        // must reveal TemplateDefault.
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+        store.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+        assert_eq!(store.get_local(width), Some(&20.0));
+
+        assert!(store.clear_local_at_source(width, LocalValueSource::TemplateBinding));
+        assert_eq!(store.get_local(width), Some(&10.0));
+        assert_eq!(
+            store.get_local_source(width),
+            Some(LocalValueSource::TemplateDefault)
+        );
+    }
+
+    #[test]
+    fn clear_local_reveals_template_binding() {
+        // Reviewer-requested: TemplateBinding → Local → clear Local
+        // must reveal TemplateBinding.
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+        store.set_local(width, 30.0);
+        assert_eq!(store.get_local(width), Some(&30.0));
+
+        assert!(store.clear_local(width));
+        assert_eq!(store.get_local(width), Some(&20.0));
+        assert_eq!(
+            store.get_local_source(width),
+            Some(LocalValueSource::TemplateBinding)
+        );
+    }
+
+    #[test]
+    fn set_to_lower_source_does_not_change_winning_value() {
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local(width, 100.0);
+        // Writing a lower source goes to that source's slot but doesn't win.
+        store.set_local_with_source(width, 50.0, LocalValueSource::TemplateBinding);
+
+        assert_eq!(store.get_local(width), Some(&100.0));
+        assert_eq!(store.get_local_source(width), Some(LocalValueSource::Local));
+        // The lower-source value is preserved underneath.
+        assert_eq!(
+            store.get_local_at_source(width, LocalValueSource::TemplateBinding),
+            Some(&50.0)
+        );
+    }
+
+    #[test]
+    fn clear_local_by_source_removes_only_that_slot() {
+        let (_, width, count) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local_with_source(width, 1.0, LocalValueSource::TemplateDefault);
+        store.set_local_with_source(count, 2_i32, LocalValueSource::TemplateDefault);
+        store.set_local(width, 99.0);
+
+        let removed = store.clear_local_by_source(LocalValueSource::TemplateDefault);
+        assert_eq!(removed, 2);
+
+        // `width` still has its Local value.
+        assert_eq!(store.get_local(width), Some(&99.0));
+        assert_eq!(store.get_local_source(width), Some(LocalValueSource::Local));
+        // `count` had only TemplateDefault; nothing remains.
+        assert!(!store.has_local(count));
+    }
+
+    #[test]
+    fn clear_local_by_source_returns_zero_when_empty() {
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+        store.set_local(width, 100.0);
+
+        assert_eq!(
+            store.clear_local_by_source(LocalValueSource::TemplateDefault),
+            0
+        );
+        assert!(store.has_local(width));
+    }
+
+    #[test]
+    fn has_local_at_source_reflects_specific_slot() {
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local_with_source(width, 7.0, LocalValueSource::TemplateBinding);
+
+        assert!(store.has_local_at_source(width, LocalValueSource::TemplateBinding));
+        assert!(!store.has_local_at_source(width, LocalValueSource::Local));
+        assert!(!store.has_local_at_source(width, LocalValueSource::TemplateDefault));
+    }
+
+    #[test]
+    fn property_ids_dedupes_across_slots() {
+        let (_, width, count) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        // Same property has entries in multiple slots; should only appear once.
+        store.set_local_with_source(width, 1.0, LocalValueSource::TemplateDefault);
+        store.set_local_with_source(width, 2.0, LocalValueSource::TemplateBinding);
+        store.set_local(width, 3.0);
+        store.set_animation(width, 4.0);
+        // `count` only in one slot.
+        store.set_local(count, 99);
+
+        let ids: Vec<_> = store.property_ids().collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&width.id()));
+        assert!(ids.contains(&count.id()));
     }
 }


### PR DESCRIPTION
Adds a `LocalValueSource` tag on every local-layer entry so a template tear-down can drop only the values it installed and so a `TemplateBinding` push can never silently clobber a user's explicit `set_local`. This is the Phase 0 substrate change Overstory needs before it can drive control templates against this store.

## Design

`LocalValueSource` (`#[non_exhaustive]`) ranks three writers within the local layer:

  3. `Local` — explicit user write via `set_local`
  2. `TemplateBinding` — value pushed by a binding subscription
  1. `TemplateDefault` — initial value written by a control template

Each source has its own sparse store: a `SmallVec` for `Local` (inline for the common case), a `Vec` for `TemplateBinding`, a `Vec` for `TemplateDefault`, plus the existing `Animation` `Vec`. Writes go to their own slot and never overwrite another source. `get_local` walks sources from highest to lowest. Clearing the winning source reveals whatever a lower source had previously installed — this matches WPF / WinUI value-source lifecycle semantics and is what makes `TemplateBinding` re-pushes safe in the presence of user `Local` writes.

## API additions

`PropertyStore`:

- `set_local_with_source(prop, value, source)` — write into a specific slot
- `get_local_source(prop) -> Option<LocalValueSource>` — winning local source
- `get_local_at_source(prop, source) -> Option<&T>` — value in a specific slot
- `has_local_at_source(prop, source) -> bool`
- `clear_local_at_source(prop, source) -> bool`
- `clear_local_by_source(source) -> usize` — bulk clear one slot across props
- `local_property_ids_at_source(source)` — slot enumeration
- `winning_local_source_for_id(id)` / `animation_entries_has(id)` — erased helpers for the notifying ext methods

`DependencyObjectExt` mirrors all of the above and adds:

- `set_local_with_source_notifying(prop, value, source, registry)` — typed effective-change check, fires `on_changed`, returns channels
- `clear_local_at_source_notifying<T>(prop, source, registry)` — per-property + source-targeted clear with typed change detection
- `clear_local_by_source_notifying(source, registry)` — bulk teardown that returns the union of `affects_channels` for every property where `source` is the current winner and no animation is masking. Conservative: returns channels even when the next-lower source happens to hold an equal value (extra dirty-marks are safe; callers wanting exact detection should use the per-property variant). Does not fire `on_changed` callbacks — documented.
- `clear_all<T>(prop)` — drop every slot (all sources + animation) for one property

## Backward compatibility

`set_local`, `clear_local`, `set_animation`, and `clear_animation` keep their existing signatures and semantics. `set_local` is just a typed shortcut for `set_local_with_source(prop, value, Local)`. `clear_local` now explicitly targets the `Local` slot only (`clear_local_at_source` / `clear_all` cover the other cases); docs updated accordingly.

## Memory footprint

`PropertyStore` carries one `SmallVec` + three `Vec`s. The three `Vec`s don't allocate until their respective source writes, so non-templated objects without animations pay only the size of three empty `Vec` headers, not three heap allocations.

## Tests

83 unit tests + 12 doctests pass; clippy `-D warnings` clean; `cargo fmt --all --check` clean. New tests cover:

- reveal-on-clear in both directions (`TemplateDefault -> TemplateBinding -> clear` and `TemplateBinding -> Local -> clear`)
- per-property notifying clear with typed callback (reveals lower source, masked by Local, equal-value shadow, empty slot)
- bulk notifying clear (visible change, masked by Local, masked by animation, conservative equal-value shadow that still returns the channel)
- `clear_all` removes every slot for one property and leaves another intact
- 4-way `property_ids` merge dedupes across slots