### PR TITLE
understory_property_binding: skip missing sources while draining

### DIFF
--- a/understory_property_binding/README.md
+++ b/understory_property_binding/README.md
@@ -94,7 +94,10 @@ application-level invalidation tracker with those returned channels.
 
 ## Gotchas and risks
 
-- Missing source values stop the drain with [`BindingError::MissingSource`].
+- Missing source values are non-fatal: the binding is skipped, stays clean,
+  and is counted in [`BindingReport::skipped_missing_source`]. It re-dirties
+  automatically when [`BindingSet::mark_endpoint_changed`] runs after the
+  source is written.
 - Runtime type mismatches stop the drain with
   [`BindingError::SourceTypeMismatch`].
 - Drain errors return [`BindingDrainError`]. Writes that already happened

--- a/understory_property_binding/src/endpoint.rs
+++ b/understory_property_binding/src/endpoint.rs
@@ -12,8 +12,10 @@ pub struct BindingId(u32);
 impl BindingId {
     /// Creates a binding id from a raw integer.
     ///
-    /// This is primarily useful for tests and diagnostics. [`crate::BindingSet`]
+    /// This is primarily useful for tests and diagnostics. [`BindingSet`]
     /// assigns ids when bindings are registered.
+    ///
+    /// [`BindingSet`]: crate::BindingSet
     #[must_use]
     pub const fn new(raw: u32) -> Self {
         Self(raw)

--- a/understory_property_binding/src/error.rs
+++ b/understory_property_binding/src/error.rs
@@ -31,6 +31,14 @@ pub enum BindingError<K> {
         existing: BindingId,
     },
     /// The host did not provide a source value for the endpoint.
+    ///
+    /// [`BindingSet::drain`] treats this as a non-fatal pending state: it
+    /// skips the binding and counts it in
+    /// [`BindingReport::skipped_missing_source`]. Other callers of a binding
+    /// evaluator may still observe this error directly.
+    ///
+    /// [`BindingSet::drain`]: crate::BindingSet::drain
+    /// [`BindingReport::skipped_missing_source`]: crate::BindingReport::skipped_missing_source
     MissingSource {
         /// The binding that failed to read its source.
         binding: BindingId,

--- a/understory_property_binding/src/lib.rs
+++ b/understory_property_binding/src/lib.rs
@@ -77,7 +77,10 @@
 //!
 //! ## Gotchas and risks
 //!
-//! - Missing source values stop the drain with [`BindingError::MissingSource`].
+//! - Missing source values are non-fatal: the binding is skipped, stays clean,
+//!   and is counted in [`BindingReport::skipped_missing_source`]. It re-dirties
+//!   automatically when [`BindingSet::mark_endpoint_changed`] runs after the
+//!   source is written.
 //! - Runtime type mismatches stop the drain with
 //!   [`BindingError::SourceTypeMismatch`].
 //! - Drain errors return [`BindingDrainError`]. Writes that already happened

--- a/understory_property_binding/src/report.rs
+++ b/understory_property_binding/src/report.rs
@@ -49,11 +49,14 @@ impl BindingWrite {
     }
 }
 
-/// Summary returned by [`crate::BindingSet::drain`].
+/// Summary returned by [`BindingSet::drain`].
+///
+/// [`BindingSet::drain`]: crate::BindingSet::drain
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct BindingReport {
     evaluated_bindings: usize,
     changed_bindings: usize,
+    skipped_missing_source: usize,
     affected_channels: ChannelSet,
 }
 
@@ -70,6 +73,17 @@ impl BindingReport {
         self.changed_bindings
     }
 
+    /// Returns the number of bindings the drain skipped because the host
+    /// reported no value for the source endpoint. Those bindings stay clean
+    /// and will be re-dirtied via [`BindingSet::mark_endpoint_changed`]
+    /// when the source is written.
+    ///
+    /// [`BindingSet::mark_endpoint_changed`]: crate::BindingSet::mark_endpoint_changed
+    #[must_use]
+    pub const fn skipped_missing_source(self) -> usize {
+        self.skipped_missing_source
+    }
+
     /// Returns the union of application channels affected by binding target writes.
     #[must_use]
     pub const fn affected_channels(self) -> ChannelSet {
@@ -82,6 +96,10 @@ impl BindingReport {
             self.changed_bindings += 1;
         }
         self.affected_channels |= write.affected_channels();
+    }
+
+    pub(crate) fn record_skipped_missing_source(&mut self) {
+        self.skipped_missing_source += 1;
     }
 }
 

--- a/understory_property_binding/src/set.rs
+++ b/understory_property_binding/src/set.rs
@@ -300,9 +300,18 @@ where
     /// dirty for a later pass unless they are already scheduled in the current
     /// pass.
     ///
-    /// If evaluation fails, writes that already happened are not rolled back.
-    /// The failed binding and the rest of the current dirty batch are marked
-    /// dirty again so the caller can repair the host state and retry.
+    /// A binding whose source has no value (the host returns `None` from
+    /// `get_erased`) is a no-op: the binding is skipped, stays clean, and
+    /// is recorded in [`BindingReport::skipped_missing_source`]. The
+    /// expectation is that the host will dirty the binding again via
+    /// [`Self::mark_endpoint_changed`] once the source becomes available.
+    /// This treats "source not yet provided" as a normal pending state
+    /// rather than a drain-aborting error.
+    ///
+    /// Other evaluation failures (type mismatch, …) abort the drain. Writes
+    /// that already happened are not rolled back. The failed binding and the
+    /// rest of the current dirty batch are marked dirty again so the caller
+    /// can repair the host state and retry.
     pub fn drain(
         &mut self,
         host: &mut dyn BindingHost<K>,
@@ -326,6 +335,9 @@ where
                         }
                     }
                     Ok(None) => {}
