### PR TITLE
understory_index: speed up RTree query traversal

### DIFF
--- a/understory_index/src/backends/rtree.rs
+++ b/understory_index/src/backends/rtree.rs
@@ -67,6 +67,8 @@ impl<T: Scalar> Default for RTree<T> {
 type RChildren<TS> = Vec<RChild<TS>>;
 type RBestSplit<TS> = Option<(crate::types::ScalarAcc<TS>, RChildren<TS>, RChildren<TS>)>;
 
+const INLINE_STACK_CAP: usize = 64;
+
 impl<T: Scalar> RTree<T> {
     fn ensure_slot(&mut self, slot: usize, bbox: Aabb2D<T>) {
         if self.slots.len() <= slot {
@@ -554,6 +556,37 @@ impl<T: Scalar> RTree<T> {
             updated
         }
     }
+
+    #[inline]
+    fn pop_stack(
+        inline: &mut [NodeIdx; INLINE_STACK_CAP],
+        inline_len: &mut usize,
+        heap: &mut Vec<NodeIdx>,
+    ) -> Option<NodeIdx> {
+        if let Some(idx) = heap.pop() {
+            Some(idx)
+        } else if *inline_len > 0 {
+            *inline_len -= 1;
+            Some(inline[*inline_len])
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn push_stack(
+        inline: &mut [NodeIdx; INLINE_STACK_CAP],
+        inline_len: &mut usize,
+        heap: &mut Vec<NodeIdx>,
+        idx: NodeIdx,
+    ) {
+        if !heap.is_empty() || *inline_len == inline.len() {
+            heap.push(idx);
+        } else {
+            inline[*inline_len] = idx;
+            *inline_len += 1;
+        }
+    }
 }
 
 impl<T: Scalar> Backend<T> for RTree<T> {
@@ -657,12 +690,16 @@ impl<T: Scalar> Backend<T> for RTree<T> {
         let Some(root_idx) = self.root else {
             return;
         };
-        let mut stack = vec![root_idx];
-        while let Some(i) = stack.pop() {
+        if !self.arena[root_idx.get()].bbox.contains_point(x, y) {
+            return;
+        }
+
+        let mut inline = [root_idx; INLINE_STACK_CAP];
+        let mut inline_len = 1_usize;
+        let mut heap = Vec::new();
+
+        while let Some(i) = Self::pop_stack(&mut inline, &mut inline_len, &mut heap) {
             let n = &self.arena[i.get()];
-            if !n.bbox.contains_point(x, y) {
-                continue;
-            }
             if n.leaf {
                 for c in &n.children {
                     if let RChild::Item { slot, bbox, .. } = c
@@ -674,7 +711,10 @@ impl<T: Scalar> Backend<T> for RTree<T> {
             } else {
                 for c in &n.children {
                     if let RChild::Node(ci) = c {
-                        stack.push(*ci);
+                        let child_bbox = self.arena[ci.get()].bbox;
+                        if child_bbox.contains_point(x, y) {
+                            Self::push_stack(&mut inline, &mut inline_len, &mut heap, *ci);
+                        }
                     }
                 }
             }
@@ -685,12 +725,16 @@ impl<T: Scalar> Backend<T> for RTree<T> {
         let Some(root_idx) = self.root else {
             return;
         };
-        let mut stack = vec![root_idx];
-        while let Some(i) = stack.pop() {
+        if !self.arena[root_idx.get()].bbox.overlaps(&rect) {
+            return;
+        }
+
+        let mut inline = [root_idx; INLINE_STACK_CAP];
+        let mut inline_len = 1_usize;
+        let mut heap = Vec::new();
+
+        while let Some(i) = Self::pop_stack(&mut inline, &mut inline_len, &mut heap) {
             let n = &self.arena[i.get()];
-            if !n.bbox.overlaps(&rect) {
-                continue;
-            }
             if n.leaf {
                 for c in &n.children {
                     if let RChild::Item { slot, bbox, .. } = c
@@ -702,7 +746,10 @@ impl<T: Scalar> Backend<T> for RTree<T> {
             } else {
                 for c in &n.children {
                     if let RChild::Node(ci) = c {
-                        stack.push(*ci);
+                        let child_bbox = self.arena[ci.get()].bbox;
+                        if child_bbox.overlaps(&rect) {
+                            Self::push_stack(&mut inline, &mut inline_len, &mut heap, *ci);
+                        }
                     }
                 }
             }
@@ -739,7 +786,22 @@ pub type RTreeF64 = RTree<f64>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backends::flatvec::FlatVec;
     use crate::index::Index;
+
+    fn point_hits<B: Backend<i64>>(backend: &B, x: i64, y: i64) -> Vec<usize> {
+        let mut hits = Vec::new();
+        backend.visit_point(x, y, |slot| hits.push(slot));
+        hits.sort_unstable();
+        hits
+    }
+
+    fn rect_hits<B: Backend<i64>>(backend: &B, rect: Aabb2D<i64>) -> Vec<usize> {
+        let mut hits = Vec::new();
+        backend.visit_rect(rect, |slot| hits.push(slot));
+        hits.sort_unstable();
+        hits
+    }
 
     #[test]
     fn rtree_i64_basic_insert_query() {
@@ -827,5 +889,56 @@ mod tests {
         assert!(payloads.contains(&1) && payloads.contains(&2));
         let q: Vec<_> = idx.query_rect(Aabb2D::new(12, 12, 20, 20)).collect();
         assert_eq!(q.len(), 1);
+    }
+
+    #[test]
+    fn rtree_queries_match_flatvec_after_updates_and_removes() {
+        let mut rtree: RTree<i64> = RTree::default();
+        let mut flat: FlatVec<i64> = FlatVec::default();
+
+        for slot in 0..24 {
+            let x = (slot % 6) as i64 * 20;
+            let y = (slot / 6) as i64 * 20;
+            let bbox = Aabb2D::new(x, y, x + 12, y + 12);
+            rtree.insert(slot, bbox);
+            flat.insert(slot, bbox);
+        }
+
+        for (slot, bbox) in [
+            (1, Aabb2D::new(130, 0, 145, 15)),
+            (8, Aabb2D::new(-20, 40, -5, 55)),
+            (14, Aabb2D::new(55, -30, 75, -10)),
+            (22, Aabb2D::new(5, 95, 35, 125)),
+        ] {
+            rtree.update(slot, bbox);
+            flat.update(slot, bbox);
+        }
+
+        for slot in [0, 5, 12, 17, 21] {
+            rtree.remove(slot);
+            flat.remove(slot);
+        }
+
+        for (x, y) in [
+            (6, 6),
+            (25, 5),
+            (135, 7),
+            (-10, 48),
+            (65, -20),
+            (20, 110),
+            (90, 50),
+            (1_000, 1_000),
+        ] {
+            assert_eq!(point_hits(&rtree, x, y), point_hits(&flat, x, y));
+        }
+
+        for rect in [
+            Aabb2D::new(-25, -35, 150, 130),
+            Aabb2D::new(0, 0, 40, 40),
+            Aabb2D::new(80, 0, 130, 80),
+            Aabb2D::new(500, 500, 600, 600),
+        ] {
+            assert_eq!(rect_hits(&rtree, rect), rect_hits(&flat, rect));
+        }
     }
 }


### PR DESCRIPTION
Avoid per-query heap allocation in common RTree point and rect traversals by using a small inline stack with heap fallback, reject queries outside the root bound early, and prefilter child bounds before pushing nodes onto the traversal stack.

On this machine, the targeted Criterion benchmark improved ui_box_tree/hit_test_point/rtree_f64 from 34.9 us to 20.6 us, a 41.4% reduction.

Benchmark: cargo bench -p understory_benches --bench ui_box_tree -- ui_box_tree/hit_test_point/rtree_f64 --baseline rtree_query_before --noplot