### PR TITLE
understory_index: commit dirty slots only

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -30,6 +30,10 @@ name = "index_compare_backends"
 harness = false
 
 [[bench]]
+name = "index_commit_dirty"
+harness = false
+
+[[bench]]
 name = "rtree_external_compare"
 harness = false
 required-features = ["compare_rstar"]

--- a/benches/benches/index_commit_dirty.rs
+++ b/benches/benches/index_commit_dirty.rs
@@ -1,0 +1,172 @@
+// Copyright 2025 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use understory_index::{Aabb2D, Backend, Index, IndexGeneric, Key};
+
+const SPARSE_DIRTY_SIZES: [usize; 3] = [1_024, 16_384, 65_536];
+const ALL_DIRTY_SIZES: [usize; 2] = [1_024, 16_384];
+
+fn gen_grid_rects(n: usize) -> Vec<Aabb2D<f64>> {
+    let side = n.isqrt();
+    let mut out = Vec::with_capacity(n);
+    for y in 0..side {
+        for x in 0..side {
+            if out.len() == n {
+                return out;
+            }
+            let x0 = x as f64 * 10.0;
+            let y0 = y as f64 * 10.0;
+            out.push(Aabb2D::from_xywh(x0, y0, 8.0, 8.0));
+        }
+    }
+    out
+}
+
+fn build_index<B, F>(rects: &[Aabb2D<f64>], make_index: F) -> IndexGeneric<f64, u32, B>
+where
+    B: Backend<f64>,
+    F: Fn() -> IndexGeneric<f64, u32, B>,
+{
+    let (idx, _) = build_index_with_keys(rects, make_index);
+    idx
+}
+
+fn build_index_with_keys<B, F>(
+    rects: &[Aabb2D<f64>],
+    make_index: F,
+) -> (IndexGeneric<f64, u32, B>, Vec<Key>)
+where
+    B: Backend<f64>,
+    F: Fn() -> IndexGeneric<f64, u32, B>,
+{
+    let mut idx = make_index();
+    let mut keys = Vec::with_capacity(rects.len());
+    idx.reserve(rects.len());
+    for (i, rect) in rects.iter().copied().enumerate() {
+        keys.push(idx.insert(rect, i as u32));
+    }
+    let _ = idx.commit();
+    (idx, keys)
+}
+
+fn bench_commit_noop<B, F>(c: &mut Criterion, group_name: &str, backend_name: &str, make_index: F)
+where
+    B: Backend<f64> + 'static,
+    F: Fn() -> IndexGeneric<f64, u32, B> + Copy + 'static,
+{
+    let mut group = c.benchmark_group(group_name);
+    for n in SPARSE_DIRTY_SIZES {
+        let rects = gen_grid_rects(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_function(BenchmarkId::new(backend_name, n), |b| {
+            let mut idx = build_index(&rects, make_index);
+            b.iter(|| black_box(idx.commit()));
+        });
+    }
+    group.finish();
+}
+
+fn bench_commit_one_update<B, F>(
+    c: &mut Criterion,
+    group_name: &str,
+    backend_name: &str,
+    make_index: F,
+) where
+    B: Backend<f64> + 'static,
+    F: Fn() -> IndexGeneric<f64, u32, B> + Copy + 'static,
+{
+    let mut group = c.benchmark_group(group_name);
+    for n in SPARSE_DIRTY_SIZES {
+        let rects = gen_grid_rects(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_function(BenchmarkId::new(backend_name, n), |b| {
+            let (mut idx, keys) = build_index_with_keys(&rects, make_index);
+            let key = keys[0];
+            let mut shifted = false;
+            b.iter(|| {
+                shifted = !shifted;
+                let x = if shifted { 1.0 } else { 0.0 };
+                idx.update(key, Aabb2D::from_xywh(x, 0.0, 8.0, 8.0));
+                black_box(idx.commit())
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_commit_all_updates<B, F>(
+    c: &mut Criterion,
+    group_name: &str,
+    backend_name: &str,
+    make_index: F,
+) where
+    B: Backend<f64> + 'static,
+    F: Fn() -> IndexGeneric<f64, u32, B> + Copy + 'static,
+{
+    let mut group = c.benchmark_group(group_name);
+    for n in ALL_DIRTY_SIZES {
+        let rects = gen_grid_rects(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_function(BenchmarkId::new(backend_name, n), |b| {
+            let (mut idx, keys) = build_index_with_keys(&rects, make_index);
+            let mut shifted = false;
+            b.iter(|| {
+                shifted = !shifted;
+                let dx = if shifted { 1.0 } else { 0.0 };
+                for (key, rect) in keys.iter().copied().zip(rects.iter().copied()) {
+                    idx.update(
+                        key,
+                        Aabb2D::from_xywh(rect.min_x + dx, rect.min_y, 8.0, 8.0),
+                    );
+                }
+                black_box(idx.commit())
+            });
+        });
+    }
+    group.finish();
+}
+
+fn index_commit_dirty(c: &mut Criterion) {
+    bench_commit_noop::<understory_index::backends::FlatVec<f64>, _>(
+        c,
+        "index_commit_noop",
+        "flatvec",
+        Index::<f64, u32>::new,
+    );
+    bench_commit_noop::<understory_index::backends::RTreeF64<u32>, _>(
+        c,
+        "index_commit_noop",
+        "rtree",
+        Index::<f64, u32>::with_rtree,
+    );
+
+    bench_commit_one_update::<understory_index::backends::FlatVec<f64>, _>(
+        c,
+        "index_commit_one_update",
+        "flatvec",
+        Index::<f64, u32>::new,
+    );
+    bench_commit_one_update::<understory_index::backends::RTreeF64<u32>, _>(
+        c,
+        "index_commit_one_update",
+        "rtree",
+        Index::<f64, u32>::with_rtree,
+    );
+
+    bench_commit_all_updates::<understory_index::backends::FlatVec<f64>, _>(
+        c,
+        "index_commit_all_updates",
+        "flatvec",
+        Index::<f64, u32>::new,
+    );
+    bench_commit_all_updates::<understory_index::backends::RTreeF64<u32>, _>(
+        c,
+        "index_commit_all_updates",
+        "rtree",
+        Index::<f64, u32>::with_rtree,
+    );
+}
+
+criterion_group!(benches, index_commit_dirty);
+criterion_main!(benches);

--- a/understory_index/src/index.rs
+++ b/understory_index/src/index.rs
@@ -54,6 +54,7 @@ struct Entry<T, P> {
 pub struct IndexGeneric<T: Copy + PartialOrd + Debug, P: Copy + Debug, B: Backend<T>> {
     entries: Vec<Slot<T, P>>,
     free_list: Vec<usize>,
+    dirty_slots: Vec<usize>,
     backend: B,
 }
 
@@ -68,6 +69,7 @@ where
         Self {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: B::default(),
         }
     }
@@ -87,6 +89,7 @@ where
         Self {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend,
         }
     }
@@ -101,20 +104,25 @@ where
     /// Reserve space for at least `n` entries.
     pub fn reserve(&mut self, n: usize) {
         self.entries.reserve(n);
+        self.dirty_slots.reserve(n);
     }
 
     /// Insert a new AABB with payload. Returns a stable handle `Key`.
     pub fn insert(&mut self, aabb: Aabb2D<T>, payload: P) -> Key {
         let (idx, generation) = if let Some(idx) = self.free_list.pop() {
-            let slot = &mut self.entries[idx];
-            slot.generation = next_generation(slot.generation);
-            slot.entry = Some(Entry {
-                aabb,
-                payload,
-                mark: Some(Mark::Added),
-                prev_aabb: None,
-            });
-            (idx, slot.generation)
+            let generation = {
+                let slot = &mut self.entries[idx];
+                slot.generation = next_generation(slot.generation);
+                slot.entry = Some(Entry {
+                    aabb,
+                    payload,
+                    mark: Some(Mark::Added),
+                    prev_aabb: None,
+                });
+                slot.generation
+            };
+            self.queue_dirty_slot(idx);
+            (idx, generation)
         } else {
             let generation = 1_u32;
             self.entries.push(Slot {
@@ -126,16 +134,24 @@ where
                     prev_aabb: None,
                 }),
             });
-            (self.entries.len() - 1, generation)
+            let idx = self.entries.len() - 1;
+            self.queue_dirty_slot(idx);
+            (idx, generation)
         };
         Key::new(idx, generation)
     }
 
     /// Update an existing AABB.
     pub fn update(&mut self, key: Key, aabb: Aabb2D<T>) {
-        if let Some(e) = self.entry_mut(key) {
+        let idx = key.idx();
+        let mut queue_dirty = false;
+        {
+            let Some(e) = self.entry_mut(key) else {
+                return;
+            };
             if e.mark.is_none() {
                 e.prev_aabb = Some(e.aabb);
+                queue_dirty = true;
             }
             e.aabb = aabb;
             e.mark = Some(match e.mark {
@@ -143,24 +159,37 @@ where
                 _ => Mark::Updated,
             });
         }
+        if queue_dirty {
+            self.queue_dirty_slot(idx);
+        }
     }
 
     /// Remove an existing AABB.
     pub fn remove(&mut self, key: Key) {
-        let Some(slot) = self.entries.get_mut(key.idx()) else {
-            return;
-        };
-        if slot.generation != key.1 {
-            return;
-        }
-        let Some(e) = slot.entry.as_mut() else {
-            return;
-        };
-        if matches!(e.mark, Some(Mark::Added)) {
-            slot.entry = None;
-            self.free_list.push(key.idx());
-        } else {
+        let idx = key.idx();
+        let mut queue_dirty = false;
+        {
+            let Some(slot) = self.entries.get_mut(idx) else {
+                return;
+            };
+            if slot.generation != key.1 {
+                return;
+            }
+            let Some(e) = slot.entry.as_mut() else {
+                return;
+            };
+            if matches!(e.mark, Some(Mark::Added)) {
+                slot.entry = None;
+                self.free_list.push(idx);
+                return;
+            }
+            if e.mark.is_none() {
+                queue_dirty = true;
+            }
             e.mark = Some(Mark::Removed);
+        }
+        if queue_dirty {
+            self.queue_dirty_slot(idx);
         }
     }
 
@@ -168,39 +197,18 @@ where
     pub fn clear(&mut self) {
         self.entries.clear();
         self.free_list.clear();
+        self.dirty_slots.clear();
         self.backend.clear();
     }
 
     /// Apply pending changes and compute batched damage. Also synchronizes backend state.
     pub fn commit(&mut self) -> Damage<T> {
         let mut dmg = Damage::default();
-        for i in 0..self.entries.len() {
-            let Some(entry) = self.entries[i].entry.as_mut() else {
-                continue;
-            };
-            match entry.mark.take() {
-                Some(Mark::Added) => {
-                    self.backend.insert(i, entry.aabb);
-                    dmg.added.push(entry.aabb);
-                }
-                Some(Mark::Removed) => {
-                    self.backend.remove(i);
-                    dmg.removed
-                        .push(entry.prev_aabb.take().unwrap_or(entry.aabb));
-                    self.entries[i].entry = None;
-                    self.free_list.push(i);
-                }
-                Some(Mark::Updated) => {
-                    self.backend.update(i, entry.aabb);
-                    if let Some(prev) = entry.prev_aabb.take()
-                        && prev != entry.aabb
-                    {
-                        dmg.moved.push((prev, entry.aabb));
-                    }
-                }
-                None => {}
-            }
+        let mut dirty_slots = core::mem::take(&mut self.dirty_slots);
+        for i in dirty_slots.drain(..) {
+            self.commit_slot(i, &mut dmg);
         }
+        self.dirty_slots = dirty_slots;
         dmg
     }
 
@@ -251,6 +259,41 @@ where
         }
         slot.entry.as_mut()
     }
+
+    fn queue_dirty_slot(&mut self, idx: usize) {
+        self.dirty_slots.push(idx);
+    }
+
+    fn commit_slot(&mut self, i: usize, dmg: &mut Damage<T>) {
+        let Some(slot) = self.entries.get_mut(i) else {
+            return;
+        };
+        let Some(entry) = slot.entry.as_mut() else {
+            return;
+        };
+        match entry.mark.take() {
+            Some(Mark::Added) => {
+                self.backend.insert(i, entry.aabb);
+                dmg.added.push(entry.aabb);
+            }
+            Some(Mark::Removed) => {
+                self.backend.remove(i);
+                dmg.removed
+                    .push(entry.prev_aabb.take().unwrap_or(entry.aabb));
+                slot.entry = None;
+                self.free_list.push(i);
+            }
+            Some(Mark::Updated) => {
+                self.backend.update(i, entry.aabb);
+                if let Some(prev) = entry.prev_aabb.take()
+                    && prev != entry.aabb
+                {
+                    dmg.moved.push((prev, entry.aabb));
+                }
+            }
+            None => {}
+        }
+    }
 }
 
 fn next_generation(generation: u32) -> u32 {
@@ -275,6 +318,7 @@ impl<P: Copy + Debug> Index<f64, P> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::bvh::BvhF64::default(),
         }
     }
@@ -285,6 +329,7 @@ impl<P: Copy + Debug> Index<f64, P> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::GridF64::new(cell_size),
         }
     }
@@ -294,6 +339,7 @@ impl<P: Copy + Debug> Index<f64, P> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::rtree::RTreeF64::default(),
         }
     }
@@ -305,6 +351,7 @@ impl<P: Copy + Debug> Index<f64, P> {
         let mut idx = IndexGeneric {
             entries: Vec::with_capacity(entries.len()),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::rtree::RTreeF64::default(),
         };
         let mut pairs: Vec<(usize, Aabb2D<f64>)> = Vec::with_capacity(entries.len());
@@ -332,6 +379,7 @@ impl<P: Copy + Debug> Index<i64, P> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::GridI64::new(cell_size),
         }
     }
