### PR TITLE
Spike of `understory_presentation`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ env:
     -p understory_index
     -p understory_inspector
     -p understory_outline
+    -p understory_presentation
     -p understory_precise_hit
     -p understory_property
     -p understory_responder

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,13 +281,14 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "kurbo"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
  "arrayvec",
  "euclid",
  "libm",
+ "polycool",
  "smallvec",
 ]
 
@@ -290,9 +300,15 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "lock_api"
@@ -330,6 +346,34 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "parlance"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+
+[[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+ "libm",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -563,6 +607,7 @@ dependencies = [
  "understory_inspector",
  "understory_outline",
  "understory_precise_hit",
+ "understory_presentation",
  "understory_property",
  "understory_property_binding",
  "understory_responder",
@@ -617,6 +662,16 @@ name = "understory_precise_hit"
 version = "0.1.0"
 dependencies = [
  "kurbo",
+]
+
+[[package]]
+name = "understory_presentation"
+version = "0.1.0"
+dependencies = [
+ "hashbrown",
+ "parlance",
+ "peniko",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "understory_focus",
   "understory_inspector",
   "understory_outline",
+  "understory_presentation",
   "understory_precise_hit",
   "understory_property",
   "understory_responder",
@@ -41,6 +42,8 @@ hashbrown = { version = "0.17.0", default-features = false, features = [
   "default-hasher",
 ] }
 invalidation = "0.2.0"
+parlance = { version = "0.1.0", default-features = false }
+peniko = { version = "0.6.1", default-features = false }
 smallvec = { version = "1.13.2", default-features = false }
 
 # Internal crate dependencies are centralized here so path dependencies carry
@@ -54,6 +57,7 @@ understory_guide = { version = "0.1.0", path = "understory_guide", default-featu
 understory_index = { version = "0.0.1", path = "understory_index", default-features = false }
 understory_inspector = { version = "0.1.0", path = "understory_inspector", default-features = false }
 understory_outline = { version = "0.1.0", path = "understory_outline", default-features = false }
+understory_presentation = { version = "0.1.0", path = "understory_presentation", default-features = false }
 understory_precise_hit = { version = "0.1.0", path = "understory_precise_hit", default-features = false }
 understory_property = { version = "0.1.0", path = "understory_property", default-features = false }
 understory_responder = { version = "0.1.0", path = "understory_responder", default-features = false }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Tracks source/target endpoint indexes, dirty binding selection, dependency ordering, and deterministic drain reports.
   - Host code owns property storage and application invalidation policy through the `BindingHost` boundary.
 
+- `understory_presentation`
+  - Retained, resolved drawing primitives keyed by caller-owned geometry ids.
+  - Stores source back-references, template part identities, surface/text primitives, and deduped dirty keys.
+  - Does not own layout, bounds, transforms, style/property resolution, behavior, or renderer command emission.
+
 - `understory_box_tree`
   - A Kurbo‑native, spatially indexed box tree for scene geometry: local bounds, transforms, optional clips, and z‑order.
   - Computes world‑space AABBs and synchronizes them into `understory_index` for fast hit‑testing and visibility.
@@ -91,7 +96,7 @@ We aim for a three‑tree model that scales and composes well.
 
 1) Widget tree — state and interaction
 2) Box tree — geometry and spatial indexing
-3) Render tree — display list (future crate)
+3) Presentation tree — resolved drawing intent
 
 This split makes debugging easier, enables incremental updates, and lets each layer evolve and be swapped independently.
 For example, a canvas or DWG or DXF viewer can reuse the box and index layers without any UI toolkit.
@@ -136,8 +141,10 @@ For example, a canvas or DWG or DXF viewer can reuse the box and index layers wi
   - `understory_transcript/README.md` documents append-order transcript storage, generic payloads, explicit update semantics, typed entry kinds, and chat/tool/process-style usage.
   - `understory_view2d/README.md` documents the 2D and 1D viewport types, clamping/fit modes, and examples of using visible regions for culling.
   - `understory_property_binding/README.md` documents one-way property bindings, host endpoint adapters, and binding-local invalidation.
+  - `understory_presentation/README.md` documents retained resolved drawing primitives, template part identities, and dirty-key draining.
 - Run examples.
   - `cargo run -p understory_examples --example index_basics`
+  - `cargo run -p understory_examples --example basic_present`
   - `cargo run -p understory_examples --example box_tree_basics`
   - `cargo run -p understory_examples --example box_tree_visible_list`
   - `cargo run -p understory_examples --example outline_property_grid`

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,6 +22,7 @@ understory_focus = { workspace = true, features = ["std"] }
 understory_index = { workspace = true, features = ["backend_grid"] }
 understory_inspector = { workspace = true, features = ["std"] }
 understory_outline = { workspace = true, features = ["std"] }
+understory_presentation = { workspace = true, features = ["std"] }
 understory_precise_hit = { workspace = true, features = ["std"] }
 understory_property.workspace = true
 understory_property_binding.workspace = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,10 @@ These examples form a short, progressive walkthrough from routing basics to inte
   - Drive the canonical `understory_property_binding` host loop over `understory_property` source slots: bindings write `TemplateBinding`, user `Local` values mask and reveal those writes, template teardown clears retained bindings, and partial reports still feed app invalidation.
   - Run: `cargo run -p understory_examples --example property_binding_loop`
 
+- basic_present
+  - Build a small `understory_presentation` store, mutate resolved surface/text primitives, drain dirty geometry keys, and show the paint-side lookup shape.
+  - Run: `cargo run -p understory_examples --example basic_present`
+
 - box_tree_basics
   - Build a small scene, commit, move a node, compute damage, and hit-test using `understory_box_tree`.
   - Run: `cargo run -p understory_examples --example box_tree_basics`

--- a/examples/examples/basic_present.rs
+++ b/examples/examples/basic_present.rs
@@ -11,8 +11,8 @@
 //! - `cargo run -p understory_examples --example basic_present`
 
 use understory_presentation::{
-    Border, Brush, Color, FontWeight, PresentationStore, Primitive, RoundedRectRadii, TextAlign,
-    TextContent,
+    Border, Brush, Color, FontWeight, ImagePrimitive, ImageQuality, ImageSlice, Insets, NineSlice,
+    PresentationStore, Primitive, RoundedRectRadii, TextAlign, TextContent,
 };
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -39,7 +39,8 @@ fn main() {
     let button_label = GeometryNode(2);
     let geometry_order = [button_background, button_label];
 
-    let mut presentation: PresentationStore<GeometryNode, Source> = PresentationStore::new();
+    let mut presentation: PresentationStore<GeometryNode, Source, &'static str> =
+        PresentationStore::new();
     presentation.insert(
         button_background,
         Source {
@@ -61,6 +62,13 @@ fn main() {
     surface.set_background(Color::from_rgb8(38, 92, 142));
     surface.border = Border::uniform(Color::from_rgb8(15, 39, 64), 1.0);
     surface.corner_radii = RoundedRectRadii::from_single_radius(6.0);
+
+    let mut image = ImagePrimitive::new("button-background");
+    image.brush.sampler = image.brush.sampler.with_quality(ImageQuality::High);
+    image.slice = ImageSlice::Nine(NineSlice::new(Insets::uniform(8.0)));
+    presentation
+        .set_image(button_background, image)
+        .expect("background part was inserted");
 
     let text = presentation
         .plain_text_mut(button_label)
@@ -93,14 +101,14 @@ fn main() {
     print_paint_walk(&geometry_order, &presentation);
 }
 
-fn print_dirty(presentation: &mut PresentationStore<GeometryNode, Source>) {
+fn print_dirty(presentation: &mut PresentationStore<GeometryNode, Source, &'static str>) {
     let dirty: Vec<_> = presentation.take_dirty().collect();
     println!("dirty keys: {dirty:?}");
 }
 
 fn print_paint_walk(
     geometry_order: &[GeometryNode],
-    presentation: &PresentationStore<GeometryNode, Source>,
+    presentation: &PresentationStore<GeometryNode, Source, &'static str>,
 ) {
     for key in geometry_order {
         let Some(node) = presentation.node(*key) else {
@@ -133,6 +141,10 @@ fn print_paint_walk(
                         text.layout.align
                     );
                 }
+                Primitive::Image(image) => println!(
+                    "  image key={:?} quality={:?} slice={:?}",
+                    image.brush.image, image.brush.sampler.quality, image.slice
+                ),
                 _ => println!("  unknown primitive"),
             }
         }

--- a/examples/examples/basic_present.rs
+++ b/examples/examples/basic_present.rs
@@ -1,0 +1,140 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Build and mutate a tiny presentation store.
+//!
+//! This example keeps geometry out of the picture on purpose. A toolkit would
+//! usually use box-tree node ids as presentation keys and then paint by walking
+//! the box tree in z-order.
+//!
+//! Run:
+//! - `cargo run -p understory_examples --example basic_present`
+
+use understory_presentation::{
+    Border, Brush, Color, FontWeight, PresentationStore, Primitive, RoundedRectRadii, TextAlign,
+    TextContent,
+};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct GeometryNode(u32);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Widget(&'static str);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Role {
+    Background,
+    Content,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Source {
+    widget: Widget,
+    role: Role,
+}
+
+fn main() {
+    let button = Widget("button");
+    let button_background = GeometryNode(1);
+    let button_label = GeometryNode(2);
+    let geometry_order = [button_background, button_label];
+
+    let mut presentation: PresentationStore<GeometryNode, Source> = PresentationStore::new();
+    presentation.insert(
+        button_background,
+        Source {
+            widget: button,
+            role: Role::Background,
+        },
+    );
+    presentation.insert(
+        button_label,
+        Source {
+            widget: button,
+            role: Role::Content,
+        },
+    );
+
+    let surface = presentation
+        .surface_mut(button_background)
+        .expect("background part was inserted");
+    surface.set_background(Color::from_rgb8(38, 92, 142));
+    surface.border = Border::uniform(Color::from_rgb8(15, 39, 64), 1.0);
+    surface.corner_radii = RoundedRectRadii::from_single_radius(6.0);
+
+    let text = presentation
+        .plain_text_mut(button_label)
+        .expect("content part was inserted");
+    text.content = TextContent::plain("Run");
+    text.foreground = Some(Brush::from(Color::WHITE));
+    text.style.font_size = 15.0;
+    text.style.font_weight = FontWeight::MEDIUM;
+    text.layout.align = TextAlign::Center;
+
+    println!("== initial present pass ==");
+    print_dirty(&mut presentation);
+    print_paint_walk(&geometry_order, &presentation);
+
+    let surface = presentation
+        .surface_mut(button_background)
+        .expect("background part was inserted");
+    surface.set_background(Color::from_rgb8(29, 122, 91));
+
+    println!();
+    println!("== property/style change ==");
+    print_dirty(&mut presentation);
+    print_paint_walk(&geometry_order, &presentation);
+
+    presentation.remove(button_label);
+
+    println!();
+    println!("== template teardown ==");
+    print_dirty(&mut presentation);
+    print_paint_walk(&geometry_order, &presentation);
+}
+
+fn print_dirty(presentation: &mut PresentationStore<GeometryNode, Source>) {
+    let dirty: Vec<_> = presentation.take_dirty().collect();
+    println!("dirty keys: {dirty:?}");
+}
+
+fn print_paint_walk(
+    geometry_order: &[GeometryNode],
+    presentation: &PresentationStore<GeometryNode, Source>,
+) {
+    for key in geometry_order {
+        let Some(node) = presentation.node(*key) else {
+            continue;
+        };
+
+        let source = node.source();
+        println!(
+            "paint {:?}: widget={} role={:?}",
+            key, source.widget.0, source.role
+        );
+        for primitive in node.primitives() {
+            match primitive {
+                Primitive::Surface(surface) => println!(
+                    "  surface backgrounds={} border_empty={} radii={:?}",
+                    surface.backgrounds.len(),
+                    surface.border.is_empty(),
+                    surface.corner_radii
+                ),
+                Primitive::Text(text) => {
+                    let Some(text) = text.as_plain() else {
+                        continue;
+                    };
+                    println!(
+                        "  text content={:?} foreground={} font_size={} weight={} align={:?}",
+                        text.content.as_str(),
+                        text.foreground.is_some(),
+                        text.style.font_size,
+                        text.style.font_weight.value(),
+                        text.layout.align
+                    );
+                }
+                _ => println!("  unknown primitive"),
+            }
+        }
+    }
+}

--- a/understory_presentation/Cargo.toml
+++ b/understory_presentation/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "understory_presentation"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Retained resolved drawing primitives for Understory presentation trees"
+readme = "README.md"
+keywords = ["presentation", "render", "ui", "graphics", "no_std"]
+categories = ["data-structures", "graphics", "no-std"]
+
+[dependencies]
+hashbrown.workspace = true
+parlance.workspace = true
+peniko.workspace = true
+smallvec.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["libm"]
+std = ["parlance/std", "peniko/std"]
+libm = ["peniko/libm"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_presentation/README.md
+++ b/understory_presentation/README.md
@@ -1,0 +1,161 @@
+<div align="center">
+
+# Understory Presentation
+
+**Retained resolved drawing primitives for Understory presentation trees**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_presentation.svg)](https://crates.io/crates/understory_presentation)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_presentation.svg)](https://docs.rs/understory_presentation)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/forest-rs/understory/ci.yml?logo=github&label=CI)](https://github.com/forest-rs/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_presentation --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Understory Presentation: retained, resolved drawing intent.
+
+This crate stores the "what to draw" layer that sits between a widget tree
+and paint. A toolkit writes already-resolved drawing primitives into a
+[`PresentationStore`], keyed by its own geometry ids. Paint can then walk the
+geometry tree, look up presentation entries, and lower primitives without
+reading properties or running style cascade resolution.
+
+This crate deliberately does **not** own layout bounds, scene traversal
+order, global transforms/clips, hit testing, style cascade, property
+storage, behavior dispatch, templates, or renderer command emission.
+
+## Fence
+
+This crate owns retained, resolved drawing intent keyed by caller-owned
+geometry ids; it explicitly does not own layout/scene geometry,
+property/style resolution, behavior, or paint command emission.
+
+## Concepts and glossary
+
+- [`PresentationStore`]: flat keyed cache of presentation nodes plus dirty
+  tracking.
+- [`PresentationNode`]: source back-reference and primitive list for one
+  drawable geometry node.
+- [`Primitive`]: resolved drawing primitive stored on a presentation node.
+- [`SurfacePrimitive`]: resolved surface fill/border intent.
+- [`TextPrimitive`]: umbrella for resolved text drawing intent.
+- [`PlainTextPrimitive`]: resolved plain-text content, foreground brush, and
+  `parlance`-based single-run style.
+
+## Model
+
+The store is generic over two ids:
+
+- `NodeKey`: the caller's geometry key, often an `understory_box_tree`
+  node id.
+- `SourceKey`: the caller's widget, element, template part, or diagnostic
+  key, used for back-references.
+
+The presentation store is intentionally flat. It stores no parent/child
+structure and no layout/scene geometry. Structural truth and traversal
+order belong to the caller's geometry tree. Individual primitives may still
+own local drawing geometry, such as future path data.
+
+Mutating store operations mark the affected `NodeKey` dirty. Dirty keys are
+deduplicated and drained in first-dirty order with
+[`PresentationStore::take_dirty`].
+
+## Feature flags
+
+- `default`: enables `libm` so the crate builds as `no_std` by default.
+- `libm`: forwards `peniko/libm` for `no_std` float math.
+- `std`: forwards `peniko/std` and `parlance/std`.
+
+If default features are disabled, callers must enable either `libm` or
+`std`.
+
+```sh
+cargo check -p understory_presentation --no-default-features --features libm
+cargo check -p understory_presentation --no-default-features --features std
+```
+
+## Minimal example
+
+```rust
+use understory_presentation::{
+    Brush, Color, PresentationStore, Primitive, RoundedRectRadii, TextContent,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SourceKey {
+    widget: u32,
+    role: &'static str,
+}
+
+let root = 1_u32;
+let label = 2_u32;
+let source_background = SourceKey { widget: 10, role: "background" };
+let source_content = SourceKey { widget: 10, role: "content" };
+
+let mut store: PresentationStore<u32, SourceKey> = PresentationStore::new();
+store.insert(root, source_background);
+store.insert(label, source_content);
+
+let surface = store.surface_mut(root).unwrap();
+surface.set_background(Color::from_rgb8(38, 92, 142));
+surface.corner_radii = RoundedRectRadii::from_single_radius(6.0);
+
+let text = store.plain_text_mut(label).unwrap();
+text.content = TextContent::plain("Run");
+text.foreground = Some(Brush::from(Color::WHITE));
+
+let dirty: Vec<_> = store.take_dirty().collect();
+assert_eq!(dirty, vec![root, label]);
+
+let label_node = store.node(label).unwrap();
+assert_eq!(label_node.source().role, "content");
+assert!(matches!(label_node.primitives()[0], Primitive::Text(_)));
+```
+
+<!-- cargo-rdme end -->
+
+[`PresentationNode`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.PresentationNode.html
+[`PresentationStore`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.PresentationStore.html
+[`PresentationStore::take_dirty`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.PresentationStore.html#method.take_dirty
+[`PlainTextPrimitive`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.PlainTextPrimitive.html
+[`Primitive`]: https://docs.rs/understory_presentation/latest/understory_presentation/enum.Primitive.html
+[`SurfacePrimitive`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.SurfacePrimitive.html
+[`TextPrimitive`]: https://docs.rs/understory_presentation/latest/understory_presentation/enum.TextPrimitive.html
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>), or
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>),
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+[AUTHORS]: https://github.com/forest-rs/understory/blob/main/AUTHORS
+[LICENSE-APACHE]: https://github.com/forest-rs/understory/blob/main/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/forest-rs/understory/blob/main/LICENSE-MIT
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct

--- a/understory_presentation/README.md
+++ b/understory_presentation/README.md
@@ -50,15 +50,23 @@ property/style resolution, behavior, or paint command emission.
 - [`TextPrimitive`]: umbrella for resolved text drawing intent.
 - [`PlainTextPrimitive`]: resolved plain-text content, foreground brush, and
   `parlance`-based single-run style.
+- [`ImagePrimitive`]: resolved image resource, sampling, fitting, and
+  optional nine-slice intent.
 
 ## Model
 
-The store is generic over two ids:
+The store is generic over three ids:
 
 - `NodeKey`: the caller's geometry key, often an `understory_box_tree`
   node id.
 - `SourceKey`: the caller's widget, element, template part, or diagnostic
   key, used for back-references.
+- `ImageKey`: the caller's image registry key, used by image primitives.
+  Defaults to `u64`.
+
+Use `PresentationStore::<NodeKey, SourceKey>::new()` for default `u64`
+image keys, or `PresentationStore::<NodeKey, SourceKey, ImageKey>::new()`
+when the host uses a custom image registry key type.
 
 The presentation store is intentionally flat. It stores no parent/child
 structure and no layout/scene geometry. Structural truth and traversal
@@ -125,7 +133,9 @@ assert!(matches!(label_node.primitives()[0], Primitive::Text(_)));
 
 [`PresentationNode`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.PresentationNode.html
 [`PresentationStore`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.PresentationStore.html
+[`PresentationStore::new`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.PresentationStore.html#method.new
 [`PresentationStore::take_dirty`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.PresentationStore.html#method.take_dirty
+[`ImagePrimitive`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.ImagePrimitive.html
 [`PlainTextPrimitive`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.PlainTextPrimitive.html
 [`Primitive`]: https://docs.rs/understory_presentation/latest/understory_presentation/enum.Primitive.html
 [`SurfacePrimitive`]: https://docs.rs/understory_presentation/latest/understory_presentation/struct.SurfacePrimitive.html

--- a/understory_presentation/src/lib.rs
+++ b/understory_presentation/src/lib.rs
@@ -33,15 +33,23 @@
 //! - [`TextPrimitive`]: umbrella for resolved text drawing intent.
 //! - [`PlainTextPrimitive`]: resolved plain-text content, foreground brush, and
 //!   `parlance`-based single-run style.
+//! - [`ImagePrimitive`]: resolved image resource, sampling, fitting, and
+//!   optional nine-slice intent.
 //!
 //! ## Model
 //!
-//! The store is generic over two ids:
+//! The store is generic over three ids:
 //!
 //! - `NodeKey`: the caller's geometry key, often an `understory_box_tree`
 //!   node id.
 //! - `SourceKey`: the caller's widget, element, template part, or diagnostic
 //!   key, used for back-references.
+//! - `ImageKey`: the caller's image registry key, used by image primitives.
+//!   Defaults to `u64`.
+//!
+//! Use `PresentationStore::<NodeKey, SourceKey>::new()` for default `u64`
+//! image keys, or `PresentationStore::<NodeKey, SourceKey, ImageKey>::new()`
+//! when the host uses a custom image registry key type.
 //!
 //! The presentation store is intentionally flat. It stores no parent/child
 //! structure and no layout/scene geometry. Structural truth and traversal
@@ -115,10 +123,11 @@ pub use parlance::{
     BaseDirection, FontFamily, FontFamilyName, FontStyle, FontWeight, FontWidth, GenericFamily,
     Language, OverflowWrap, TextWrapMode, WordBreak,
 };
-pub use peniko::kurbo::RoundedRectRadii;
-pub use peniko::{Brush, Color};
+pub use peniko::kurbo::{Insets, RoundedRectRadii};
+pub use peniko::{Brush, Color, ImageBrush, ImageQuality, ImageSampler};
 pub use primitive::{
-    BackgroundLayer, Border, BorderSide, PlainTextPrimitive, Primitive, Shadow, SurfacePrimitive,
-    TextAlign, TextContent, TextLayout, TextLineHeight, TextOverflow, TextPrimitive, TextStyle,
+    BackgroundLayer, Border, BorderSide, ImageFit, ImagePrimitive, ImageSlice, NineSlice,
+    PlainTextPrimitive, Primitive, Shadow, SliceMode, SurfacePrimitive, TextAlign, TextContent,
+    TextLayout, TextLineHeight, TextOverflow, TextPrimitive, TextStyle,
 };
 pub use store::{PresentationNode, PresentationStore};

--- a/understory_presentation/src/lib.rs
+++ b/understory_presentation/src/lib.rs
@@ -1,0 +1,124 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=understory_presentation --heading-base-level=0
+
+//! Understory Presentation: retained, resolved drawing intent.
+//!
+//! This crate stores the "what to draw" layer that sits between a widget tree
+//! and paint. A toolkit writes already-resolved drawing primitives into a
+//! [`PresentationStore`], keyed by its own geometry ids. Paint can then walk the
+//! geometry tree, look up presentation entries, and lower primitives without
+//! reading properties or running style cascade resolution.
+//!
+//! This crate deliberately does **not** own layout bounds, scene traversal
+//! order, global transforms/clips, hit testing, style cascade, property
+//! storage, behavior dispatch, templates, or renderer command emission.
+//!
+//! ## Fence
+//!
+//! This crate owns retained, resolved drawing intent keyed by caller-owned
+//! geometry ids; it explicitly does not own layout/scene geometry,
+//! property/style resolution, behavior, or paint command emission.
+//!
+//! ## Concepts and glossary
+//!
+//! - [`PresentationStore`]: flat keyed cache of presentation nodes plus dirty
+//!   tracking.
+//! - [`PresentationNode`]: source back-reference and primitive list for one
+//!   drawable geometry node.
+//! - [`Primitive`]: resolved drawing primitive stored on a presentation node.
+//! - [`SurfacePrimitive`]: resolved surface fill/border intent.
+//! - [`TextPrimitive`]: umbrella for resolved text drawing intent.
+//! - [`PlainTextPrimitive`]: resolved plain-text content, foreground brush, and
+//!   `parlance`-based single-run style.
+//!
+//! ## Model
+//!
+//! The store is generic over two ids:
+//!
+//! - `NodeKey`: the caller's geometry key, often an `understory_box_tree`
+//!   node id.
+//! - `SourceKey`: the caller's widget, element, template part, or diagnostic
+//!   key, used for back-references.
+//!
+//! The presentation store is intentionally flat. It stores no parent/child
+//! structure and no layout/scene geometry. Structural truth and traversal
+//! order belong to the caller's geometry tree. Individual primitives may still
+//! own local drawing geometry, such as future path data.
+//!
+//! Mutating store operations mark the affected `NodeKey` dirty. Dirty keys are
+//! deduplicated and drained in first-dirty order with
+//! [`PresentationStore::take_dirty`].
+//!
+//! ## Feature flags
+//!
+//! - `default`: enables `libm` so the crate builds as `no_std` by default.
+//! - `libm`: forwards `peniko/libm` for `no_std` float math.
+//! - `std`: forwards `peniko/std` and `parlance/std`.
+//!
+//! If default features are disabled, callers must enable either `libm` or
+//! `std`.
+//!
+//! ```sh
+//! cargo check -p understory_presentation --no-default-features --features libm
+//! cargo check -p understory_presentation --no-default-features --features std
+//! ```
+//!
+//! ## Minimal example
+//!
+//! ```rust
+//! use understory_presentation::{
+//!     Brush, Color, PresentationStore, Primitive, RoundedRectRadii, TextContent,
+//! };
+//!
+//! #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+//! struct SourceKey {
+//!     widget: u32,
+//!     role: &'static str,
+//! }
+//!
+//! let root = 1_u32;
+//! let label = 2_u32;
+//! let source_background = SourceKey { widget: 10, role: "background" };
+//! let source_content = SourceKey { widget: 10, role: "content" };
+//!
+//! let mut store: PresentationStore<u32, SourceKey> = PresentationStore::new();
+//! store.insert(root, source_background);
+//! store.insert(label, source_content);
+//!
+//! let surface = store.surface_mut(root).unwrap();
+//! surface.set_background(Color::from_rgb8(38, 92, 142));
+//! surface.corner_radii = RoundedRectRadii::from_single_radius(6.0);
+//!
+//! let text = store.plain_text_mut(label).unwrap();
+//! text.content = TextContent::plain("Run");
+//! text.foreground = Some(Brush::from(Color::WHITE));
+//!
+//! let dirty: Vec<_> = store.take_dirty().collect();
+//! assert_eq!(dirty, vec![root, label]);
+//!
+//! let label_node = store.node(label).unwrap();
+//! assert_eq!(label_node.source().role, "content");
+//! assert!(matches!(label_node.primitives()[0], Primitive::Text(_)));
+//! ```
+
+#![no_std]
+
+extern crate alloc;
+
+mod primitive;
+mod store;
+
+pub use parlance::{
+    BaseDirection, FontFamily, FontFamilyName, FontStyle, FontWeight, FontWidth, GenericFamily,
+    Language, OverflowWrap, TextWrapMode, WordBreak,
+};
+pub use peniko::kurbo::RoundedRectRadii;
+pub use peniko::{Brush, Color};
+pub use primitive::{
+    BackgroundLayer, Border, BorderSide, PlainTextPrimitive, Primitive, Shadow, SurfacePrimitive,
+    TextAlign, TextContent, TextLayout, TextLineHeight, TextOverflow, TextPrimitive, TextStyle,
+};
+pub use store::{PresentationNode, PresentationStore};

--- a/understory_presentation/src/primitive/image.rs
+++ b/understory_presentation/src/primitive/image.rs
@@ -1,0 +1,137 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use peniko::{ImageBrush, ImageSampler, kurbo::Insets};
+
+/// Resolved image drawing intent.
+///
+/// `ImageKey` is chosen by the host toolkit. Presentation stores image intent,
+/// not decoded image bytes or GPU resources. The lowerer maps this key through
+/// the host's image registry.
+///
+/// Geometry such as the destination bounds lives outside this crate. The image
+/// primitive stores the image resource, sampling hints, fitting behavior, and
+/// optional nine-slice metadata for the lowerer to apply to those bounds.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ImagePrimitive<ImageKey = u64> {
+    /// Image resource and sampling parameters.
+    pub brush: ImageBrush<ImageKey>,
+
+    /// How the image maps into the node bounds.
+    pub fit: ImageFit,
+
+    /// Optional image slicing mode.
+    pub slice: ImageSlice,
+}
+
+impl<ImageKey> ImagePrimitive<ImageKey> {
+    /// Creates an image primitive with default sampling and stretch fitting.
+    #[must_use]
+    pub fn new(image: ImageKey) -> Self {
+        Self {
+            brush: ImageBrush {
+                image,
+                sampler: ImageSampler::default(),
+            },
+            fit: ImageFit::default(),
+            slice: ImageSlice::default(),
+        }
+    }
+}
+
+/// How an image is fitted into destination bounds.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ImageFit {
+    /// Stretch independently in x and y to fill the bounds.
+    #[default]
+    Stretch,
+
+    /// Preserve aspect ratio and fit entirely within the bounds.
+    Contain,
+
+    /// Preserve aspect ratio and cover the bounds, allowing crop.
+    Cover,
+
+    /// Use the image's intrinsic size, positioned by the lowerer.
+    None,
+
+    /// Use intrinsic size unless the image must shrink to fit.
+    ScaleDown,
+}
+
+/// Image slicing mode.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[non_exhaustive]
+pub enum ImageSlice {
+    /// Draw the image as a single fitted rectangle.
+    #[default]
+    None,
+
+    /// Draw the image using nine-slice scaling.
+    Nine(NineSlice),
+}
+
+/// Nine-slice image metadata.
+///
+/// Insets are measured in source image pixels. The lowerer maps the sliced
+/// source regions into the node bounds.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NineSlice {
+    /// Source-image insets that define the nine regions.
+    pub insets: Insets,
+
+    /// Scaling behavior for the edge regions.
+    pub edges: SliceMode,
+
+    /// Scaling behavior for the center region.
+    pub center: SliceMode,
+}
+
+impl NineSlice {
+    /// Creates nine-slice metadata using stretched edges and center.
+    #[must_use]
+    pub const fn new(insets: Insets) -> Self {
+        Self {
+            insets,
+            edges: SliceMode::Stretch,
+            center: SliceMode::Stretch,
+        }
+    }
+}
+
+/// Scaling behavior for a sliced image region.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum SliceMode {
+    /// Stretch the source region to the destination region.
+    #[default]
+    Stretch,
+
+    /// Tile the source region across the destination region.
+    Repeat,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_primitive_defaults_to_stretching_the_image() {
+        let image = ImagePrimitive::new("button-background");
+
+        assert_eq!(image.brush.image, "button-background");
+        assert_eq!(image.brush.sampler, ImageSampler::default());
+        assert_eq!(image.fit, ImageFit::Stretch);
+        assert_eq!(image.slice, ImageSlice::None);
+    }
+
+    #[test]
+    fn nine_slice_defaults_to_stretching_regions() {
+        let slice = NineSlice::new(Insets::uniform(6.0));
+
+        assert_eq!(slice.insets.x0, 6.0);
+        assert_eq!(slice.edges, SliceMode::Stretch);
+        assert_eq!(slice.center, SliceMode::Stretch);
+    }
+}

--- a/understory_presentation/src/primitive/mod.rs
+++ b/understory_presentation/src/primitive/mod.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Presentation primitives.
+
+use alloc::boxed::Box;
+
+mod surface;
+mod text;
+
+pub use surface::{BackgroundLayer, Border, BorderSide, Shadow, SurfacePrimitive};
+pub use text::{
+    PlainTextPrimitive, TextAlign, TextContent, TextLayout, TextLineHeight, TextOverflow,
+    TextPrimitive, TextStyle,
+};
+
+/// Resolved drawing primitive stored on a presentation node.
+///
+/// Primitives are intentionally renderer-agnostic. A toolkit lowerer turns
+/// these values plus geometry-tree bounds into backend-specific drawing
+/// commands during paint.
+///
+/// Variants are boxed to keep [`Primitive`] small and keep the
+/// `SmallVec<[Primitive; 1]>` storage in [`PresentationNode`] predictable. This
+/// intentionally allocates one box per stored primitive.
+///
+/// [`PresentationNode`]: crate::PresentationNode
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Primitive {
+    /// A resolved box-decoration surface.
+    Surface(Box<SurfacePrimitive>),
+
+    /// Resolved text intent.
+    Text(Box<TextPrimitive>),
+}
+
+impl Primitive {
+    /// Creates a surface primitive.
+    #[must_use]
+    pub fn surface(surface: SurfacePrimitive) -> Self {
+        Self::Surface(Box::new(surface))
+    }
+
+    /// Creates a text primitive.
+    #[must_use]
+    pub fn text(text: TextPrimitive) -> Self {
+        Self::Text(Box::new(text))
+    }
+
+    /// Creates a plain text primitive.
+    #[must_use]
+    pub fn plain_text(text: PlainTextPrimitive) -> Self {
+        Self::text(TextPrimitive::plain(text))
+    }
+
+    /// Returns this primitive as a surface primitive, if it is one.
+    #[must_use]
+    pub fn as_surface(&self) -> Option<&SurfacePrimitive> {
+        match self {
+            Self::Surface(surface) => Some(surface.as_ref()),
+            Self::Text(_) => None,
+        }
+    }
+
+    /// Returns this primitive as a mutable surface primitive, if it is one.
+    #[must_use]
+    pub fn as_surface_mut(&mut self) -> Option<&mut SurfacePrimitive> {
+        match self {
+            Self::Surface(surface) => Some(surface.as_mut()),
+            Self::Text(_) => None,
+        }
+    }
+
+    /// Returns this primitive as a text primitive, if it is one.
+    #[must_use]
+    pub fn as_text(&self) -> Option<&TextPrimitive> {
+        match self {
+            Self::Surface(_) => None,
+            Self::Text(text) => Some(text.as_ref()),
+        }
+    }
+
+    /// Returns this primitive as a mutable text primitive, if it is one.
+    #[must_use]
+    pub fn as_text_mut(&mut self) -> Option<&mut TextPrimitive> {
+        match self {
+            Self::Surface(_) => None,
+            Self::Text(text) => Some(text.as_mut()),
+        }
+    }
+}

--- a/understory_presentation/src/primitive/mod.rs
+++ b/understory_presentation/src/primitive/mod.rs
@@ -5,9 +5,11 @@
 
 use alloc::boxed::Box;
 
+mod image;
 mod surface;
 mod text;
 
+pub use image::{ImageFit, ImagePrimitive, ImageSlice, NineSlice, SliceMode};
 pub use surface::{BackgroundLayer, Border, BorderSide, Shadow, SurfacePrimitive};
 pub use text::{
     PlainTextPrimitive, TextAlign, TextContent, TextLayout, TextLineHeight, TextOverflow,
@@ -27,15 +29,18 @@ pub use text::{
 /// [`PresentationNode`]: crate::PresentationNode
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
-pub enum Primitive {
+pub enum Primitive<ImageKey = u64> {
     /// A resolved box-decoration surface.
     Surface(Box<SurfacePrimitive>),
 
     /// Resolved text intent.
     Text(Box<TextPrimitive>),
+
+    /// Resolved image intent.
+    Image(Box<ImagePrimitive<ImageKey>>),
 }
 
-impl Primitive {
+impl<ImageKey> Primitive<ImageKey> {
     /// Creates a surface primitive.
     #[must_use]
     pub fn surface(surface: SurfacePrimitive) -> Self {
@@ -54,12 +59,18 @@ impl Primitive {
         Self::text(TextPrimitive::plain(text))
     }
 
+    /// Creates an image primitive.
+    #[must_use]
+    pub fn image(image: ImagePrimitive<ImageKey>) -> Self {
+        Self::Image(Box::new(image))
+    }
+
     /// Returns this primitive as a surface primitive, if it is one.
     #[must_use]
     pub fn as_surface(&self) -> Option<&SurfacePrimitive> {
         match self {
             Self::Surface(surface) => Some(surface.as_ref()),
-            Self::Text(_) => None,
+            Self::Text(_) | Self::Image(_) => None,
         }
     }
 
@@ -68,7 +79,7 @@ impl Primitive {
     pub fn as_surface_mut(&mut self) -> Option<&mut SurfacePrimitive> {
         match self {
             Self::Surface(surface) => Some(surface.as_mut()),
-            Self::Text(_) => None,
+            Self::Text(_) | Self::Image(_) => None,
         }
     }
 
@@ -76,7 +87,7 @@ impl Primitive {
     #[must_use]
     pub fn as_text(&self) -> Option<&TextPrimitive> {
         match self {
-            Self::Surface(_) => None,
+            Self::Surface(_) | Self::Image(_) => None,
             Self::Text(text) => Some(text.as_ref()),
         }
     }
@@ -85,8 +96,26 @@ impl Primitive {
     #[must_use]
     pub fn as_text_mut(&mut self) -> Option<&mut TextPrimitive> {
         match self {
-            Self::Surface(_) => None,
+            Self::Surface(_) | Self::Image(_) => None,
             Self::Text(text) => Some(text.as_mut()),
+        }
+    }
+
+    /// Returns this primitive as an image primitive, if it is one.
+    #[must_use]
+    pub fn as_image(&self) -> Option<&ImagePrimitive<ImageKey>> {
+        match self {
+            Self::Surface(_) | Self::Text(_) => None,
+            Self::Image(image) => Some(image.as_ref()),
+        }
+    }
+
+    /// Returns this primitive as a mutable image primitive, if it is one.
+    #[must_use]
+    pub fn as_image_mut(&mut self) -> Option<&mut ImagePrimitive<ImageKey>> {
+        match self {
+            Self::Surface(_) | Self::Text(_) => None,
+            Self::Image(image) => Some(image.as_mut()),
         }
     }
 }

--- a/understory_presentation/src/primitive/surface.rs
+++ b/understory_presentation/src/primitive/surface.rs
@@ -1,0 +1,201 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use smallvec::SmallVec;
+
+use crate::{Brush, Color};
+use peniko::kurbo::RoundedRectRadii;
+
+/// Resolved box-decoration drawing intent.
+///
+/// Geometry such as bounds and transforms lives outside this crate. Surface
+/// backgrounds, borders, corner radii, and shadows are resolved inputs that a
+/// toolkit lowerer applies to the node's final geometry.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SurfacePrimitive {
+    /// Background layers, painted in list order.
+    pub backgrounds: SmallVec<[BackgroundLayer; 1]>,
+
+    /// Per-side border model.
+    pub border: Border,
+
+    /// Per-corner radii in logical pixels.
+    pub corner_radii: RoundedRectRadii,
+
+    /// Outer shadows, painted in list order.
+    pub shadows: SmallVec<[Shadow; 1]>,
+}
+
+impl SurfacePrimitive {
+    /// Replaces the surface with a single background brush.
+    pub fn set_background(&mut self, brush: impl Into<Brush>) {
+        self.backgrounds.clear();
+        self.backgrounds.push(BackgroundLayer::new(brush));
+    }
+
+    /// Returns true when the surface has no visible decoration.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.backgrounds.is_empty() && self.border.is_empty() && self.shadows.is_empty()
+    }
+}
+
+/// A single resolved background layer.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BackgroundLayer {
+    /// Brush used to fill the node's local bounds.
+    pub brush: Brush,
+}
+
+impl BackgroundLayer {
+    /// Creates a background layer from a brush.
+    #[must_use]
+    pub fn new(brush: impl Into<Brush>) -> Self {
+        Self {
+            brush: brush.into(),
+        }
+    }
+}
+
+/// Per-side border model.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Border {
+    /// Top border side.
+    pub top: BorderSide,
+
+    /// Right border side.
+    pub right: BorderSide,
+
+    /// Bottom border side.
+    pub bottom: BorderSide,
+
+    /// Left border side.
+    pub left: BorderSide,
+}
+
+impl Border {
+    /// Creates the same border side on all four edges.
+    #[must_use]
+    pub fn uniform(brush: impl Into<Brush>, width: f64) -> Self {
+        let side = BorderSide::new(brush, width);
+        Self {
+            top: side.clone(),
+            right: side.clone(),
+            bottom: side.clone(),
+            left: side,
+        }
+    }
+
+    /// Returns true when every side is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.top.is_empty()
+            && self.right.is_empty()
+            && self.bottom.is_empty()
+            && self.left.is_empty()
+    }
+}
+
+/// One side of a border.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BorderSide {
+    /// Border brush.
+    pub brush: Option<Brush>,
+
+    /// Border width in logical pixels.
+    pub width: f64,
+}
+
+impl BorderSide {
+    /// Creates a border side.
+    #[must_use]
+    pub fn new(brush: impl Into<Brush>, width: f64) -> Self {
+        Self {
+            brush: Some(brush.into()),
+            width,
+        }
+    }
+
+    /// Returns true when the side should not draw.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.brush.is_none() || self.width <= 0.0
+    }
+}
+
+/// Resolved outer shadow intent for a surface.
+///
+/// The lowerer applies the shadow to the node's final geometry. This keeps
+/// shadow spread and blur bounds-dependent without making presentation own
+/// geometry.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Shadow {
+    /// Shadow color.
+    pub color: Color,
+
+    /// Horizontal offset in logical pixels.
+    pub offset_x: f64,
+
+    /// Vertical offset in logical pixels.
+    pub offset_y: f64,
+
+    /// Blur radius in logical pixels.
+    pub blur_radius: f64,
+
+    /// Spread distance in logical pixels.
+    pub spread: f64,
+}
+
+impl Shadow {
+    /// Creates an outer shadow.
+    #[must_use]
+    pub fn new(color: Color, offset_x: f64, offset_y: f64, blur_radius: f64) -> Self {
+        Self {
+            color,
+            offset_x,
+            offset_y,
+            blur_radius,
+            spread: 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_background_replaces_existing_layers() {
+        let mut surface = SurfacePrimitive::default();
+        surface.set_background(Color::from_rgb8(10, 20, 30));
+        surface.set_background(Color::from_rgb8(40, 50, 60));
+
+        assert_eq!(surface.backgrounds.len(), 1);
+        assert_eq!(
+            surface.backgrounds[0].brush,
+            Brush::from(Color::from_rgb8(40, 50, 60))
+        );
+    }
+
+    #[test]
+    fn uniform_border_sets_each_side() {
+        let border = Border::uniform(Color::from_rgb8(10, 20, 30), 2.0);
+        let expected = BorderSide::new(Color::from_rgb8(10, 20, 30), 2.0);
+
+        assert_eq!(border.top, expected);
+        assert_eq!(border.right, expected);
+        assert_eq!(border.bottom, expected);
+        assert_eq!(border.left, expected);
+        assert!(!border.is_empty());
+    }
+
+    #[test]
+    fn corner_radii_alone_do_not_make_surface_visible() {
+        let surface = SurfacePrimitive {
+            corner_radii: RoundedRectRadii::from_single_radius(8.0),
+            ..SurfacePrimitive::default()
+        };
+
+        assert!(surface.is_empty());
+    }
+}

--- a/understory_presentation/src/primitive/text.rs
+++ b/understory_presentation/src/primitive/text.rs
@@ -1,0 +1,289 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::string::{String, ToString};
+
+use parlance::{
+    BaseDirection, FontFamily, FontStyle, FontWeight, FontWidth, GenericFamily, Language,
+    OverflowWrap, TextWrapMode, WordBreak,
+};
+
+use crate::Brush;
+
+/// Resolved text drawing intent.
+///
+/// This is an umbrella over concrete text payloads. Today the presentation
+/// crate only provides [`PlainTextPrimitive`]; styled text can be added as a
+/// sibling variant without changing the outer [`crate::Primitive::Text`] role.
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TextPrimitive {
+    /// Plain single-run text.
+    Plain(PlainTextPrimitive),
+}
+
+impl TextPrimitive {
+    /// Creates a plain text primitive.
+    #[must_use]
+    pub const fn plain(text: PlainTextPrimitive) -> Self {
+        Self::Plain(text)
+    }
+
+    /// Returns this text primitive as plain text, if it is plain text.
+    #[must_use]
+    pub const fn as_plain(&self) -> Option<&PlainTextPrimitive> {
+        match self {
+            Self::Plain(text) => Some(text),
+        }
+    }
+
+    /// Returns this text primitive as mutable plain text, if it is plain text.
+    #[must_use]
+    pub const fn as_plain_mut(&mut self) -> Option<&mut PlainTextPrimitive> {
+        match self {
+            Self::Plain(text) => Some(text),
+        }
+    }
+}
+
+impl Default for TextPrimitive {
+    fn default() -> Self {
+        Self::Plain(PlainTextPrimitive::default())
+    }
+}
+
+/// Resolved plain text drawing intent.
+///
+/// Text shaping is intentionally not stored here. Shaping usually depends on
+/// geometry, so a toolkit lowerer should shape text while lowering this
+/// primitive using bounds from its geometry tree.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PlainTextPrimitive {
+    /// Text content to draw.
+    pub content: TextContent,
+
+    /// Optional foreground brush.
+    pub foreground: Option<Brush>,
+
+    /// Resolved single-run font and typographic inputs.
+    pub style: TextStyle,
+
+    /// Resolved layout hints for shaping and painting within the node bounds.
+    pub layout: TextLayout,
+}
+
+/// Owned text content stored by a text primitive.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum TextContent {
+    /// No text content.
+    #[default]
+    Empty,
+
+    /// Plain UTF-8 text.
+    Plain(String),
+}
+
+impl TextContent {
+    /// Creates plain text content.
+    #[must_use]
+    pub fn plain(text: impl AsRef<str>) -> Self {
+        Self::Plain(text.as_ref().to_string())
+    }
+
+    /// Returns true when the content is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Empty => true,
+            Self::Plain(text) => text.is_empty(),
+        }
+    }
+
+    /// Returns the content as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Empty => "",
+            Self::Plain(text) => text.as_str(),
+        }
+    }
+}
+
+impl From<&str> for TextContent {
+    fn from(value: &str) -> Self {
+        Self::plain(value)
+    }
+}
+
+impl From<String> for TextContent {
+    fn from(value: String) -> Self {
+        Self::Plain(value)
+    }
+}
+
+/// Resolved single-run font and typographic inputs.
+///
+/// This uses `parlance` for font and CSS text leaf types so presentation does
+/// not define a parallel text vocabulary.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TextStyle {
+    /// Preferred font family list.
+    pub font_family: FontFamily<'static>,
+
+    /// Font size in logical pixels.
+    pub font_size: f32,
+
+    /// Font width.
+    pub font_width: FontWidth,
+
+    /// Font weight.
+    pub font_weight: FontWeight,
+
+    /// Font style.
+    pub font_style: FontStyle,
+
+    /// Optional content language.
+    pub language: Option<Language>,
+
+    /// Line height policy.
+    pub line_height: TextLineHeight,
+
+    /// Extra letter spacing in logical pixels.
+    pub letter_spacing: f32,
+
+    /// Extra word spacing in logical pixels.
+    pub word_spacing: f32,
+
+    /// Control over where words can break.
+    pub word_break: WordBreak,
+
+    /// Control over emergency line breaking.
+    pub overflow_wrap: OverflowWrap,
+
+    /// Control over non-emergency line breaking.
+    pub text_wrap_mode: TextWrapMode,
+}
+
+impl Default for TextStyle {
+    fn default() -> Self {
+        Self {
+            font_family: FontFamily::from(GenericFamily::SystemUi),
+            font_size: 14.0,
+            font_width: FontWidth::NORMAL,
+            font_weight: FontWeight::NORMAL,
+            font_style: FontStyle::Normal,
+            language: None,
+            line_height: TextLineHeight::default(),
+            letter_spacing: 0.0,
+            word_spacing: 0.0,
+            word_break: WordBreak::Normal,
+            overflow_wrap: OverflowWrap::Normal,
+            text_wrap_mode: TextWrapMode::NoWrap,
+        }
+    }
+}
+
+/// Line height policy for text layout.
+///
+/// `parlance` does not currently define a line-height type, so presentation
+/// keeps this local and intentionally mirrors the variants a Parley lowerer can
+/// map directly.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TextLineHeight {
+    /// Scale the font's preferred metrics line height.
+    MetricsRelative(f32),
+
+    /// Scale the font size.
+    FontSizeRelative(f32),
+
+    /// Absolute line height in logical pixels.
+    Absolute(f32),
+}
+
+impl Default for TextLineHeight {
+    fn default() -> Self {
+        Self::MetricsRelative(1.0)
+    }
+}
+
+/// Resolved text layout hints.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TextLayout {
+    /// Horizontal alignment within the node bounds.
+    pub align: TextAlign,
+
+    /// Overflow behavior.
+    pub overflow: TextOverflow,
+
+    /// Optional maximum number of lines.
+    pub max_lines: Option<u16>,
+
+    /// Paragraph base direction.
+    pub base_direction: BaseDirection,
+}
+
+impl Default for TextLayout {
+    fn default() -> Self {
+        Self {
+            align: TextAlign::Start,
+            overflow: TextOverflow::Clip,
+            max_lines: None,
+            base_direction: BaseDirection::Auto,
+        }
+    }
+}
+
+/// Horizontal text alignment.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TextAlign {
+    /// Align to the start edge of the inline direction.
+    #[default]
+    Start,
+
+    /// Center within the line box.
+    Center,
+
+    /// Align to the end edge of the inline direction.
+    End,
+}
+
+/// Text overflow behavior.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TextOverflow {
+    /// Clip overflow.
+    #[default]
+    Clip,
+
+    /// Request ellipsis when the lowerer supports it.
+    Ellipsis,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_content_exposes_str() {
+        let content = TextContent::plain("Apply");
+
+        assert!(!content.is_empty());
+        assert_eq!(content.as_str(), "Apply");
+    }
+
+    #[test]
+    fn text_defaults_are_calm() {
+        let text = PlainTextPrimitive::default();
+
+        assert!(text.content.is_empty());
+        assert_eq!(text.style.font_size, 14.0);
+        assert_eq!(
+            text.style.font_family,
+            FontFamily::from(GenericFamily::SystemUi)
+        );
+        assert_eq!(text.style.font_width, FontWidth::NORMAL);
+        assert_eq!(text.style.font_weight, FontWeight::NORMAL);
+        assert_eq!(text.style.text_wrap_mode, TextWrapMode::NoWrap);
+        assert_eq!(text.layout.align, TextAlign::Start);
+        assert_eq!(text.layout.base_direction, BaseDirection::Auto);
+    }
+}

--- a/understory_presentation/src/store.rs
+++ b/understory_presentation/src/store.rs
@@ -7,19 +7,19 @@ use core::hash::Hash;
 use hashbrown::{HashMap, HashSet};
 use smallvec::SmallVec;
 
-use crate::{PlainTextPrimitive, Primitive, SurfacePrimitive, TextPrimitive};
+use crate::{ImagePrimitive, PlainTextPrimitive, Primitive, SurfacePrimitive, TextPrimitive};
 
 /// Retained presentation data for one geometry node.
 ///
 /// `SourceKey` is chosen by the host, typically a widget or element id used for
 /// diagnostics and template back-references.
 #[derive(Clone, Debug, PartialEq)]
-pub struct PresentationNode<SourceKey> {
+pub struct PresentationNode<SourceKey, ImageKey = u64> {
     source: SourceKey,
-    primitives: SmallVec<[Primitive; 1]>,
+    primitives: SmallVec<[Primitive<ImageKey>; 1]>,
 }
 
-impl<SourceKey> PresentationNode<SourceKey> {
+impl<SourceKey, ImageKey> PresentationNode<SourceKey, ImageKey> {
     /// Creates an empty presentation node for `source`.
     #[must_use]
     pub const fn new(source: SourceKey) -> Self {
@@ -48,13 +48,13 @@ impl<SourceKey> PresentationNode<SourceKey> {
 
     /// Returns the resolved primitives stored on this node.
     #[must_use]
-    pub fn primitives(&self) -> &[Primitive] {
+    pub fn primitives(&self) -> &[Primitive<ImageKey>] {
         &self.primitives
     }
 
     /// Returns mutable access to the resolved primitive list.
     #[must_use]
-    pub fn primitives_mut(&mut self) -> &mut SmallVec<[Primitive; 1]> {
+    pub fn primitives_mut(&mut self) -> &mut SmallVec<[Primitive<ImageKey>; 1]> {
         &mut self.primitives
     }
 
@@ -129,7 +129,7 @@ impl<SourceKey> PresentationNode<SourceKey> {
             .iter()
             .position(|primitive| match primitive {
                 Primitive::Text(text) => text.as_plain().is_some(),
-                Primitive::Surface(_) => false,
+                Primitive::Surface(_) | Primitive::Image(_) => false,
             })
             .unwrap_or_else(|| {
                 self.primitives
@@ -143,6 +143,39 @@ impl<SourceKey> PresentationNode<SourceKey> {
         text.as_plain_mut()
             .expect("plain text index points at a plain text primitive")
     }
+
+    /// Returns the first image primitive, if present.
+    #[must_use]
+    pub fn image(&self) -> Option<&ImagePrimitive<ImageKey>> {
+        self.primitives.iter().find_map(Primitive::as_image)
+    }
+
+    /// Returns mutable access to the first image primitive, if present.
+    #[must_use]
+    pub fn image_mut(&mut self) -> Option<&mut ImagePrimitive<ImageKey>> {
+        self.primitives.iter_mut().find_map(Primitive::as_image_mut)
+    }
+
+    /// Replaces the first image primitive or appends one when none exists.
+    pub fn set_image(&mut self, image: ImagePrimitive<ImageKey>) -> &mut ImagePrimitive<ImageKey> {
+        if let Some(index) = self
+            .primitives
+            .iter()
+            .position(|primitive| matches!(primitive, Primitive::Image(_)))
+        {
+            let Primitive::Image(existing) = &mut self.primitives[index] else {
+                unreachable!("image index points at an image primitive");
+            };
+            **existing = image;
+            existing.as_mut()
+        } else {
+            self.primitives.push(Primitive::image(image));
+            let Some(Primitive::Image(inserted)) = self.primitives.last_mut() else {
+                unreachable!("last inserted primitive is an image");
+            };
+            inserted.as_mut()
+        }
+    }
 }
 
 /// Flat keyed store of retained presentation nodes.
@@ -152,35 +185,39 @@ impl<SourceKey> PresentationNode<SourceKey> {
 /// geometry; callers paint by walking their own geometry tree and looking up
 /// nodes here. Individual primitives may still own local drawing geometry.
 #[derive(Clone, Debug)]
-pub struct PresentationStore<NodeKey, SourceKey> {
-    nodes: HashMap<NodeKey, PresentationNode<SourceKey>>,
+pub struct PresentationStore<NodeKey, SourceKey, ImageKey = u64> {
+    nodes: HashMap<NodeKey, PresentationNode<SourceKey, ImageKey>>,
     order: Vec<NodeKey>,
     dirty: Vec<NodeKey>,
     dirty_set: HashSet<NodeKey>,
 }
 
-impl<NodeKey, SourceKey> Default for PresentationStore<NodeKey, SourceKey>
+impl<NodeKey, SourceKey, ImageKey> Default for PresentationStore<NodeKey, SourceKey, ImageKey>
 where
     NodeKey: Copy + Eq + Hash,
 {
     fn default() -> Self {
-        Self::new()
+        Self::empty()
     }
 }
 
-impl<NodeKey, SourceKey> PresentationStore<NodeKey, SourceKey>
+impl<NodeKey, SourceKey, ImageKey> PresentationStore<NodeKey, SourceKey, ImageKey>
 where
     NodeKey: Copy + Eq + Hash,
 {
-    /// Creates an empty presentation store.
-    #[must_use]
-    pub fn new() -> Self {
+    fn empty() -> Self {
         Self {
             nodes: HashMap::new(),
             order: Vec::new(),
             dirty: Vec::new(),
             dirty_set: HashSet::new(),
         }
+    }
+
+    /// Creates an empty presentation store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::empty()
     }
 
     /// Returns the number of live presentation nodes.
@@ -208,7 +245,7 @@ where
         &mut self,
         key: NodeKey,
         source: SourceKey,
-    ) -> Option<PresentationNode<SourceKey>> {
+    ) -> Option<PresentationNode<SourceKey, ImageKey>> {
         let old = self.nodes.insert(key, PresentationNode::new(source));
         if old.is_none() {
             self.order.push(key);
@@ -218,7 +255,7 @@ where
     }
 
     /// Removes a presentation node, marking `key` dirty if it was live.
-    pub fn remove(&mut self, key: NodeKey) -> Option<PresentationNode<SourceKey>> {
+    pub fn remove(&mut self, key: NodeKey) -> Option<PresentationNode<SourceKey, ImageKey>> {
         let old = self.nodes.remove(&key)?;
         self.order.retain(|ordered| *ordered != key);
         self.mark_dirty(key);
@@ -236,12 +273,12 @@ where
 
     /// Returns a presentation node by key.
     #[must_use]
-    pub fn node(&self, key: NodeKey) -> Option<&PresentationNode<SourceKey>> {
+    pub fn node(&self, key: NodeKey) -> Option<&PresentationNode<SourceKey, ImageKey>> {
         self.nodes.get(&key)
     }
 
     /// Returns a mutable presentation node by key and marks it dirty.
-    pub fn node_mut(&mut self, key: NodeKey) -> Option<&mut PresentationNode<SourceKey>> {
+    pub fn node_mut(&mut self, key: NodeKey) -> Option<&mut PresentationNode<SourceKey, ImageKey>> {
         if self.nodes.contains_key(&key) {
             self.mark_dirty(key);
         }
@@ -269,6 +306,35 @@ where
         self.node_mut(key).map(PresentationNode::plain_text_mut)
     }
 
+    /// Returns the first image primitive on a node.
+    ///
+    /// Returns `None` when `key` does not identify a live presentation node or
+    /// when the node has no image primitive.
+    pub fn image_mut(&mut self, key: NodeKey) -> Option<&mut ImagePrimitive<ImageKey>> {
+        if self
+            .nodes
+            .get(&key)
+            .and_then(PresentationNode::image)
+            .is_some()
+        {
+            self.mark_dirty(key);
+        }
+        self.nodes
+            .get_mut(&key)
+            .and_then(PresentationNode::image_mut)
+    }
+
+    /// Replaces or appends the first image primitive on a node.
+    ///
+    /// Returns `None` when `key` does not identify a live presentation node.
+    pub fn set_image(
+        &mut self,
+        key: NodeKey,
+        image: ImagePrimitive<ImageKey>,
+    ) -> Option<&mut ImagePrimitive<ImageKey>> {
+        self.node_mut(key).map(|node| node.set_image(image))
+    }
+
     /// Returns live keys in insertion order.
     ///
     /// This order is useful for diagnostics and listing. It is not paint order:
@@ -283,7 +349,9 @@ where
     /// This order is useful for diagnostics and listing. It is not paint order:
     /// callers should walk their own geometry tree and use [`Self::node`] to
     /// look up presentation data for each geometry key.
-    pub fn nodes(&self) -> impl Iterator<Item = (NodeKey, &PresentationNode<SourceKey>)> + '_ {
+    pub fn nodes(
+        &self,
+    ) -> impl Iterator<Item = (NodeKey, &PresentationNode<SourceKey, ImageKey>)> + '_ {
         self.order
             .iter()
             .copied()
@@ -341,9 +409,11 @@ mod tests {
     use super::*;
     use crate::{Color, RoundedRectRadii, TextContent};
 
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct Asset(&'static str);
     #[test]
     fn insert_tracks_nodes_and_dirty_order() {
-        let mut store = PresentationStore::new();
+        let mut store: PresentationStore<i32, i32> = PresentationStore::new();
 
         assert_eq!(store.insert(1, 10), None);
         assert_eq!(store.insert(2, 10), None);
@@ -356,7 +426,7 @@ mod tests {
 
     #[test]
     fn replacing_node_preserves_order_and_returns_old_node() {
-        let mut store = PresentationStore::new();
+        let mut store: PresentationStore<i32, i32> = PresentationStore::new();
         store.insert(1, 10);
         store.insert(2, 10);
         store.clear_dirty();
@@ -371,7 +441,7 @@ mod tests {
 
     #[test]
     fn surface_mut_creates_surface_and_dedupes_dirty() {
-        let mut store = PresentationStore::new();
+        let mut store: PresentationStore<i32, i32> = PresentationStore::new();
         store.insert(1, 10);
         store.clear_dirty();
 
@@ -387,7 +457,7 @@ mod tests {
 
     #[test]
     fn plain_text_mut_creates_plain_text() {
-        let mut store = PresentationStore::new();
+        let mut store: PresentationStore<i32, i32> = PresentationStore::new();
         store.insert(1, 10);
         store.clear_dirty();
 
@@ -408,18 +478,60 @@ mod tests {
     }
 
     #[test]
+    fn set_image_uses_host_image_key_type() {
+        let mut store = PresentationStore::<u32, u32, Asset>::new();
+        store.insert(1, 10);
+        store.clear_dirty();
+
+        let image = store
+            .set_image(1, ImagePrimitive::new(Asset("button-background")))
+            .unwrap();
+
+        assert_eq!(image.brush.image, Asset("button-background"));
+        assert_eq!(
+            store.node(1).unwrap().image().unwrap().brush.image,
+            Asset("button-background")
+        );
+        assert_eq!(store.take_dirty().collect::<Vec<_>>(), vec![1]);
+    }
+
+    #[test]
+    fn set_image_replaces_existing_image() {
+        let mut store: PresentationStore<i32, i32> = PresentationStore::new();
+        store.insert(1, 10);
+
+        store.set_image(1, ImagePrimitive::new(42));
+        store.set_image(1, ImagePrimitive::new(43));
+
+        let node = store.node(1).unwrap();
+        assert_eq!(node.primitives().len(), 1);
+        assert_eq!(node.image().unwrap().brush.image, 43);
+    }
+
+    #[test]
+    fn image_mut_does_not_create_default_image() {
+        let mut store: PresentationStore<i32, i32> = PresentationStore::new();
+        store.insert(1, 10);
+        store.clear_dirty();
+
+        assert!(store.image_mut(1).is_none());
+        assert!(store.dirty_is_empty());
+    }
+
+    #[test]
     fn missing_primitive_helpers_return_none_without_dirty() {
         let mut store: PresentationStore<u32, u32> = PresentationStore::new();
 
         assert!(store.surface_mut(99).is_none());
         assert!(store.text_mut(99).is_none());
         assert!(store.plain_text_mut(99).is_none());
+        assert!(store.image_mut(99).is_none());
         assert!(store.dirty_is_empty());
     }
 
     #[test]
     fn remove_marks_existing_key_dirty() {
-        let mut store = PresentationStore::new();
+        let mut store: PresentationStore<i32, i32> = PresentationStore::new();
         store.insert(1, 10);
         store.insert(2, 10);
         store.clear_dirty();
@@ -432,7 +544,7 @@ mod tests {
 
     #[test]
     fn clear_marks_live_keys_dirty_in_insertion_order() {
-        let mut store = PresentationStore::new();
+        let mut store: PresentationStore<i32, i32> = PresentationStore::new();
         store.insert(1, 10);
         store.insert(2, 10);
         store.clear_dirty();

--- a/understory_presentation/src/store.rs
+++ b/understory_presentation/src/store.rs
@@ -1,0 +1,445 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec::Vec;
+use core::hash::Hash;
+
+use hashbrown::{HashMap, HashSet};
+use smallvec::SmallVec;
+
+use crate::{PlainTextPrimitive, Primitive, SurfacePrimitive, TextPrimitive};
+
+/// Retained presentation data for one geometry node.
+///
+/// `SourceKey` is chosen by the host, typically a widget or element id used for
+/// diagnostics and template back-references.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PresentationNode<SourceKey> {
+    source: SourceKey,
+    primitives: SmallVec<[Primitive; 1]>,
+}
+
+impl<SourceKey> PresentationNode<SourceKey> {
+    /// Creates an empty presentation node for `source`.
+    #[must_use]
+    pub const fn new(source: SourceKey) -> Self {
+        Self {
+            source,
+            primitives: SmallVec::new_const(),
+        }
+    }
+
+    /// Returns the source widget or element key.
+    #[must_use]
+    pub const fn source(&self) -> &SourceKey {
+        &self.source
+    }
+
+    /// Returns a mutable reference to the source widget or element key.
+    #[must_use]
+    pub const fn source_mut(&mut self) -> &mut SourceKey {
+        &mut self.source
+    }
+
+    /// Replaces the source widget or element key.
+    pub fn set_source(&mut self, source: SourceKey) {
+        self.source = source;
+    }
+
+    /// Returns the resolved primitives stored on this node.
+    #[must_use]
+    pub fn primitives(&self) -> &[Primitive] {
+        &self.primitives
+    }
+
+    /// Returns mutable access to the resolved primitive list.
+    #[must_use]
+    pub fn primitives_mut(&mut self) -> &mut SmallVec<[Primitive; 1]> {
+        &mut self.primitives
+    }
+
+    /// Clears all primitives from this node.
+    pub fn clear_primitives(&mut self) {
+        self.primitives.clear();
+    }
+
+    /// Returns the first surface primitive, if present.
+    #[must_use]
+    pub fn surface(&self) -> Option<&SurfacePrimitive> {
+        self.primitives.iter().find_map(Primitive::as_surface)
+    }
+
+    /// Returns the first surface primitive, creating a default one if needed.
+    #[must_use]
+    pub fn surface_mut(&mut self) -> &mut SurfacePrimitive {
+        let index = self
+            .primitives
+            .iter()
+            .position(|primitive| matches!(primitive, Primitive::Surface(_)))
+            .unwrap_or_else(|| {
+                self.primitives
+                    .push(Primitive::surface(SurfacePrimitive::default()));
+                self.primitives.len() - 1
+            });
+
+        let Primitive::Surface(surface) = &mut self.primitives[index] else {
+            unreachable!("surface index points at a surface primitive");
+        };
+        surface.as_mut()
+    }
+
+    /// Returns the first text primitive, if present.
+    #[must_use]
+    pub fn text(&self) -> Option<&TextPrimitive> {
+        self.primitives.iter().find_map(Primitive::as_text)
+    }
+
+    /// Returns the first text primitive, creating plain text if needed.
+    #[must_use]
+    pub fn text_mut(&mut self) -> &mut TextPrimitive {
+        let index = self
+            .primitives
+            .iter()
+            .position(|primitive| matches!(primitive, Primitive::Text(_)))
+            .unwrap_or_else(|| {
+                self.primitives
+                    .push(Primitive::text(TextPrimitive::default()));
+                self.primitives.len() - 1
+            });
+
+        let Primitive::Text(text) = &mut self.primitives[index] else {
+            unreachable!("text index points at a text primitive");
+        };
+        text.as_mut()
+    }
+
+    /// Returns the first plain text primitive, if present.
+    #[must_use]
+    pub fn plain_text(&self) -> Option<&PlainTextPrimitive> {
+        self.primitives
+            .iter()
+            .find_map(|primitive| primitive.as_text().and_then(TextPrimitive::as_plain))
+    }
+
+    /// Returns the first plain text primitive, creating one if needed.
+    #[must_use]
+    pub fn plain_text_mut(&mut self) -> &mut PlainTextPrimitive {
+        let index = self
+            .primitives
+            .iter()
+            .position(|primitive| match primitive {
+                Primitive::Text(text) => text.as_plain().is_some(),
+                Primitive::Surface(_) => false,
+            })
+            .unwrap_or_else(|| {
+                self.primitives
+                    .push(Primitive::plain_text(PlainTextPrimitive::default()));
+                self.primitives.len() - 1
+            });
+
+        let Primitive::Text(text) = &mut self.primitives[index] else {
+            unreachable!("text index points at a text primitive");
+        };
+        text.as_plain_mut()
+            .expect("plain text index points at a plain text primitive")
+    }
+}
+
+/// Flat keyed store of retained presentation nodes.
+///
+/// `NodeKey` is chosen by the host, typically a geometry key such as a
+/// box-tree node id. This store owns no tree structure or layout/scene
+/// geometry; callers paint by walking their own geometry tree and looking up
+/// nodes here. Individual primitives may still own local drawing geometry.
+#[derive(Clone, Debug)]
+pub struct PresentationStore<NodeKey, SourceKey> {
+    nodes: HashMap<NodeKey, PresentationNode<SourceKey>>,
+    order: Vec<NodeKey>,
+    dirty: Vec<NodeKey>,
+    dirty_set: HashSet<NodeKey>,
+}
+
+impl<NodeKey, SourceKey> Default for PresentationStore<NodeKey, SourceKey>
+where
+    NodeKey: Copy + Eq + Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<NodeKey, SourceKey> PresentationStore<NodeKey, SourceKey>
+where
+    NodeKey: Copy + Eq + Hash,
+{
+    /// Creates an empty presentation store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            nodes: HashMap::new(),
+            order: Vec::new(),
+            dirty: Vec::new(),
+            dirty_set: HashSet::new(),
+        }
+    }
+
+    /// Returns the number of live presentation nodes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Returns true when the store has no live presentation nodes.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Returns true when `key` has a live presentation node.
+    #[must_use]
+    pub fn contains_key(&self, key: NodeKey) -> bool {
+        self.nodes.contains_key(&key)
+    }
+
+    /// Inserts or replaces a presentation node and marks `key` dirty.
+    ///
+    /// Replacing an existing key preserves its insertion-order position.
+    pub fn insert(
+        &mut self,
+        key: NodeKey,
+        source: SourceKey,
+    ) -> Option<PresentationNode<SourceKey>> {
+        let old = self.nodes.insert(key, PresentationNode::new(source));
+        if old.is_none() {
+            self.order.push(key);
+        }
+        self.mark_dirty(key);
+        old
+    }
+
+    /// Removes a presentation node, marking `key` dirty if it was live.
+    pub fn remove(&mut self, key: NodeKey) -> Option<PresentationNode<SourceKey>> {
+        let old = self.nodes.remove(&key)?;
+        self.order.retain(|ordered| *ordered != key);
+        self.mark_dirty(key);
+        Some(old)
+    }
+
+    /// Clears all presentation nodes and marks every previously live key dirty.
+    pub fn clear(&mut self) {
+        let keys = core::mem::take(&mut self.order);
+        for key in keys {
+            self.mark_dirty(key);
+        }
+        self.nodes.clear();
+    }
+
+    /// Returns a presentation node by key.
+    #[must_use]
+    pub fn node(&self, key: NodeKey) -> Option<&PresentationNode<SourceKey>> {
+        self.nodes.get(&key)
+    }
+
+    /// Returns a mutable presentation node by key and marks it dirty.
+    pub fn node_mut(&mut self, key: NodeKey) -> Option<&mut PresentationNode<SourceKey>> {
+        if self.nodes.contains_key(&key) {
+            self.mark_dirty(key);
+        }
+        self.nodes.get_mut(&key)
+    }
+
+    /// Returns the first surface primitive on a node, creating it if needed.
+    ///
+    /// Returns `None` when `key` does not identify a live presentation node.
+    pub fn surface_mut(&mut self, key: NodeKey) -> Option<&mut SurfacePrimitive> {
+        self.node_mut(key).map(PresentationNode::surface_mut)
+    }
+
+    /// Returns the first text primitive on a node, creating it if needed.
+    ///
+    /// Returns `None` when `key` does not identify a live presentation node.
+    pub fn text_mut(&mut self, key: NodeKey) -> Option<&mut TextPrimitive> {
+        self.node_mut(key).map(PresentationNode::text_mut)
+    }
+
+    /// Returns the first plain text primitive on a node, creating it if needed.
+    ///
+    /// Returns `None` when `key` does not identify a live presentation node.
+    pub fn plain_text_mut(&mut self, key: NodeKey) -> Option<&mut PlainTextPrimitive> {
+        self.node_mut(key).map(PresentationNode::plain_text_mut)
+    }
+
+    /// Returns live keys in insertion order.
+    ///
+    /// This order is useful for diagnostics and listing. It is not paint order:
+    /// callers should walk their own geometry tree and use [`Self::node`] to
+    /// look up presentation data for each geometry key.
+    pub fn keys(&self) -> impl Iterator<Item = NodeKey> + '_ {
+        self.order.iter().copied()
+    }
+
+    /// Returns live nodes in insertion order.
+    ///
+    /// This order is useful for diagnostics and listing. It is not paint order:
+    /// callers should walk their own geometry tree and use [`Self::node`] to
+    /// look up presentation data for each geometry key.
+    pub fn nodes(&self) -> impl Iterator<Item = (NodeKey, &PresentationNode<SourceKey>)> + '_ {
+        self.order
+            .iter()
+            .copied()
+            .filter_map(|key| self.nodes.get(&key).map(|node| (key, node)))
+    }
+
+    /// Marks `key` dirty if it is not already dirty.
+    ///
+    /// This is useful when data outside the presentation node changes but paint
+    /// should still revisit the node.
+    pub fn mark_dirty(&mut self, key: NodeKey) {
+        if self.dirty_set.insert(key) {
+            self.dirty.push(key);
+        }
+    }
+
+    /// Returns true when `key` is currently dirty.
+    #[must_use]
+    pub fn is_dirty(&self, key: NodeKey) -> bool {
+        self.dirty_set.contains(&key)
+    }
+
+    /// Returns the number of currently dirty keys.
+    #[must_use]
+    pub fn dirty_len(&self) -> usize {
+        self.dirty.len()
+    }
+
+    /// Returns true when no keys are currently dirty.
+    #[must_use]
+    pub fn dirty_is_empty(&self) -> bool {
+        self.dirty.is_empty()
+    }
+
+    /// Clears dirty state without yielding the dirty keys.
+    pub fn clear_dirty(&mut self) {
+        self.dirty.clear();
+        self.dirty_set.clear();
+    }
+
+    /// Drains dirty keys in first-dirty order.
+    ///
+    /// Dirty tracking has set semantics: each key is yielded at most once until
+    /// it is marked dirty again.
+    pub fn take_dirty(&mut self) -> impl Iterator<Item = NodeKey> + '_ {
+        self.dirty_set.clear();
+        self.dirty.drain(..)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+    use crate::{Color, RoundedRectRadii, TextContent};
+
+    #[test]
+    fn insert_tracks_nodes_and_dirty_order() {
+        let mut store = PresentationStore::new();
+
+        assert_eq!(store.insert(1, 10), None);
+        assert_eq!(store.insert(2, 10), None);
+
+        assert_eq!(store.len(), 2);
+        assert_eq!(store.keys().collect::<Vec<_>>(), vec![1, 2]);
+        assert_eq!(store.take_dirty().collect::<Vec<_>>(), vec![1, 2]);
+        assert!(store.dirty_is_empty());
+    }
+
+    #[test]
+    fn replacing_node_preserves_order_and_returns_old_node() {
+        let mut store = PresentationStore::new();
+        store.insert(1, 10);
+        store.insert(2, 10);
+        store.clear_dirty();
+
+        let old = store.insert(1, 11).unwrap();
+
+        assert_eq!(old.source(), &10);
+        assert_eq!(store.keys().collect::<Vec<_>>(), vec![1, 2]);
+        assert_eq!(store.node(1).unwrap().source(), &11);
+        assert_eq!(store.take_dirty().collect::<Vec<_>>(), vec![1]);
+    }
+
+    #[test]
+    fn surface_mut_creates_surface_and_dedupes_dirty() {
+        let mut store = PresentationStore::new();
+        store.insert(1, 10);
+        store.clear_dirty();
+
+        let surface = store.surface_mut(1).unwrap();
+        surface.set_background(Color::from_rgb8(20, 30, 40));
+
+        let surface = store.surface_mut(1).unwrap();
+        surface.corner_radii = RoundedRectRadii::from_single_radius(4.0);
+
+        assert!(store.node(1).unwrap().surface().is_some());
+        assert_eq!(store.take_dirty().collect::<Vec<_>>(), vec![1]);
+    }
+
+    #[test]
+    fn plain_text_mut_creates_plain_text() {
+        let mut store = PresentationStore::new();
+        store.insert(1, 10);
+        store.clear_dirty();
+
+        let text = store.plain_text_mut(1).unwrap();
+        text.content = TextContent::plain("Apply");
+
+        assert_eq!(
+            store
+                .node(1)
+                .unwrap()
+                .plain_text()
+                .unwrap()
+                .content
+                .as_str(),
+            "Apply"
+        );
+        assert_eq!(store.take_dirty().collect::<Vec<_>>(), vec![1]);
+    }
+
+    #[test]
+    fn missing_primitive_helpers_return_none_without_dirty() {
+        let mut store: PresentationStore<u32, u32> = PresentationStore::new();
+
+        assert!(store.surface_mut(99).is_none());
+        assert!(store.text_mut(99).is_none());
+        assert!(store.plain_text_mut(99).is_none());
+        assert!(store.dirty_is_empty());
+    }
+
+    #[test]
+    fn remove_marks_existing_key_dirty() {
+        let mut store = PresentationStore::new();
+        store.insert(1, 10);
+        store.insert(2, 10);
+        store.clear_dirty();
+
+        assert!(store.remove(1).is_some());
+        assert!(store.node(1).is_none());
+        assert_eq!(store.keys().collect::<Vec<_>>(), vec![2]);
+        assert_eq!(store.take_dirty().collect::<Vec<_>>(), vec![1]);
+    }
+
+    #[test]
+    fn clear_marks_live_keys_dirty_in_insertion_order() {
+        let mut store = PresentationStore::new();
+        store.insert(1, 10);
+        store.insert(2, 10);
+        store.clear_dirty();
+
+        store.clear();
+
+        assert!(store.is_empty());
+        assert_eq!(store.take_dirty().collect::<Vec<_>>(), vec![1, 2]);
+    }
+}


### PR DESCRIPTION
Adds `understory_presentation`, a small `no_std` retained drawing-intent crate keyed by caller-owned geometry ids.

The crate provides:

* `PresentationStore` / `PresentationNode` with dirty tracking
* resolved surface, plain-text, and image primitives
* generic caller-owned `NodeKey`, `SourceKey`, and `ImageKey`

## Design Notes

`understory_presentation` deliberately does not own layout bounds, scene traversal order, transforms/clips, hit testing, style resolution, templates, or renderer command emission. Callers walk their own geometry tree and look up presentation data by node key.