+                    Err(BindingError::MissingSource { .. }) => {
+                        report.record_skipped_missing_source();
+                    }
                     Err(error) => {
                         self.remark_dirty_batch(&raw_bindings[index..]);
                         return Err(BindingDrainError::new(error, report));
@@ -529,7 +541,7 @@ mod tests {
     };
 
     use crate::{
-        BindingError, BindingHost, BindingId, BindingReport, BindingSet, BindingWrite, EndpointKey,
+        BindingError, BindingHost, BindingId, BindingSet, BindingWrite, EndpointKey,
         PropertyEndpoint,
     };
 
@@ -923,7 +935,12 @@ mod tests {
     }
 
     #[test]
-    fn failed_drain_preserves_failed_and_remaining_dirty_bindings() {
+    fn missing_source_is_skipped_and_resumes_when_source_arrives() {
+        // Binding 0: first → second. Source has no value yet.
+        // Binding 1: second → third. Source already populated.
+        // First drain: 0 skips (counted as skipped_missing_source),
+        //              1 evaluates. No error. Binding 0 stays clean.
+        // After providing first's value + re-marking, binding 0 fires.
         let (_registry, width) = registry();
         let first = PropertyEndpoint::new(1, width);
         let second = PropertyEndpoint::new(2, width);
@@ -938,29 +955,29 @@ mod tests {
 
         bindings.mark_source_changed(first);
         bindings.mark_source_changed(second);
-        let error = bindings.drain(&mut host).unwrap_err();
-
-        assert!(matches!(
-            error.error(),
-            BindingError::MissingSource {
-                binding,
-                endpoint
-            } if *binding == BindingId::new(0) && *endpoint == first.key()
-        ));
-        assert_eq!(error.report(), BindingReport::default());
-        assert!(bindings.has_dirty_bindings());
-
-        host.set_initial(first, 10_u32);
         let report = bindings.drain(&mut host).unwrap();
 
-        assert_eq!(report.evaluated_bindings(), 2);
+        assert_eq!(report.evaluated_bindings(), 1);
         assert_eq!(report.changed_bindings(), 1);
-        assert_eq!(host.value(second), Some(&10));
+        assert_eq!(report.skipped_missing_source(), 1);
         assert_eq!(host.value(third), Some(&10));
+        assert!(!bindings.has_dirty_bindings());
+
+        host.set_initial(first, 20_u32);
+        bindings.mark_source_changed(first);
+        let retry = bindings.drain(&mut host).unwrap();
+
+        assert_eq!(retry.evaluated_bindings(), 2);
+        assert_eq!(retry.changed_bindings(), 2);
+        assert_eq!(retry.skipped_missing_source(), 0);
+        assert_eq!(host.value(second), Some(&20));
+        assert_eq!(host.value(third), Some(&20));
     }
 
     #[test]
-    fn failed_drain_returns_partial_report_for_completed_writes() {
+    fn missing_source_does_not_block_sibling_writes() {
+        // Sibling bindings: one with a source value, one without.
+        // The unsourced binding is skipped; the other still writes.
         let (_registry, width) = registry();
         let first_source = PropertyEndpoint::new(1, width);
         let first_target = PropertyEndpoint::new(2, width);
@@ -977,21 +994,17 @@ mod tests {
 
         bindings.mark_source_changed(first_source);
         bindings.mark_source_changed(missing_source);
-        let error = bindings.drain(&mut host).unwrap_err();
-        let report = error.report();
+        let report = bindings.drain(&mut host).unwrap();
 
-        assert!(matches!(
-            error.error(),
-            BindingError::MissingSource { binding, endpoint }
-                if *binding == BindingId::new(1) && *endpoint == missing_source.key()
-        ));
         assert_eq!(report.evaluated_bindings(), 1);
         assert_eq!(report.changed_bindings(), 1);
+        assert_eq!(report.skipped_missing_source(), 1);
         assert!(report.affected_channels().contains(LAYOUT));
         assert_eq!(host.value(first_target), Some(&10));
-        assert!(bindings.has_dirty_bindings());
+        assert!(!bindings.has_dirty_bindings());
 
         host.set_initial(missing_source, 20_u32);
+        bindings.mark_source_changed(missing_source);
         let retry = bindings.drain(&mut host).unwrap();
 
         assert_eq!(retry.evaluated_bindings(), 1);


### PR DESCRIPTION
Treat a binding source with no host value as a pending state instead of a drain-aborting error. This avoids one not-yet-populated source poisoning sibling bindings in the same dirty batch.

Skipped bindings stay clean and are counted on BindingReport::skipped_missing_source. When the host later writes that source and calls mark_endpoint_changed, the normal source index re-dirties the binding and it evaluates then.

Type mismatches and other evaluation failures still abort and re-mark the failed/current batch for retry. Update the crate docs, regenerated README, and regression tests for missing-source siblings and later source arrival.