@@ -341,6 +389,7 @@ impl<P: Copy + Debug> Index<i64, P> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::rtree::RTreeI64::default(),
         }
     }
@@ -352,6 +401,7 @@ impl<P: Copy + Debug> Index<i64, P> {
         let mut idx = IndexGeneric {
             entries: Vec::with_capacity(entries.len()),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::rtree::RTreeI64::default(),
         };
         let mut pairs: Vec<(usize, Aabb2D<i64>)> = Vec::with_capacity(entries.len());
@@ -378,6 +428,7 @@ impl<P: Copy + Debug> Index<f32, P> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::bvh::BvhF32::default(),
         }
     }
@@ -388,6 +439,7 @@ impl<P: Copy + Debug> Index<f32, P> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::GridF32::new(cell_size),
         }
     }
@@ -397,6 +449,7 @@ impl<P: Copy + Debug> Index<f32, P> {
         IndexGeneric {
             entries: Vec::new(),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::rtree::RTreeF32::default(),
         }
     }
@@ -408,6 +461,7 @@ impl<P: Copy + Debug> Index<f32, P> {
         let mut idx = IndexGeneric {
             entries: Vec::with_capacity(entries.len()),
             free_list: Vec::new(),
+            dirty_slots: Vec::new(),
             backend: crate::backends::rtree::RTreeF32::default(),
         };
         let mut pairs: Vec<(usize, Aabb2D<f32>)> = Vec::with_capacity(entries.len());
@@ -515,6 +569,22 @@ mod tests {
         let hits: Vec<_> = idx.query_point(25, 25).collect();
         assert_eq!(hits.as_slice(), &[(fresh, 2)]);
         assert_eq!(idx.query_point(105, 105).count(), 0);
+    }
+
+    #[test]
+    fn repeated_updates_before_commit_report_one_move_to_final_aabb() {
+        let mut idx: Index<i64, u32> = Index::new();
+        let k = idx.insert(Aabb2D::new(0, 0, 10, 10), 1);
+        let _ = idx.commit();
+
+        idx.update(k, Aabb2D::new(5, 5, 15, 15));
+        idx.update(k, Aabb2D::new(10, 10, 20, 20));
+
+        let dmg = idx.commit();
+        assert_eq!(dmg.moved.len(), 1);
+        assert_eq!(dmg.moved[0].0, Aabb2D::new(0, 0, 10, 10));
+        assert_eq!(dmg.moved[0].1, Aabb2D::new(10, 10, 20, 20));
+        assert!(idx.commit().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Add a Criterion benchmark for commit() and make commit drain the slots touched by insert, update, and remove instead of scanning every allocated slot. The motivation is UI-style frames where a large index usually has zero or one moved box; commit cost should scale with pending changes, not total index size.

Criterion before/after from index_commit_dirty showed the sparse-frame win: noop commit at 65,536 entries dropped from about 64 us to about 7 ns; one FlatVec update at 65,536 entries dropped from about 63 us to about 24 ns; one RTree update at 65,536 entries dropped from about 63 us to about 101 ns.

Dense updates stay close to the old path: FlatVec all-updates at 16,384 entries moved from 108.6 us to 117.9 us, while RTree all-updates at 16,384 entries moved from 1.970 ms to 1.964 ms.