### PR TITLE
Add box decoration geometry and surface property resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "understory_box_decoration"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+]
+
+[[package]]
 name = "understory_box_tree"
 version = "0.0.1"
 dependencies = [
@@ -684,6 +691,7 @@ dependencies = [
  "parlance",
  "peniko",
  "smallvec",
+ "understory_box_decoration",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "understory_outline",
  "understory_precise_hit",
  "understory_presentation",
+ "understory_presentation_properties",
  "understory_property",
  "understory_property_binding",
  "understory_responder",
@@ -692,6 +693,17 @@ dependencies = [
  "peniko",
  "smallvec",
  "understory_box_decoration",
+]
+
+[[package]]
+name = "understory_presentation_properties"
+version = "0.1.0"
+dependencies = [
+ "invalidation",
+ "kurbo",
+ "understory_presentation",
+ "understory_property",
+ "understory_style",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "understory_property_binding",
   "understory_guide",
   "understory_index",
+  "understory_box_decoration",
   "understory_box_tree",
   "understory_focus",
   "understory_node_graph",
@@ -51,6 +52,7 @@ smallvec = { version = "1.13.2", default-features = false }
 # the version requirements needed for packaging.
 understory_axis = { version = "0.1.0", path = "understory_axis", default-features = false }
 understory_property_binding = { version = "0.1.0", path = "understory_property_binding", default-features = false }
+understory_box_decoration = { version = "0.1.0", path = "understory_box_decoration", default-features = false }
 understory_box_tree = { version = "0.0.1", path = "understory_box_tree", default-features = false }
 understory_event_state = { version = "0.1.0", path = "understory_event_state", default-features = false }
 understory_focus = { version = "0.1.0", path = "understory_focus", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "understory_inspector",
   "understory_outline",
   "understory_presentation",
+  "understory_presentation_properties",
   "understory_precise_hit",
   "understory_property",
   "understory_responder",
@@ -62,6 +63,7 @@ understory_inspector = { version = "0.1.0", path = "understory_inspector", defau
 understory_node_graph = { version = "0.1.0", path = "understory_node_graph", default-features = false }
 understory_outline = { version = "0.1.0", path = "understory_outline", default-features = false }
 understory_presentation = { version = "0.1.0", path = "understory_presentation", default-features = false }
+understory_presentation_properties = { version = "0.1.0", path = "understory_presentation_properties", default-features = false }
 understory_precise_hit = { version = "0.1.0", path = "understory_precise_hit", default-features = false }
 understory_property = { version = "0.1.0", path = "understory_property", default-features = false }
 understory_responder = { version = "0.1.0", path = "understory_responder", default-features = false }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Stores source back-references, template part identities, surface/text primitives, and deduped dirty keys.
   - Does not own layout, bounds, transforms, style/property resolution, behavior, or renderer command emission.
 
+- `understory_box_decoration`
+  - Renderer-neutral box decoration geometry for border boxes, border widths, and CSS-style rounded corners.
+  - Supports elliptical per-corner radii, CSS smallest-factor radius fitting, derived inner border radii, and Kurbo paths.
+  - Does not own style cascade, CSS parsing, brushes, images, layout, hit policy, or renderer command emission.
+
 - `understory_box_tree`
   - A Kurbo‑native, spatially indexed box tree for scene geometry: local bounds, transforms, optional clips, and z‑order.
   - Computes world‑space AABBs and synchronizes them into `understory_index` for fast hit‑testing and visibility.
@@ -136,6 +141,7 @@ For example, a canvas or DWG or DXF viewer can reuse the box and index layers wi
 
 - Read the crate READMEs.
   - `understory_index/README.md` has the API and a “Choosing a backend” guide.
+  - `understory_box_decoration/README.md` documents rounded box decoration geometry, fitted corner radii, and inner border edges.
   - `understory_box_tree/README.md` has usage, hit‑testing, and visible‑set examples.
   - `understory_responder/README.md` explains routing, capture, and how to integrate with a picker.
   - `understory_focus/README.md` covers focus navigation policies and adapters.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
   - Stores source back-references, template part identities, surface/text primitives, and deduped dirty keys.
   - Does not own layout, bounds, transforms, style/property resolution, behavior, or renderer command emission.
 
+- `understory_presentation_properties`
+  - Canonical dependency-property integration for resolved presentation primitives.
+  - Registers surface background, border brush, border width, padding width, corner radius, and corner shape properties with invalidation metadata.
+  - Resolves property/style/theme values into `understory_presentation::SurfacePrimitive` without owning storage, matching, layout, or rendering.
+
 - `understory_box_decoration`
-  - Renderer-neutral box decoration geometry for border boxes, border widths, and CSS-style rounded corners.
-  - Supports elliptical per-corner radii, CSS smallest-factor radius fitting, derived inner border radii, and Kurbo paths.
+  - Renderer-neutral box decoration geometry for physical edges, box-area contours, and shaped corners.
+  - Supports elliptical per-corner radii, CSS smallest-factor radius fitting, round/square/bevel/superellipse corner shapes, derived border/padding/content contours, central border-side regions, and on-demand Kurbo path writing.
   - Does not own style cascade, CSS parsing, brushes, images, layout, hit policy, or renderer command emission.
 
 - `understory_box_tree`
@@ -141,7 +146,7 @@ For example, a canvas or DWG or DXF viewer can reuse the box and index layers wi
 
 - Read the crate READMEs.
   - `understory_index/README.md` has the API and a “Choosing a backend” guide.
-  - `understory_box_decoration/README.md` documents rounded box decoration geometry, fitted corner radii, and inner border edges.
+  - `understory_box_decoration/README.md` documents box decoration contours, shaped corners, fitted radii, and border/padding/content edge derivation.
   - `understory_box_tree/README.md` has usage, hit‑testing, and visible‑set examples.
   - `understory_responder/README.md` explains routing, capture, and how to integrate with a picker.
   - `understory_focus/README.md` covers focus navigation policies and adapters.
@@ -154,9 +159,11 @@ For example, a canvas or DWG or DXF viewer can reuse the box and index layers wi
   - `understory_view2d/README.md` documents the 2D and 1D viewport types, clamping/fit modes, and examples of using visible regions for culling.
   - `understory_property_binding/README.md` documents one-way property bindings, host endpoint adapters, and binding-local invalidation.
   - `understory_presentation/README.md` documents retained resolved drawing primitives, template part identities, and dirty-key draining.
+  - `understory_presentation_properties/README.md` documents canonical presentation property registration and surface resolution.
 - Run examples.
   - `cargo run -p understory_examples --example index_basics`
   - `cargo run -p understory_examples --example basic_present`
+  - `cargo run -p understory_examples --example presentation_properties`
   - `cargo run -p understory_examples --example box_tree_basics`
   - `cargo run -p understory_examples --example box_tree_visible_list`
   - `cargo run -p understory_examples --example outline_property_grid`

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,6 +21,7 @@ understory_presentation = { workspace = true, features = ["std"] }
 understory_precise_hit = { workspace = true, features = ["std"] }
 understory_property.workspace = true
 understory_property_binding.workspace = true
+understory_presentation_properties = { workspace = true, features = ["std"] }
 understory_responder = { workspace = true, features = [
   "box_tree_adapter",
   "hit2d_adapter",

--- a/examples/examples/basic_present.rs
+++ b/examples/examples/basic_present.rs
@@ -11,8 +11,9 @@
 //! - `cargo run -p understory_examples --example basic_present`
 
 use understory_presentation::{
-    Border, Brush, Color, FontWeight, ImagePrimitive, ImageQuality, ImageSlice, Insets, NineSlice,
-    PresentationStore, Primitive, RoundedRectRadii, TextAlign, TextContent,
+    Border, Brush, Color, CornerRadii, CornerShape, CornerShapes, FontWeight, ImagePrimitive,
+    ImageQuality, ImageSlice, Insets, NineSlice, PresentationStore, Primitive, TextAlign,
+    TextContent,
 };
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -61,7 +62,9 @@ fn main() {
         .expect("background part was inserted");
     surface.set_background(Color::from_rgb8(38, 92, 142));
     surface.border = Border::uniform(Color::from_rgb8(15, 39, 64), 1.0);
-    surface.corner_radii = RoundedRectRadii::from_single_radius(6.0);
+    surface.padding_widths = understory_presentation::Edges::vertical_horizontal(6.0, 10.0);
+    surface.corner_radii = CornerRadii::uniform(6.0);
+    surface.corner_shapes = CornerShapes::all(CornerShape::squircle());
 
     let mut image = ImagePrimitive::new("button-background");
     image.brush.sampler = image.brush.sampler.with_quality(ImageQuality::High);
@@ -123,10 +126,12 @@ fn print_paint_walk(
         for primitive in node.primitives() {
             match primitive {
                 Primitive::Surface(surface) => println!(
-                    "  surface backgrounds={} border_empty={} radii={:?}",
+                    "  surface backgrounds={} border_empty={} padding={:?} radii={:?} shapes={:?}",
                     surface.backgrounds.len(),
                     surface.border.is_empty(),
-                    surface.corner_radii
+                    surface.padding_widths,
+                    surface.corner_radii,
+                    surface.corner_shapes
                 ),
                 Primitive::Text(text) => {
                     let Some(text) = text.as_plain() else {

--- a/examples/examples/presentation_properties.rs
+++ b/examples/examples/presentation_properties.rs
@@ -1,0 +1,136 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Resolve dependency properties into a presentation surface.
+//!
+//! Run:
+//! - `cargo run -p understory_examples --example presentation_properties`
+
+use invalidation::Channel;
+use kurbo::Rect;
+use understory_presentation::{Brush, Color, CornerShape, Edges, PresentationStore};
+use understory_presentation_properties::{
+    CornerRadius, StyleMatch, SurfaceProperties, SurfacePropertyChannels,
+};
+use understory_property::{DependencyObject, PropertyRegistry, PropertyStore};
+use understory_style::{
+    NoResolveParentLookup, ResolveCx, StyleBuilder, StyleCascadeBuilder, StyleOrigin, ThemeBuilder,
+};
+
+const GEOMETRY: Channel = Channel::new(0);
+const PAINT: Channel = Channel::new(1);
+
+#[derive(Debug)]
+struct Widget {
+    id: u32,
+    store: PropertyStore<u32>,
+}
+
+impl Widget {
+    fn new(id: u32) -> Self {
+        Self {
+            id,
+            store: PropertyStore::new(id),
+        }
+    }
+}
+
+impl DependencyObject<u32> for Widget {
+    fn property_store(&self) -> &PropertyStore<u32> {
+        &self.store
+    }
+
+    fn property_store_mut(&mut self) -> &mut PropertyStore<u32> {
+        &mut self.store
+    }
+
+    fn key(&self) -> u32 {
+        self.id
+    }
+
+    fn parent_key(&self) -> Option<u32> {
+        None
+    }
+}
+
+fn main() {
+    let mut registry = PropertyRegistry::new();
+    let surface = SurfaceProperties::register(
+        &mut registry,
+        SurfacePropertyChannels::new(GEOMETRY.into_set(), PAINT.into_set()),
+    );
+
+    let button_style = StyleBuilder::new()
+        .set(surface.background, Some(Brush::from(Color::WHITE)))
+        .set(surface.border_widths.top, 2.0)
+        .set(surface.border_widths.right, 2.0)
+        .set(surface.border_widths.bottom, 3.0)
+        .set(surface.border_widths.left, 2.0)
+        .set(surface.border_brushes.top, Some(Brush::from(Color::BLACK)))
+        .set(
+            surface.border_brushes.right,
+            Some(Brush::from(Color::BLACK)),
+        )
+        .set(
+            surface.border_brushes.bottom,
+            Some(Brush::from(Color::BLACK)),
+        )
+        .set(surface.border_brushes.left, Some(Brush::from(Color::BLACK)))
+        .set(surface.padding_widths.top, 6.0)
+        .set(surface.padding_widths.right, 10.0)
+        .set(surface.padding_widths.bottom, 6.0)
+        .set(surface.padding_widths.left, 10.0)
+        .set(surface.corner_radii.top_left, CornerRadius::circular(8.0))
+        .set(surface.corner_radii.top_right, CornerRadius::circular(8.0))
+        .set(
+            surface.corner_radii.bottom_right,
+            CornerRadius::new(12.0, 6.0),
+        )
+        .set(
+            surface.corner_radii.bottom_left,
+            CornerRadius::new(12.0, 6.0),
+        )
+        .set(surface.corner_shapes.top_left, CornerShape::squircle())
+        .set(surface.corner_shapes.top_right, CornerShape::squircle())
+        .build();
+    let cascade = StyleCascadeBuilder::new()
+        .push_style(StyleOrigin::Base, button_style)
+        .build();
+
+    let theme = ThemeBuilder::new().build();
+    let cx = ResolveCx::new(&registry, &theme, NoResolveParentLookup);
+    let button = Widget::new(42);
+
+    let resolved_surface = surface.resolve_surface(
+        &cx,
+        &button,
+        Some(StyleMatch::new(&cascade, cascade.root_state())),
+    );
+    let geometry = resolved_surface.decoration_geometry(Rect::new(0.0, 0.0, 120.0, 44.0));
+
+    let mut presentation: PresentationStore<u32, u32> = PresentationStore::new();
+    presentation.insert(1, button.key());
+    *presentation
+        .surface_mut(1)
+        .expect("presentation node was inserted") = resolved_surface;
+
+    let dirty: Vec<_> = presentation.take_dirty().collect();
+    println!("dirty presentation nodes: {dirty:?}");
+    println!(
+        "visible border widths: {:?}",
+        presentation
+            .node(1)
+            .and_then(|node| node.surface())
+            .map(|surface| surface.border.visible_widths())
+            .unwrap_or(Edges::ZERO)
+    );
+    println!(
+        "padding box after border widths: {:?}",
+        geometry.padding_box
+    );
+    println!(
+        "content box after padding widths: {:?}",
+        geometry.content_box
+    );
+    println!("fitted border contour: {:?}", geometry.border_edge);
+}

--- a/understory_box_decoration/CHANGELOG.md
+++ b/understory_box_decoration/CHANGELOG.md
@@ -1,0 +1,38 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+Understory Box Decoration has not had a published release yet.
+
+## [Unreleased]
+
+### Added
+
+- Added the initial `understory_box_decoration` crate with `no_std` resolved
+  geometry primitives for CSS-style box decorations.
+- Added `Edges`, `Corners`, `CornerRadii`, `CornerShape`, `Superellipse`,
+  `BoxContour`, and `BoxDecorationGeometry` for resolved physical edge widths,
+  fitted elliptical corner radii, shaped corner contours, derived
+  border/padding/content geometry, and on-demand Kurbo path writing.
+- Added `Side`, `BoxArea`, and `BorderSideGeometry` for physical box-area
+  selection and central border-side regions.
+- Added CSS specification baseline documentation for CSS Backgrounds and
+  Borders Level 3 contours, plus initial CSS Borders and Box Decorations Level
+  4 `corner-shape` / superellipse coverage and a roadmap for broader Level 4
+  features.
+
+### Changed
+
+- Made the default feature set `libm` instead of `std` so the crate remains
+  `no_std`-friendly by default while still forwarding Kurbo floating-point
+  support.
+
+[Unreleased]: https://github.com/forest-rs/understory/compare/HEAD
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/understory_box_decoration/Cargo.toml
+++ b/understory_box_decoration/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "understory_box_decoration"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Renderer-neutral box decoration geometry primitives."
+readme = "README.md"
+keywords = ["box", "css", "geometry", "graphics", "ui"]
+categories = ["graphics", "gui", "no-std"]
+
+[features]
+default = ["libm"]
+std = ["kurbo/std"]
+libm = ["kurbo/libm"]
+
+[dependencies]
+kurbo.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_box_decoration/LICENSE-APACHE
+++ b/understory_box_decoration/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/understory_box_decoration/LICENSE-MIT
+++ b/understory_box_decoration/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/understory_box_decoration/README.md
+++ b/understory_box_decoration/README.md
@@ -29,6 +29,11 @@ on-demand path emission. It deliberately leaves style cascade, CSS parsing,
 layout, brushes, images, hit policy, and renderer command emission to
 higher-level crates.
 
+If those values come from dependency properties, use
+`understory_presentation_properties` to register canonical surface
+properties and resolve them into `understory_presentation` primitives before
+asking this crate for final geometry.
+
 The first implemented contour family covers CSS-style box contours with
 elliptical radii and shaped corners. It supports round, square, bevel, and
 superellipse-based corner shapes, scales adjacent radii with the CSS

--- a/understory_box_decoration/README.md
+++ b/understory_box_decoration/README.md
@@ -1,0 +1,143 @@
+<div align="center">
+
+# Understory Box Decoration
+
+**Renderer-neutral box decoration geometry primitives**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_box_decoration.svg)](https://crates.io/crates/understory_box_decoration)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_box_decoration.svg)](https://docs.rs/understory_box_decoration)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/forest-rs/understory/ci.yml?logo=github&label=CI)](https://github.com/forest-rs/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_box_decoration --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Renderer-neutral box decoration geometry primitives.
+
+`understory_box_decoration` owns resolved geometry for painted boxes:
+physical edge widths, box-area contours, corner shapes, side regions, and
+on-demand path emission. It deliberately leaves style cascade, CSS parsing,
+layout, brushes, images, hit policy, and renderer command emission to
+higher-level crates.
+
+The first implemented contour family covers CSS-style box contours with
+elliptical radii and shaped corners. It supports round, square, bevel, and
+superellipse-based corner shapes, scales adjacent radii with the CSS
+smallest factor rule when they would overlap a side, and derives padding
+and content contours from concrete border and padding widths.
+
+## Specification baseline
+
+The current API is based on the box contour pieces of
+[CSS Backgrounds and Borders Module Level 3], specifically the
+`border-radius` model, elliptical corner radii, inner edge derivation, and
+the radius overlap reduction rule for adjacent corners.
+
+[CSS Borders and Box Decorations Module Level 4] informs the contour model,
+especially `corner-shape` and superellipse corners. Larger Level 4 features
+such as `border-shape`, partial borders, and richer shadow controls remain
+roadmap material. This crate is intended to grow toward those features
+while keeping style parsing and renderer lowering outside the crate
+boundary.
+
+## Minimal example
+
+```rust
+use kurbo::{BezPath, Rect, Size};
+use understory_box_decoration::{
+    BoxArea, BoxDecorationGeometry, CornerRadii, CornerShape, CornerShapes,
+    Edges,
+};
+
+let geometry = BoxDecorationGeometry::from_border_box(
+    Rect::new(0.0, 0.0, 120.0, 80.0),
+    Edges::all(4.0),
+    Edges::all(8.0),
+    CornerRadii::all(Size::new(18.0, 12.0)),
+    CornerShapes::all(CornerShape::squircle()),
+);
+
+assert_eq!(geometry.padding_box, Rect::new(4.0, 4.0, 116.0, 76.0));
+assert_eq!(geometry.content_box, Rect::new(12.0, 12.0, 108.0, 68.0));
+
+// A renderer can reuse path storage while asking for the concrete paths it
+// needs for a fill, clip, border, shadow, or hit region.
+let mut clip_path = BezPath::new();
+geometry.write_background_clip(BoxArea::Padding, &mut clip_path);
+
+let mut border_path = BezPath::new();
+geometry.write_border_ring_path(&mut border_path);
+assert!(!clip_path.is_empty());
+assert!(!border_path.is_empty());
+```
+
+## Boundary and invariants
+
+This crate treats inputs as already resolved into local coordinate units.
+Constructors harden those inputs for geometry consumers:
+
+- rectangles are normalized to non-negative width and height;
+- negative or non-finite border widths become zero;
+- negative or non-finite padding widths become zero;
+- negative or non-finite radii become zero;
+- border-edge radii are scaled so top, right, bottom, and left side pairs
+  fit;
+- padding and content edge radii are derived from the previous contour's
+  radii and then scaled to fit their own boxes.
+
+The crate itself is `#![no_std]`. The default `libm` feature forwards to
+Kurbo's libm-backed floating point helpers so ordinary builds remain
+`no_std`-friendly. Enable the `std` feature when an application wants
+Kurbo's standard-library support.
+
+## Roadmap
+
+Near-term work should add resolved length-percentage radii so CSS parsing
+layers can defer percentage resolution until the border box is known. After
+that, the natural coverage expansion is corner transition regions,
+`box-shadow` spread geometry, and richer background painting areas. Level 4
+`border-shape` should probably consume a separate CSS-shapes value crate
+rather than making this crate own every shape syntax.
+
+[CSS Backgrounds and Borders Module Level 3]: https://www.w3.org/TR/css-backgrounds-3/#border-radius
+[CSS Borders and Box Decorations Module Level 4]: https://drafts.csswg.org/css-borders-4/
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>), or
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>),
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+[LICENSE-APACHE]: https://github.com/forest-rs/understory/blob/main/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/forest-rs/understory/blob/main/LICENSE-MIT
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: https://github.com/forest-rs/understory/blob/main/AUTHORS

--- a/understory_box_decoration/src/contour.rs
+++ b/understory_box_decoration/src/contour.rs
@@ -1,0 +1,174 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use kurbo::{BezPath, Point, Rect, RoundedRect, Size};
+
+use crate::path::write_contour_path;
+use crate::util::{clean_size, normalize_rect};
+use crate::{CornerRadii, CornerShape, CornerShapes, Corners, Side};
+
+/// One resolved corner of a box contour.
+///
+/// A corner combines the fitted radius area with the shape used inside that
+/// area. `radii.width` is the horizontal radius and `radii.height` is the
+/// vertical radius in the contour's local coordinate space.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ResolvedCorner {
+    /// Horizontal and vertical corner radii.
+    pub radii: Size,
+    /// Shape used inside the radius area.
+    pub shape: CornerShape,
+}
+
+impl ResolvedCorner {
+    /// A square, zero-radius corner.
+    pub const ZERO: Self = Self::new(Size::ZERO, CornerShape::Round);
+
+    /// Creates a resolved corner from radii and a shape.
+    #[must_use]
+    pub const fn new(radii: Size, shape: CornerShape) -> Self {
+        Self {
+            radii: clean_size(radii),
+            shape,
+        }
+    }
+}
+
+impl Default for ResolvedCorner {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+/// A resolved physical contour for one box edge.
+///
+/// A contour is not a materialized path. It stores the rectangle plus the
+/// resolved corner parameters needed to write paths for fills, clips, borders,
+/// shadows, or hit regions on demand.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct BoxContour {
+    /// Rectangular edge before corner shaping.
+    pub rect: Rect,
+    /// Resolved corner parameters in physical corner order.
+    pub corners: Corners<ResolvedCorner>,
+}
+
+impl BoxContour {
+    /// Creates a contour from already-fitted corner geometry.
+    #[must_use]
+    pub fn new(rect: Rect, corners: Corners<ResolvedCorner>) -> Self {
+        Self {
+            rect: normalize_rect(rect),
+            corners,
+        }
+    }
+
+    /// Creates a contour from fitted radii and physical corner shapes.
+    #[must_use]
+    pub fn from_radii(rect: Rect, radii: CornerRadii, shapes: CornerShapes) -> Self {
+        Self::new(
+            rect,
+            Corners::new(
+                ResolvedCorner::new(radii.top_left, shapes.top_left),
+                ResolvedCorner::new(radii.top_right, shapes.top_right),
+                ResolvedCorner::new(radii.bottom_right, shapes.bottom_right),
+                ResolvedCorner::new(radii.bottom_left, shapes.bottom_left),
+            ),
+        )
+    }
+
+    /// Returns this contour's radii without shape information.
+    #[must_use]
+    pub const fn radii(self) -> CornerRadii {
+        CornerRadii::new(
+            self.corners.top_left.radii,
+            self.corners.top_right.radii,
+            self.corners.bottom_right.radii,
+            self.corners.bottom_left.radii,
+        )
+    }
+
+    /// Appends this contour as a closed path.
+    ///
+    /// The path is appended to `out`; callers that want only this contour
+    /// should clear or create their [`BezPath`] before calling.
+    pub fn write_path(self, out: &mut BezPath) {
+        write_contour_path(self, out);
+    }
+
+    /// Builds a new closed path for this contour.
+    ///
+    /// Prefer [`BoxContour::write_path`] in hot paths so the caller can reuse
+    /// path storage.
+    #[must_use]
+    pub fn to_path(self) -> BezPath {
+        let mut path = BezPath::new();
+        self.write_path(&mut path);
+        path
+    }
+
+    /// Return a Kurbo rounded rectangle when every corner is round and
+    /// circular.
+    #[must_use]
+    pub fn rounded_rect(self) -> Option<RoundedRect> {
+        if self.corners.top_left.shape != CornerShape::Round
+            || self.corners.top_right.shape != CornerShape::Round
+            || self.corners.bottom_right.shape != CornerShape::Round
+            || self.corners.bottom_left.shape != CornerShape::Round
+        {
+            return None;
+        }
+
+        self.radii().to_kurbo_rounded_rect(self.rect)
+    }
+
+    /// Returns the straight span on one side between adjacent corner areas.
+    ///
+    /// This is useful for side-oriented border lowering. It deliberately names
+    /// only the central side span; corner transition regions are separate
+    /// future geometry, because CSS leaves color/style transitions in rounded
+    /// corners implementation-defined.
+    #[must_use]
+    pub fn side_span(self, side: Side) -> ContourSideSpan {
+        let rect = self.rect;
+        let radii = self.radii();
+        match side {
+            Side::Top => ContourSideSpan::new(
+                Point::new(rect.x0 + radii.top_left.width, rect.y0),
+                Point::new(rect.x1 - radii.top_right.width, rect.y0),
+            ),
+            Side::Right => ContourSideSpan::new(
+                Point::new(rect.x1, rect.y0 + radii.top_right.height),
+                Point::new(rect.x1, rect.y1 - radii.bottom_right.height),
+            ),
+            Side::Bottom => ContourSideSpan::new(
+                Point::new(rect.x1 - radii.bottom_right.width, rect.y1),
+                Point::new(rect.x0 + radii.bottom_left.width, rect.y1),
+            ),
+            Side::Left => ContourSideSpan::new(
+                Point::new(rect.x0, rect.y1 - radii.bottom_left.height),
+                Point::new(rect.x0, rect.y0 + radii.top_left.height),
+            ),
+        }
+    }
+}
+
+/// The straight portion of one side of a contour.
+///
+/// Spans follow clockwise path order: top left-to-right, right top-to-bottom,
+/// bottom right-to-left, and left bottom-to-top.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ContourSideSpan {
+    /// First point of the side span in clockwise contour order.
+    pub start: Point,
+    /// Last point of the side span in clockwise contour order.
+    pub end: Point,
+}
+
+impl ContourSideSpan {
+    /// Creates a side span from two points.
+    #[must_use]
+    pub const fn new(start: Point, end: Point) -> Self {
+        Self { start, end }
+    }
+}

--- a/understory_box_decoration/src/edges.rs
+++ b/understory_box_decoration/src/edges.rs
@@ -1,0 +1,91 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::util::finite_non_negative;
+
+/// Widths or offsets for the four edges of a rectangular box.
+///
+/// The field names follow CSS and Kurbo's usual y-down coordinate naming:
+/// `top` is the smaller y edge and `bottom` is the larger y edge. `Edges<f64>`
+/// is used for border widths, but the type is generic so callers can use the
+/// same shape for edge-associated metadata.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Edges<T> {
+    /// Value associated with the top edge.
+    pub top: T,
+    /// Value associated with the right edge.
+    pub right: T,
+    /// Value associated with the bottom edge.
+    pub bottom: T,
+    /// Value associated with the left edge.
+    pub left: T,
+}
+
+impl<T: Copy> Edges<T> {
+    /// Create edge values in top, right, bottom, left order.
+    pub const fn new(top: T, right: T, bottom: T, left: T) -> Self {
+        Self {
+            top,
+            right,
+            bottom,
+            left,
+        }
+    }
+
+    /// Use one value for every edge.
+    pub const fn all(value: T) -> Self {
+        Self::new(value, value, value, value)
+    }
+
+    /// Use one value for vertical edges and one for horizontal edges.
+    ///
+    /// This matches CSS two-value shorthand order: top/bottom first, then
+    /// right/left.
+    pub const fn vertical_horizontal(vertical: T, horizontal: T) -> Self {
+        Self::new(vertical, horizontal, vertical, horizontal)
+    }
+}
+
+impl Edges<f64> {
+    /// Edge widths with every side set to zero.
+    pub const ZERO: Self = Self::new(0.0, 0.0, 0.0, 0.0);
+
+    /// Sum of left and right values.
+    pub const fn horizontal(self) -> f64 {
+        self.left + self.right
+    }
+
+    /// Sum of top and bottom values.
+    pub const fn vertical(self) -> f64 {
+        self.top + self.bottom
+    }
+
+    /// Return true when any edge has a positive finite value.
+    pub const fn any_positive(self) -> bool {
+        finite_non_negative(self.top) > 0.0
+            || finite_non_negative(self.right) > 0.0
+            || finite_non_negative(self.bottom) > 0.0
+            || finite_non_negative(self.left) > 0.0
+    }
+
+    /// Clamp negative and non-finite values to zero.
+    pub const fn clamped_non_negative(self) -> Self {
+        Self::new(
+            finite_non_negative(self.top),
+            finite_non_negative(self.right),
+            finite_non_negative(self.bottom),
+            finite_non_negative(self.left),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn any_positive_ignores_non_finite_edges() {
+        assert!(!Edges::new(f64::INFINITY, f64::NAN, -1.0, 0.0).any_positive());
+        assert!(Edges::new(f64::INFINITY, f64::NAN, -1.0, 0.5).any_positive());
+    }
+}

--- a/understory_box_decoration/src/geometry.rs
+++ b/understory_box_decoration/src/geometry.rs
@@ -1,0 +1,505 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use kurbo::{BezPath, Point, Rect};
+
+use crate::util::{finite_non_negative, normalize_rect};
+use crate::{BoxArea, BoxContour, CornerRadii, CornerShapes, Edges, Side};
+
+/// Fully resolved geometry for a single box decoration.
+///
+/// The geometry stores contours and scalar parameters, not materialized paths.
+/// Use writer methods such as
+/// [`BoxDecorationGeometry::write_border_ring_path`] and
+/// [`BoxDecorationGeometry::write_background_clip`] when a renderer or hit
+/// tester needs a concrete [`BezPath`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BoxDecorationGeometry {
+    /// Outer border edge in local coordinates.
+    pub border_box: Rect,
+    /// Padding edge in local coordinates.
+    pub padding_box: Rect,
+    /// Content edge in local coordinates.
+    pub content_box: Rect,
+    /// Non-negative border widths for each side.
+    pub border_widths: Edges<f64>,
+    /// Non-negative padding widths for each side.
+    pub padding_widths: Edges<f64>,
+    /// Resolved contour for the border edge.
+    pub border_edge: BoxContour,
+    /// Resolved contour for the padding edge.
+    pub padding_edge: BoxContour,
+    /// Resolved contour for the content edge.
+    pub content_edge: BoxContour,
+}
+
+impl BoxDecorationGeometry {
+    /// Resolve decoration geometry from a border box, edge widths, corner
+    /// radii, and corner shapes.
+    ///
+    /// This is the common entry point for UI presentation layers: layout
+    /// supplies a border box, style supplies physical border/padding widths
+    /// plus corner parameters, and this crate derives the contours a renderer
+    /// needs to paint fills, clips, shadows, and borders.
+    pub fn from_border_box(
+        border_box: Rect,
+        border_widths: Edges<f64>,
+        padding_widths: Edges<f64>,
+        requested_radii: CornerRadii,
+        corner_shapes: CornerShapes,
+    ) -> Self {
+        let border_box = normalize_rect(border_box);
+        let border_widths = border_widths.clamped_non_negative();
+        let padding_widths = padding_widths.clamped_non_negative();
+        let border_radii = requested_radii.scale_to_fit(border_box);
+        let padding_box = inset_rect(border_box, border_widths);
+        let padding_radii = border_radii
+            .inset_by_edges(border_widths)
+            .scale_to_fit(padding_box);
+        let content_box = inset_rect(padding_box, padding_widths);
+        let content_radii = padding_radii
+            .inset_by_edges(padding_widths)
+            .scale_to_fit(content_box);
+
+        let border_edge = BoxContour::from_radii(border_box, border_radii, corner_shapes);
+        let padding_edge = BoxContour::from_radii(padding_box, padding_radii, corner_shapes);
+        let content_edge = BoxContour::from_radii(content_box, content_radii, corner_shapes);
+
+        Self {
+            border_box,
+            padding_box,
+            content_box,
+            border_widths,
+            padding_widths,
+            border_edge,
+            padding_edge,
+            content_edge,
+        }
+    }
+
+    /// Resolve decoration geometry with round corners.
+    #[must_use]
+    pub fn from_round_border_box(
+        border_box: Rect,
+        border_widths: Edges<f64>,
+        padding_widths: Edges<f64>,
+        requested_radii: CornerRadii,
+    ) -> Self {
+        Self::from_border_box(
+            border_box,
+            border_widths,
+            padding_widths,
+            requested_radii,
+            CornerShapes::ROUND,
+        )
+    }
+
+    /// Return true when the border has any positive width.
+    pub const fn has_border_width(self) -> bool {
+        self.border_widths.any_positive()
+    }
+
+    /// Returns the resolved contour for a CSS-style box area.
+    #[must_use]
+    pub const fn contour(self, area: BoxArea) -> BoxContour {
+        match area {
+            BoxArea::Border => self.border_edge,
+            BoxArea::Padding => self.padding_edge,
+            BoxArea::Content => self.content_edge,
+        }
+    }
+
+    /// Appends a compound path for the border ring.
+    ///
+    /// This writes the outer border contour and inner padding contour as two
+    /// closed subpaths with the same winding direction. Renderers **must** use
+    /// an even-odd fill rule, or an equivalent path-difference operation, to
+    /// paint this as a hollow border ring. A default nonzero fill will also
+    /// fill the inner padding contour.
+    ///
+    /// The method appends to `out` so hot paths can reuse path storage instead
+    /// of allocating a new path for every box.
+    pub fn write_border_ring_path(self, out: &mut BezPath) {
+        self.border_edge.write_path(out);
+        self.padding_edge.write_path(out);
+    }
+
+    /// Appends a closed path for the requested background clip area.
+    pub fn write_background_clip(self, area: BoxArea, out: &mut BezPath) {
+        self.contour(area).write_path(out);
+    }
+
+    /// Builds a new even-odd compound path for the border ring.
+    ///
+    /// Prefer [`BoxDecorationGeometry::write_border_ring_path`] in hot paths,
+    /// and remember that the returned path must be filled with an even-odd fill
+    /// rule to remain hollow.
+    #[must_use]
+    pub fn to_border_ring_path(self) -> BezPath {
+        let mut path = BezPath::new();
+        self.write_border_ring_path(&mut path);
+        path
+    }
+
+    /// Returns the central side region for one physical border side.
+    ///
+    /// The returned region spans between the matching straight side spans of
+    /// the border and padding contours. It intentionally does not include
+    /// corner transition regions, because CSS leaves rounded-corner
+    /// color/style transitions implementation-defined.
+    #[must_use]
+    pub fn border_side_region(self, side: Side) -> BorderSideGeometry {
+        let outer = self.border_edge.side_span(side);
+        let inner = self.padding_edge.side_span(side);
+        let width = match side {
+            Side::Top => self.border_widths.top,
+            Side::Right => self.border_widths.right,
+            Side::Bottom => self.border_widths.bottom,
+            Side::Left => self.border_widths.left,
+        };
+
+        BorderSideGeometry {
+            side,
+            width,
+            outer_start: outer.start,
+            outer_end: outer.end,
+            inner_start: inner.start,
+            inner_end: inner.end,
+            bounds: bounds_for_points([outer.start, outer.end, inner.start, inner.end]),
+        }
+    }
+}
+
+/// Central geometry for one physical border side.
+///
+/// This describes the side band between the straight spans of the outer border
+/// contour and inner padding contour. It is suitable for simple side-aware
+/// lowerers and leaves corner transition regions for a richer future API.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BorderSideGeometry {
+    /// Physical side represented by this region.
+    pub side: Side,
+    /// Visible border width for this side.
+    pub width: f64,
+    /// First point on the outer contour side span.
+    pub outer_start: Point,
+    /// Last point on the outer contour side span.
+    pub outer_end: Point,
+    /// First point on the inner contour side span.
+    pub inner_start: Point,
+    /// Last point on the inner contour side span.
+    pub inner_end: Point,
+    /// Axis-aligned bounds of the four side-region points.
+    pub bounds: Rect,
+}
+
+impl BorderSideGeometry {
+    /// Returns true when this side has no positive border width.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        !self.width.is_finite() || self.width <= 0.0
+    }
+
+    /// Appends this side region as a closed quadrilateral.
+    ///
+    /// The path is appended to `out`; callers that want only this region
+    /// should clear or create their [`BezPath`] before calling.
+    pub fn write_path(self, out: &mut BezPath) {
+        out.move_to(self.outer_start);
+        out.line_to(self.outer_end);
+        out.line_to(self.inner_end);
+        out.line_to(self.inner_start);
+        out.close_path();
+    }
+}
+
+/// Return `rect` inset by `edges`, clamping overlarge insets to a zero-size
+/// rectangle on each over-constrained axis.
+///
+/// When the left and right insets exceed the rectangle width, the resulting
+/// x coordinates collapse proportionally between the two inset requests.
+/// The same rule is applied independently to the y axis.
+pub fn inset_rect(rect: Rect, edges: Edges<f64>) -> Rect {
+    let rect = normalize_rect(rect);
+    let edges = edges.clamped_non_negative();
+    let (x0, x1) = inset_axis(rect.x0, rect.x1, edges.left, edges.right);
+    let (y0, y1) = inset_axis(rect.y0, rect.y1, edges.top, edges.bottom);
+    Rect::new(x0, y0, x1, y1)
+}
+
+fn inset_axis(min: f64, max: f64, before: f64, after: f64) -> (f64, f64) {
+    let extent = finite_non_negative(max - min);
+    let sum = before + after;
+
+    if extent <= 0.0 {
+        let point = (min + max) * 0.5;
+        (point, point)
+    } else if sum >= extent && sum > 0.0 {
+        let point = min + extent * (before / sum);
+        (point, point)
+    } else {
+        (min + before, max - after)
+    }
+}
+
+fn bounds_for_points(points: [Point; 4]) -> Rect {
+    let mut x0 = points[0].x;
+    let mut y0 = points[0].y;
+    let mut x1 = points[0].x;
+    let mut y1 = points[0].y;
+
+    for point in points.into_iter().skip(1) {
+        x0 = x0.min(point.x);
+        y0 = y0.min(point.y);
+        x1 = x1.max(point.x);
+        y1 = y1.max(point.y);
+    }
+
+    Rect::new(x0, y0, x1, y1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kurbo::{PathEl, Size};
+
+    #[test]
+    fn geometry_derives_border_padding_and_content_contours() {
+        let geometry = BoxDecorationGeometry::from_round_border_box(
+            Rect::new(0.0, 0.0, 100.0, 50.0),
+            Edges::new(4.0, 6.0, 8.0, 10.0),
+            Edges::new(2.0, 3.0, 4.0, 5.0),
+            CornerRadii::uniform(20.0),
+        );
+
+        assert_eq!(geometry.padding_box, Rect::new(10.0, 4.0, 94.0, 42.0));
+        assert_eq!(geometry.content_box, Rect::new(15.0, 6.0, 91.0, 38.0));
+        assert_eq!(
+            geometry.padding_edge.radii(),
+            CornerRadii::new(
+                Size::new(10.0, 16.0),
+                Size::new(14.0, 16.0),
+                Size::new(14.0, 12.0),
+                Size::new(10.0, 12.0),
+            ),
+        );
+        assert_eq!(
+            geometry.content_edge.radii(),
+            CornerRadii::new(
+                Size::new(5.0, 14.0),
+                Size::new(11.0, 14.0),
+                Size::new(11.0, 8.0),
+                Size::new(5.0, 8.0),
+            ),
+        );
+    }
+
+    #[test]
+    fn write_border_ring_path_appends_outer_and_inner_subpaths() {
+        let geometry = BoxDecorationGeometry::from_round_border_box(
+            Rect::new(0.0, 0.0, 100.0, 50.0),
+            Edges::all(4.0),
+            Edges::ZERO,
+            CornerRadii::uniform(12.0),
+        );
+
+        let mut path = BezPath::new();
+        geometry.write_border_ring_path(&mut path);
+        let close_count = path
+            .iter()
+            .filter(|el| matches!(el, PathEl::ClosePath))
+            .count();
+        assert_eq!(close_count, 2);
+    }
+
+    #[test]
+    fn overlarge_insets_collapse_proportionally() {
+        let inset = inset_rect(
+            Rect::new(0.0, 0.0, 100.0, 50.0),
+            Edges::new(40.0, 80.0, 20.0, 120.0),
+        );
+
+        assert_eq!(
+            inset,
+            Rect::new(60.0, 33.333_333_333_333_33, 60.0, 33.333_333_333_333_33,),
+        );
+    }
+
+    #[test]
+    fn negative_and_non_finite_values_are_hardened() {
+        let geometry = BoxDecorationGeometry::from_round_border_box(
+            Rect::new(0.0, 0.0, 100.0, 50.0),
+            Edges::new(-1.0, f64::INFINITY, f64::NAN, 2.0),
+            Edges::new(1.0, f64::NAN, f64::INFINITY, -1.0),
+            CornerRadii::new(
+                Size::new(-1.0, 10.0),
+                Size::new(f64::INFINITY, 10.0),
+                Size::new(10.0, f64::NAN),
+                Size::new(10.0, 10.0),
+            ),
+        );
+
+        assert_eq!(geometry.border_widths, Edges::new(0.0, 0.0, 0.0, 2.0));
+        assert_eq!(geometry.padding_widths, Edges::new(1.0, 0.0, 0.0, 0.0));
+        assert_eq!(
+            geometry.border_edge.corners.top_left.radii,
+            Size::new(0.0, 10.0)
+        );
+        assert_eq!(
+            geometry.border_edge.corners.top_right.radii,
+            Size::new(0.0, 10.0)
+        );
+        assert_eq!(
+            geometry.border_edge.corners.bottom_right.radii,
+            Size::new(10.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn zero_size_boxes_collapse_radii_and_keep_paths_finite() {
+        let geometry = BoxDecorationGeometry::from_round_border_box(
+            Rect::new(5.0, 5.0, 5.0, 5.0),
+            Edges::all(8.0),
+            Edges::all(4.0),
+            CornerRadii::all(Size::new(10.0, 20.0)),
+        );
+
+        assert_eq!(geometry.border_box, Rect::new(5.0, 5.0, 5.0, 5.0));
+        assert_eq!(geometry.padding_box, Rect::new(5.0, 5.0, 5.0, 5.0));
+        assert_eq!(geometry.content_box, Rect::new(5.0, 5.0, 5.0, 5.0));
+        assert_eq!(geometry.border_edge.radii(), CornerRadii::ZERO);
+        assert_eq!(geometry.padding_edge.radii(), CornerRadii::ZERO);
+        assert_eq!(geometry.content_edge.radii(), CornerRadii::ZERO);
+        assert!(path_is_finite(&geometry.border_edge.to_path()));
+        assert!(path_is_finite(&geometry.padding_edge.to_path()));
+        assert!(path_is_finite(&geometry.to_border_ring_path()));
+    }
+
+    #[test]
+    fn background_clip_uses_named_box_area_contours() {
+        let geometry = BoxDecorationGeometry::from_round_border_box(
+            Rect::new(0.0, 0.0, 100.0, 80.0),
+            Edges::all(10.0),
+            Edges::all(5.0),
+            CornerRadii::uniform(16.0),
+        );
+
+        let mut content_clip = BezPath::new();
+        geometry.write_background_clip(BoxArea::Content, &mut content_clip);
+
+        assert_eq!(
+            geometry.contour(BoxArea::Content).rect,
+            geometry.content_box
+        );
+        assert!(path_is_finite(&content_clip));
+    }
+
+    #[test]
+    fn non_round_corner_shapes_write_finite_closed_paths() {
+        let geometry = BoxDecorationGeometry::from_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(6.0),
+            Edges::all(4.0),
+            CornerRadii::all(Size::new(24.0, 16.0)),
+            CornerShapes::new(
+                crate::CornerShape::Square,
+                crate::CornerShape::Bevel,
+                crate::CornerShape::squircle(),
+                crate::CornerShape::scoop(),
+            ),
+        );
+
+        let path = geometry.border_edge.to_path();
+        let close_count = path
+            .iter()
+            .filter(|el| matches!(el, PathEl::ClosePath))
+            .count();
+
+        assert_eq!(close_count, 1);
+        assert_eq!(
+            geometry.border_edge.corners.top_left.shape,
+            crate::CornerShape::Square
+        );
+        assert_eq!(
+            geometry.border_edge.corners.bottom_left.shape,
+            crate::CornerShape::scoop()
+        );
+        assert!(path_is_finite(&path));
+    }
+
+    #[test]
+    fn explicit_round_superellipse_writes_round_corners() {
+        let geometry = BoxDecorationGeometry::from_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::ZERO,
+            Edges::ZERO,
+            CornerRadii::uniform(12.0),
+            CornerShapes::all(crate::CornerShape::Superellipse(crate::Superellipse::ROUND)),
+        );
+
+        let path = geometry.border_edge.to_path();
+        assert!(path.iter().any(|el| matches!(el, PathEl::CurveTo(..))));
+        assert!(path_is_finite(&path));
+    }
+
+    #[test]
+    fn side_regions_follow_central_contour_spans() {
+        let geometry = BoxDecorationGeometry::from_round_border_box(
+            Rect::new(0.0, 0.0, 100.0, 50.0),
+            Edges::new(4.0, 6.0, 8.0, 10.0),
+            Edges::ZERO,
+            CornerRadii::uniform(12.0),
+        );
+
+        let top = geometry.border_side_region(Side::Top);
+
+        assert_eq!(top.width, 4.0);
+        assert!(!top.is_empty());
+        assert_eq!(top.outer_start, Point::new(12.0, 0.0));
+        assert_eq!(top.outer_end, Point::new(88.0, 0.0));
+        assert_eq!(top.inner_start, Point::new(12.0, 4.0));
+        assert_eq!(top.inner_end, Point::new(88.0, 4.0));
+
+        let mut path = BezPath::new();
+        top.write_path(&mut path);
+        assert!(path_is_finite(&path));
+    }
+
+    #[test]
+    fn side_regions_with_non_finite_widths_are_empty() {
+        let side = BorderSideGeometry {
+            side: Side::Top,
+            width: f64::NAN,
+            outer_start: Point::ZERO,
+            outer_end: Point::ZERO,
+            inner_start: Point::ZERO,
+            inner_end: Point::ZERO,
+            bounds: Rect::ZERO,
+        };
+
+        assert!(side.is_empty());
+    }
+
+    fn path_is_finite(path: &BezPath) -> bool {
+        path.iter().all(|element| match element {
+            PathEl::MoveTo(point) | PathEl::LineTo(point) => {
+                point.x.is_finite() && point.y.is_finite()
+            }
+            PathEl::QuadTo(control, point) => {
+                control.x.is_finite()
+                    && control.y.is_finite()
+                    && point.x.is_finite()
+                    && point.y.is_finite()
+            }
+            PathEl::CurveTo(control_0, control_1, point) => {
+                control_0.x.is_finite()
+                    && control_0.y.is_finite()
+                    && control_1.x.is_finite()
+                    && control_1.y.is_finite()
+                    && point.x.is_finite()
+                    && point.y.is_finite()
+            }
+            PathEl::ClosePath => true,
+        })
+    }
+}

--- a/understory_box_decoration/src/lib.rs
+++ b/understory_box_decoration/src/lib.rs
@@ -1,0 +1,113 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=understory_box_decoration --heading-base-level=0
+
+//! Renderer-neutral box decoration geometry primitives.
+//!
+//! `understory_box_decoration` owns resolved geometry for painted boxes:
+//! physical edge widths, box-area contours, corner shapes, side regions, and
+//! on-demand path emission. It deliberately leaves style cascade, CSS parsing,
+//! layout, brushes, images, hit policy, and renderer command emission to
+//! higher-level crates.
+//!
+//! The first implemented contour family covers CSS-style box contours with
+//! elliptical radii and shaped corners. It supports round, square, bevel, and
+//! superellipse-based corner shapes, scales adjacent radii with the CSS
+//! smallest factor rule when they would overlap a side, and derives padding
+//! and content contours from concrete border and padding widths.
+//!
+//! ## Specification baseline
+//!
+//! The current API is based on the box contour pieces of
+//! [CSS Backgrounds and Borders Module Level 3], specifically the
+//! `border-radius` model, elliptical corner radii, inner edge derivation, and
+//! the radius overlap reduction rule for adjacent corners.
+//!
+//! [CSS Borders and Box Decorations Module Level 4] informs the contour model,
+//! especially `corner-shape` and superellipse corners. Larger Level 4 features
+//! such as `border-shape`, partial borders, and richer shadow controls remain
+//! roadmap material. This crate is intended to grow toward those features
+//! while keeping style parsing and renderer lowering outside the crate
+//! boundary.
+//!
+//! ## Minimal example
+//!
+//! ```rust
+//! use kurbo::{BezPath, Rect, Size};
+//! use understory_box_decoration::{
+//!     BoxArea, BoxDecorationGeometry, CornerRadii, CornerShape, CornerShapes,
+//!     Edges,
+//! };
+//!
+//! let geometry = BoxDecorationGeometry::from_border_box(
+//!     Rect::new(0.0, 0.0, 120.0, 80.0),
+//!     Edges::all(4.0),
+//!     Edges::all(8.0),
+//!     CornerRadii::all(Size::new(18.0, 12.0)),
+//!     CornerShapes::all(CornerShape::squircle()),
+//! );
+//!
+//! assert_eq!(geometry.padding_box, Rect::new(4.0, 4.0, 116.0, 76.0));
+//! assert_eq!(geometry.content_box, Rect::new(12.0, 12.0, 108.0, 68.0));
+//!
+//! // A renderer can reuse path storage while asking for the concrete paths it
+//! // needs for a fill, clip, border, shadow, or hit region.
+//! let mut clip_path = BezPath::new();
+//! geometry.write_background_clip(BoxArea::Padding, &mut clip_path);
+//!
+//! let mut border_path = BezPath::new();
+//! geometry.write_border_ring_path(&mut border_path);
+//! assert!(!clip_path.is_empty());
+//! assert!(!border_path.is_empty());
+//! ```
+//!
+//! ## Boundary and invariants
+//!
+//! This crate treats inputs as already resolved into local coordinate units.
+//! Constructors harden those inputs for geometry consumers:
+//!
+//! - rectangles are normalized to non-negative width and height;
+//! - negative or non-finite border widths become zero;
+//! - negative or non-finite padding widths become zero;
+//! - negative or non-finite radii become zero;
+//! - border-edge radii are scaled so top, right, bottom, and left side pairs
+//!   fit;
+//! - padding and content edge radii are derived from the previous contour's
+//!   radii and then scaled to fit their own boxes.
+//!
+//! The crate itself is `#![no_std]`. The default `libm` feature forwards to
+//! Kurbo's libm-backed floating point helpers so ordinary builds remain
+//! `no_std`-friendly. Enable the `std` feature when an application wants
+//! Kurbo's standard-library support.
+//!
+//! ## Roadmap
+//!
+//! Near-term work should add resolved length-percentage radii so CSS parsing
+//! layers can defer percentage resolution until the border box is known. After
+//! that, the natural coverage expansion is corner transition regions,
+//! `box-shadow` spread geometry, and richer background painting areas. Level 4
+//! `border-shape` should probably consume a separate CSS-shapes value crate
+//! rather than making this crate own every shape syntax.
+//!
+//! [CSS Backgrounds and Borders Module Level 3]: https://www.w3.org/TR/css-backgrounds-3/#border-radius
+//! [CSS Borders and Box Decorations Module Level 4]: https://drafts.csswg.org/css-borders-4/
+
+#![no_std]
+
+mod contour;
+mod edges;
+mod geometry;
+mod path;
+mod radii;
+mod shape;
+mod side;
+mod util;
+
+pub use contour::{BoxContour, ContourSideSpan, ResolvedCorner};
+pub use edges::Edges;
+pub use geometry::{BorderSideGeometry, BoxDecorationGeometry, inset_rect};
+pub use radii::{CornerRadii, Corners};
+pub use shape::{CornerShape, CornerShapes, Superellipse};
+pub use side::{BoxArea, Side};

--- a/understory_box_decoration/src/lib.rs
+++ b/understory_box_decoration/src/lib.rs
@@ -12,6 +12,11 @@
 //! layout, brushes, images, hit policy, and renderer command emission to
 //! higher-level crates.
 //!
+//! If those values come from dependency properties, use
+//! `understory_presentation_properties` to register canonical surface
+//! properties and resolve them into `understory_presentation` primitives before
+//! asking this crate for final geometry.
+//!
 //! The first implemented contour family covers CSS-style box contours with
 //! elliptical radii and shaped corners. It supports round, square, bevel, and
 //! superellipse-based corner shapes, scales adjacent radii with the CSS

--- a/understory_box_decoration/src/path.rs
+++ b/understory_box_decoration/src/path.rs
@@ -1,0 +1,235 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[cfg(not(feature = "std"))]
+use kurbo::common::FloatFuncs as _;
+use kurbo::{BezPath, Point, Rect, Size};
+
+use crate::{BoxContour, CornerRadii, CornerShape, ResolvedCorner, Superellipse};
+
+const ARC_KAPPA: f64 = 0.552_284_749_830_793_6;
+const SUPERELLIPSE_SEGMENTS: usize = 12;
+const SUPERELLIPSE_LIMIT: f64 = 10.0;
+
+pub(crate) fn rounded_rect_path(rect: Rect, radii: CornerRadii) -> BezPath {
+    let mut path = BezPath::new();
+    let contour = BoxContour::from_radii(rect, radii, crate::CornerShapes::ROUND);
+    write_contour_path(contour, &mut path);
+    path
+}
+
+pub(crate) fn write_contour_path(contour: BoxContour, path: &mut BezPath) {
+    let rect = contour.rect;
+    let corners = contour.corners;
+
+    path.move_to(Point::new(rect.x0 + corners.top_left.radii.width, rect.y0));
+    path.line_to(Point::new(rect.x1 - corners.top_right.radii.width, rect.y0));
+    append_corner(
+        path,
+        CornerPlacement::TopRight,
+        rect,
+        corners.top_right,
+        Point::new(rect.x1, rect.y0 + corners.top_right.radii.height),
+    );
+
+    path.line_to(Point::new(
+        rect.x1,
+        rect.y1 - corners.bottom_right.radii.height,
+    ));
+    append_corner(
+        path,
+        CornerPlacement::BottomRight,
+        rect,
+        corners.bottom_right,
+        Point::new(rect.x1 - corners.bottom_right.radii.width, rect.y1),
+    );
+
+    path.line_to(Point::new(
+        rect.x0 + corners.bottom_left.radii.width,
+        rect.y1,
+    ));
+    append_corner(
+        path,
+        CornerPlacement::BottomLeft,
+        rect,
+        corners.bottom_left,
+        Point::new(rect.x0, rect.y1 - corners.bottom_left.radii.height),
+    );
+
+    path.line_to(Point::new(rect.x0, rect.y0 + corners.top_left.radii.height));
+    append_corner(
+        path,
+        CornerPlacement::TopLeft,
+        rect,
+        corners.top_left,
+        Point::new(rect.x0 + corners.top_left.radii.width, rect.y0),
+    );
+    path.close_path();
+}
+
+#[derive(Clone, Copy, Debug)]
+enum CornerPlacement {
+    TopRight,
+    BottomRight,
+    BottomLeft,
+    TopLeft,
+}
+
+fn append_corner(
+    path: &mut BezPath,
+    placement: CornerPlacement,
+    rect: Rect,
+    corner: ResolvedCorner,
+    end: Point,
+) {
+    let radii = corner.radii;
+    if radii.width <= 0.0 || radii.height <= 0.0 {
+        path.line_to(end);
+        return;
+    }
+
+    match corner.shape {
+        CornerShape::Round => append_round_corner(path, placement, rect, radii, end),
+        CornerShape::Square => append_square_corner(path, placement, rect, end),
+        CornerShape::Bevel => path.line_to(end),
+        CornerShape::Superellipse(superellipse) => {
+            append_superellipse_corner(path, placement, rect, radii, superellipse, end);
+        }
+    }
+}
+
+fn append_round_corner(
+    path: &mut BezPath,
+    placement: CornerPlacement,
+    rect: Rect,
+    radii: Size,
+    end: Point,
+) {
+    let (control1, control2) = match placement {
+        CornerPlacement::TopRight => (
+            Point::new(rect.x1 - radii.width + ARC_KAPPA * radii.width, rect.y0),
+            Point::new(rect.x1, rect.y0 + radii.height - ARC_KAPPA * radii.height),
+        ),
+        CornerPlacement::BottomRight => (
+            Point::new(rect.x1, rect.y1 - radii.height + ARC_KAPPA * radii.height),
+            Point::new(rect.x1 - radii.width + ARC_KAPPA * radii.width, rect.y1),
+        ),
+        CornerPlacement::BottomLeft => (
+            Point::new(rect.x0 + radii.width - ARC_KAPPA * radii.width, rect.y1),
+            Point::new(rect.x0, rect.y1 - radii.height + ARC_KAPPA * radii.height),
+        ),
+        CornerPlacement::TopLeft => (
+            Point::new(rect.x0, rect.y0 + radii.height - ARC_KAPPA * radii.height),
+            Point::new(rect.x0 + radii.width - ARC_KAPPA * radii.width, rect.y0),
+        ),
+    };
+    path.curve_to(control1, control2, end);
+}
+
+fn append_square_corner(path: &mut BezPath, placement: CornerPlacement, rect: Rect, end: Point) {
+    path.line_to(match placement {
+        CornerPlacement::TopRight => Point::new(rect.x1, rect.y0),
+        CornerPlacement::BottomRight => Point::new(rect.x1, rect.y1),
+        CornerPlacement::BottomLeft => Point::new(rect.x0, rect.y1),
+        CornerPlacement::TopLeft => Point::new(rect.x0, rect.y0),
+    });
+    path.line_to(end);
+}
+
+fn append_notch_corner(
+    path: &mut BezPath,
+    placement: CornerPlacement,
+    rect: Rect,
+    radii: Size,
+    end: Point,
+) {
+    path.line_to(match placement {
+        CornerPlacement::TopRight => Point::new(rect.x1 - radii.width, rect.y0 + radii.height),
+        CornerPlacement::BottomRight => Point::new(rect.x1 - radii.width, rect.y1 - radii.height),
+        CornerPlacement::BottomLeft => Point::new(rect.x0 + radii.width, rect.y1 - radii.height),
+        CornerPlacement::TopLeft => Point::new(rect.x0 + radii.width, rect.y0 + radii.height),
+    });
+    path.line_to(end);
+}
+
+fn append_superellipse_corner(
+    path: &mut BezPath,
+    placement: CornerPlacement,
+    rect: Rect,
+    radii: Size,
+    superellipse: Superellipse,
+    end: Point,
+) {
+    let parameter = superellipse.parameter();
+    if distance(parameter, 1.0) <= 1e-9 {
+        append_round_corner(path, placement, rect, radii, end);
+        return;
+    }
+    if distance(parameter, 0.0) <= 1e-9 {
+        path.line_to(end);
+        return;
+    }
+    if parameter >= SUPERELLIPSE_LIMIT || parameter == f64::INFINITY {
+        append_square_corner(path, placement, rect, end);
+        return;
+    }
+    if parameter <= -SUPERELLIPSE_LIMIT || parameter == f64::NEG_INFINITY {
+        append_notch_corner(path, placement, rect, radii, end);
+        return;
+    }
+
+    let exponent = 2.0_f64.powf(parameter);
+    if !exponent.is_finite() || exponent <= 0.0 {
+        path.line_to(end);
+        return;
+    }
+
+    for i in 1..=SUPERELLIPSE_SEGMENTS {
+        let progress = i as f64 / SUPERELLIPSE_SEGMENTS as f64;
+        let (u, v) = superellipse_point(placement, progress, exponent);
+        path.line_to(point_in_corner(rect, placement, radii, u, v));
+    }
+}
+
+fn superellipse_point(placement: CornerPlacement, progress: f64, exponent: f64) -> (f64, f64) {
+    match placement {
+        CornerPlacement::TopRight => (forward_superellipse(progress, exponent), progress),
+        CornerPlacement::BottomRight => (reverse_superellipse(progress, exponent), progress),
+        CornerPlacement::BottomLeft => {
+            let q = 1.0 - progress;
+            (1.0 - reverse_superellipse(q, exponent), q)
+        }
+        CornerPlacement::TopLeft => (progress, 1.0 - forward_superellipse(progress, exponent)),
+    }
+}
+
+fn forward_superellipse(progress: f64, exponent: f64) -> f64 {
+    let q = 1.0 - progress;
+    positive_unit(1.0 - q.powf(exponent)).powf(1.0 / exponent)
+}
+
+fn reverse_superellipse(progress: f64, exponent: f64) -> f64 {
+    positive_unit(1.0 - progress.powf(exponent)).powf(1.0 / exponent)
+}
+
+fn point_in_corner(rect: Rect, placement: CornerPlacement, radii: Size, u: f64, v: f64) -> Point {
+    let (x0, y0) = match placement {
+        CornerPlacement::TopRight => (rect.x1 - radii.width, rect.y0),
+        CornerPlacement::BottomRight => (rect.x1 - radii.width, rect.y1 - radii.height),
+        CornerPlacement::BottomLeft => (rect.x0, rect.y1 - radii.height),
+        CornerPlacement::TopLeft => (rect.x0, rect.y0),
+    };
+    Point::new(x0 + radii.width * u, y0 + radii.height * v)
+}
+
+fn positive_unit(value: f64) -> f64 {
+    if value.is_nan() {
+        0.0
+    } else {
+        value.clamp(0.0, 1.0)
+    }
+}
+
+fn distance(a: f64, b: f64) -> f64 {
+    if a >= b { a - b } else { b - a }
+}

--- a/understory_box_decoration/src/radii.rs
+++ b/understory_box_decoration/src/radii.rs
@@ -1,0 +1,288 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use kurbo::{BezPath, Rect, RoundedRect, RoundedRectRadii, Size};
+
+use crate::Edges;
+use crate::path::rounded_rect_path;
+use crate::util::{
+    clean_size, distance, finite_non_negative, fit_scale, normalize_rect, scale_size,
+};
+
+const CIRCULAR_EPSILON: f64 = 1e-9;
+
+/// Values for the four physical corners of a rectangular box.
+///
+/// Corner order follows CSS `border-radius`: top-left, top-right,
+/// bottom-right, bottom-left. The type is generic so the same physical
+/// ordering can carry radii, corner shapes, resolved corner geometry, or
+/// property handles.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Corners<T> {
+    /// Value associated with the top-left corner.
+    pub top_left: T,
+    /// Value associated with the top-right corner.
+    pub top_right: T,
+    /// Value associated with the bottom-right corner.
+    pub bottom_right: T,
+    /// Value associated with the bottom-left corner.
+    pub bottom_left: T,
+}
+
+impl<T> Corners<T> {
+    /// Create corner values in top-left, top-right, bottom-right,
+    /// bottom-left order.
+    pub const fn new(top_left: T, top_right: T, bottom_right: T, bottom_left: T) -> Self {
+        Self {
+            top_left,
+            top_right,
+            bottom_right,
+            bottom_left,
+        }
+    }
+}
+
+impl<T: Copy> Corners<T> {
+    /// Use one value for every corner.
+    pub const fn all(value: T) -> Self {
+        Self::new(value, value, value, value)
+    }
+}
+
+/// Elliptical corner radii for a box contour.
+///
+/// Each corner is a [`Size`] where `width` is the horizontal radius and
+/// `height` is the vertical radius. This is more general than Kurbo's
+/// [`RoundedRectRadii`], which stores one circular radius per corner. Use
+/// [`CornerRadii::as_kurbo_radii`] or [`CornerRadii::to_kurbo_rounded_rect`]
+/// when the radii are circular and a renderer can use Kurbo's compact rounded
+/// rectangle type directly.
+pub type CornerRadii = Corners<Size>;
+
+impl CornerRadii {
+    /// Radii with every corner set to zero.
+    pub const ZERO: Self = Self::new(Size::ZERO, Size::ZERO, Size::ZERO, Size::ZERO);
+
+    /// Use the same circular radius for every corner.
+    pub const fn uniform(radius: f64) -> Self {
+        Self::all(Size::new(radius, radius))
+    }
+
+    /// Create circular radii for each corner.
+    ///
+    /// Arguments are in top-left, top-right, bottom-right, bottom-left order.
+    pub const fn circular(
+        top_left: f64,
+        top_right: f64,
+        bottom_right: f64,
+        bottom_left: f64,
+    ) -> Self {
+        Self::new(
+            Size::new(top_left, top_left),
+            Size::new(top_right, top_right),
+            Size::new(bottom_right, bottom_right),
+            Size::new(bottom_left, bottom_left),
+        )
+    }
+
+    /// Clamp negative and non-finite radius components to zero.
+    pub const fn clamped_non_negative(self) -> Self {
+        Self::new(
+            clean_size(self.top_left),
+            clean_size(self.top_right),
+            clean_size(self.bottom_right),
+            clean_size(self.bottom_left),
+        )
+    }
+
+    /// Scale adjacent corner radii so they fit within `rect`.
+    ///
+    /// This follows the CSS border-radius conflict resolution rule: compute
+    /// the ratio for every side whose two adjacent radii exceed the side
+    /// length, then multiply all radii by the smallest ratio. Negative and
+    /// non-finite radius components are treated as zero before scaling.
+    pub fn scale_to_fit(self, rect: Rect) -> Self {
+        let radii = self.clamped_non_negative();
+        let rect = normalize_rect(rect);
+        let width = finite_non_negative(rect.width());
+        let height = finite_non_negative(rect.height());
+
+        let mut scale = 1.0;
+        scale = fit_scale(scale, width, radii.top_left.width + radii.top_right.width);
+        scale = fit_scale(
+            scale,
+            height,
+            radii.top_right.height + radii.bottom_right.height,
+        );
+        scale = fit_scale(
+            scale,
+            width,
+            radii.bottom_left.width + radii.bottom_right.width,
+        );
+        scale = fit_scale(
+            scale,
+            height,
+            radii.top_left.height + radii.bottom_left.height,
+        );
+
+        if scale < 1.0 {
+            radii.scaled(scale)
+        } else {
+            radii
+        }
+    }
+
+    /// Convert to Kurbo's circular per-corner radii when possible.
+    ///
+    /// Returns `None` for elliptical radii because [`RoundedRectRadii`] cannot
+    /// represent them without losing information.
+    pub fn as_kurbo_radii(self) -> Option<RoundedRectRadii> {
+        let radii = self.clamped_non_negative();
+        if is_circular(radii.top_left)
+            && is_circular(radii.top_right)
+            && is_circular(radii.bottom_right)
+            && is_circular(radii.bottom_left)
+        {
+            Some(RoundedRectRadii::new(
+                radii.top_left.width,
+                radii.top_right.width,
+                radii.bottom_right.width,
+                radii.bottom_left.width,
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Convert to Kurbo's rounded rectangle type when the fitted radii are
+    /// circular.
+    ///
+    /// This is useful for renderers that have a fast path for Kurbo
+    /// [`RoundedRect`]. For elliptical radii, use [`CornerRadii::to_path`].
+    pub fn to_kurbo_rounded_rect(self, rect: Rect) -> Option<RoundedRect> {
+        let rect = normalize_rect(rect);
+        self.scale_to_fit(rect)
+            .as_kurbo_radii()
+            .map(|radii| RoundedRect::from_rect(rect, radii))
+    }
+
+    /// Build a closed path for `rect` using the fitted elliptical radii.
+    ///
+    /// The path uses cubic Bezier quarter-ellipse approximations for rounded
+    /// corners. Renderers that need exact circular arcs can use
+    /// [`CornerRadii::to_kurbo_rounded_rect`] when it returns `Some`.
+    pub fn to_path(self, rect: Rect) -> BezPath {
+        let rect = normalize_rect(rect);
+        let radii = self.scale_to_fit(rect);
+        rounded_rect_path(rect, radii)
+    }
+
+    pub(crate) fn inset_by_edges(self, edges: Edges<f64>) -> Self {
+        Self::new(
+            Size::new(
+                finite_non_negative(self.top_left.width - edges.left),
+                finite_non_negative(self.top_left.height - edges.top),
+            ),
+            Size::new(
+                finite_non_negative(self.top_right.width - edges.right),
+                finite_non_negative(self.top_right.height - edges.top),
+            ),
+            Size::new(
+                finite_non_negative(self.bottom_right.width - edges.right),
+                finite_non_negative(self.bottom_right.height - edges.bottom),
+            ),
+            Size::new(
+                finite_non_negative(self.bottom_left.width - edges.left),
+                finite_non_negative(self.bottom_left.height - edges.bottom),
+            ),
+        )
+    }
+
+    fn scaled(self, scale: f64) -> Self {
+        Self::new(
+            scale_size(self.top_left, scale),
+            scale_size(self.top_right, scale),
+            scale_size(self.bottom_right, scale),
+            scale_size(self.bottom_left, scale),
+        )
+    }
+}
+
+impl From<f64> for CornerRadii {
+    fn from(radius: f64) -> Self {
+        Self::uniform(radius)
+    }
+}
+
+impl From<Size> for CornerRadii {
+    fn from(radius: Size) -> Self {
+        Self::all(radius)
+    }
+}
+
+impl From<RoundedRectRadii> for CornerRadii {
+    fn from(radii: RoundedRectRadii) -> Self {
+        Self::circular(
+            radii.top_left,
+            radii.top_right,
+            radii.bottom_right,
+            radii.bottom_left,
+        )
+    }
+}
+
+fn is_circular(size: Size) -> bool {
+    distance(size.width, size.height) <= CIRCULAR_EPSILON
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kurbo::{PathEl, Point};
+
+    #[test]
+    fn radii_scale_to_css_smallest_factor() {
+        let radii = CornerRadii::new(
+            Size::new(80.0, 10.0),
+            Size::new(80.0, 20.0),
+            Size::new(10.0, 20.0),
+            Size::new(10.0, 10.0),
+        );
+
+        let scaled = radii.scale_to_fit(Rect::new(0.0, 0.0, 100.0, 50.0));
+
+        assert_eq!(scaled.top_left, Size::new(50.0, 6.25));
+        assert_eq!(scaled.top_right, Size::new(50.0, 12.5));
+        assert_eq!(scaled.bottom_right, Size::new(6.25, 12.5));
+        assert_eq!(scaled.bottom_left, Size::new(6.25, 6.25));
+    }
+
+    #[test]
+    fn circular_radii_can_use_kurbo_rounded_rect() {
+        let radii = CornerRadii::circular(4.0, 8.0, 12.0, 16.0);
+
+        assert_eq!(
+            radii.as_kurbo_radii(),
+            Some(RoundedRectRadii::new(4.0, 8.0, 12.0, 16.0)),
+        );
+        assert!(
+            radii
+                .to_kurbo_rounded_rect(Rect::new(0.0, 0.0, 100.0, 50.0))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn elliptical_radii_use_path() {
+        let radii = CornerRadii::all(Size::new(12.0, 8.0));
+
+        assert_eq!(radii.as_kurbo_radii(), None);
+
+        let path = radii.to_path(Rect::new(0.0, 0.0, 100.0, 50.0));
+        assert_eq!(
+            path.iter().next(),
+            Some(PathEl::MoveTo(Point::new(12.0, 0.0))),
+        );
+        assert_eq!(path.iter().last(), Some(PathEl::ClosePath));
+    }
+}

--- a/understory_box_decoration/src/shape.rs
+++ b/understory_box_decoration/src/shape.rs
@@ -1,0 +1,126 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::Corners;
+
+/// Resolved physical corner shapes for a box contour.
+pub type CornerShapes = Corners<CornerShape>;
+
+impl CornerShapes {
+    /// Round corner shapes for every corner.
+    pub const ROUND: Self = Self::all(CornerShape::Round);
+}
+
+/// The shape used inside a corner's resolved radius area.
+///
+/// The enum is intentionally smaller than the authored CSS keyword set.
+/// CSS `corner-shape` keywords such as `scoop`, `notch`, and `squircle` are
+/// represented as superellipse parameters here; preserving the exact authored
+/// keyword belongs in a property or parser layer.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub enum CornerShape {
+    /// A quarter ellipse, equivalent to CSS `round` / `superellipse(1)`.
+    #[default]
+    Round,
+    /// A convex square corner, equivalent to CSS `square` /
+    /// `superellipse(infinity)`.
+    Square,
+    /// A diagonal corner, equivalent to CSS `bevel` / `superellipse(0)`.
+    Bevel,
+    /// A CSS-style superellipse corner parameter.
+    Superellipse(Superellipse),
+}
+
+impl CornerShape {
+    /// A concave quarter-ellipse scoop, equivalent to CSS `scoop` /
+    /// `superellipse(-1)`.
+    #[must_use]
+    pub const fn scoop() -> Self {
+        Self::Superellipse(Superellipse::new(-1.0))
+    }
+
+    /// A concave square notch, equivalent to CSS `notch` /
+    /// `superellipse(-infinity)`.
+    #[must_use]
+    pub const fn notch() -> Self {
+        Self::Superellipse(Superellipse::new(f64::NEG_INFINITY))
+    }
+
+    /// A convex curve between round and square, equivalent to CSS `squircle` /
+    /// `superellipse(2)`.
+    #[must_use]
+    pub const fn squircle() -> Self {
+        Self::Superellipse(Superellipse::new(2.0))
+    }
+
+    /// Creates a corner shape from a CSS-style superellipse parameter.
+    ///
+    /// `superellipse(1)` is represented as [`CornerShape::Round`],
+    /// `superellipse(0)` as [`CornerShape::Bevel`], and positive infinity as
+    /// [`CornerShape::Square`]. Negative infinity is retained as a
+    /// superellipse because it represents a concave notch rather than a square
+    /// outer corner.
+    #[must_use]
+    pub const fn superellipse(parameter: f64) -> Self {
+        if parameter == 1.0 || parameter.is_nan() {
+            Self::Round
+        } else if parameter == 0.0 {
+            Self::Bevel
+        } else if parameter == f64::INFINITY {
+            Self::Square
+        } else {
+            Self::Superellipse(Superellipse::new(parameter))
+        }
+    }
+}
+
+/// CSS-style superellipse parameter for a shaped corner.
+///
+/// CSS Borders and Box Decorations Level 4 defines `superellipse(K)` using an
+/// exponent of `2^K`. This type stores the resolved `K` value. NaN is coerced
+/// to `1.0`, matching the normal rounded-corner shape; infinities are kept so
+/// callers can represent square and notch limits.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Superellipse {
+    parameter: f64,
+}
+
+impl Superellipse {
+    /// The parameter for a round quarter ellipse.
+    ///
+    /// [`CornerShape::superellipse`] canonicalizes this value to
+    /// [`CornerShape::Round`], but renderers also treat an explicitly-stored
+    /// `CornerShape::Superellipse(Superellipse::ROUND)` as a round corner.
+    pub const ROUND: Self = Self::new(1.0);
+
+    /// The parameter for a diagonal bevel.
+    pub const BEVEL: Self = Self::new(0.0);
+
+    /// The parameter for a concave scoop.
+    pub const SCOOP: Self = Self::new(-1.0);
+
+    /// The parameter for a squircle.
+    pub const SQUIRCLE: Self = Self::new(2.0);
+
+    /// The parameter for a square limit.
+    pub const SQUARE: Self = Self::new(f64::INFINITY);
+
+    /// The parameter for a notch limit.
+    pub const NOTCH: Self = Self::new(f64::NEG_INFINITY);
+
+    /// Creates a CSS-style superellipse parameter.
+    #[must_use]
+    pub const fn new(parameter: f64) -> Self {
+        if parameter.is_nan() {
+            Self { parameter: 1.0 }
+        } else {
+            Self { parameter }
+        }
+    }
+
+    /// Returns the stored CSS-style `K` parameter.
+    #[must_use]
+    pub const fn parameter(self) -> f64 {
+        self.parameter
+    }
+}

--- a/understory_box_decoration/src/side.rs
+++ b/understory_box_decoration/src/side.rs
@@ -1,0 +1,39 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// A physical side of a rectangular box.
+///
+/// `Side` deliberately uses physical, y-down coordinates: top, right, bottom,
+/// and left. Logical sides, writing modes, and shorthand expansion belong in a
+/// value or style layer before geometry is resolved.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Side {
+    /// The smaller-y side of the box.
+    Top,
+    /// The larger-x side of the box.
+    Right,
+    /// The larger-y side of the box.
+    Bottom,
+    /// The smaller-x side of the box.
+    Left,
+}
+
+impl Side {
+    /// All physical sides in clockwise order.
+    pub const ALL: [Self; 4] = [Self::Top, Self::Right, Self::Bottom, Self::Left];
+}
+
+/// A CSS-style box area that can be clipped or painted.
+///
+/// The geometry kernel resolves these areas only after it has concrete border
+/// and padding widths. Margin geometry is intentionally absent because margin
+/// belongs to layout rather than box decoration painting.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum BoxArea {
+    /// The border edge / border box.
+    Border,
+    /// The padding edge / padding box.
+    Padding,
+    /// The content edge / content box.
+    Content,
+}

--- a/understory_box_decoration/src/util.rs
+++ b/understory_box_decoration/src/util.rs
@@ -1,0 +1,43 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use kurbo::{Rect, Size};
+
+pub(crate) fn normalize_rect(rect: Rect) -> Rect {
+    if rect.x0.is_finite() && rect.y0.is_finite() && rect.x1.is_finite() && rect.y1.is_finite() {
+        rect.abs()
+    } else {
+        Rect::ZERO
+    }
+}
+
+pub(crate) const fn finite_non_negative(value: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        0.0
+    }
+}
+
+pub(crate) const fn clean_size(size: Size) -> Size {
+    Size::new(
+        finite_non_negative(size.width),
+        finite_non_negative(size.height),
+    )
+}
+
+pub(crate) fn fit_scale(current: f64, side: f64, adjacent_radii: f64) -> f64 {
+    if adjacent_radii > side && adjacent_radii > 0.0 {
+        current.min(side / adjacent_radii)
+    } else {
+        current
+    }
+}
+
+pub(crate) const fn scale_size(size: Size, scale: f64) -> Size {
+    Size::new(size.width * scale, size.height * scale)
+}
+
+pub(crate) fn distance(a: f64, b: f64) -> f64 {
+    if a >= b { a - b } else { b - a }
+}

--- a/understory_presentation/Cargo.toml
+++ b/understory_presentation/Cargo.toml
@@ -14,14 +14,15 @@ hashbrown.workspace = true
 parlance.workspace = true
 peniko.workspace = true
 smallvec.workspace = true
+understory_box_decoration.workspace = true
 
 [lints]
 workspace = true
 
 [features]
 default = ["libm"]
-std = ["parlance/std", "peniko/std"]
-libm = ["peniko/libm"]
+std = ["parlance/std", "peniko/std", "understory_box_decoration/std"]
+libm = ["peniko/libm", "understory_box_decoration/libm"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/understory_presentation/README.md
+++ b/understory_presentation/README.md
@@ -29,6 +29,12 @@ and paint. A toolkit writes already-resolved drawing primitives into a
 geometry tree, look up presentation entries, and lower primitives without
 reading properties or running style cascade resolution.
 
+When these values originate from dependency properties, use
+`understory_presentation_properties` as the upstream adapter. That crate
+registers canonical surface properties and resolves them into
+[`SurfacePrimitive`] values, while this crate remains a property-blind cache
+of drawing intent.
+
 This crate deliberately does **not** own layout bounds, scene traversal
 order, global transforms/clips, hit testing, style cascade, property
 storage, behavior dispatch, templates, or renderer command emission.

--- a/understory_presentation/README.md
+++ b/understory_presentation/README.md
@@ -46,7 +46,8 @@ property/style resolution, behavior, or paint command emission.
 - [`PresentationNode`]: source back-reference and primitive list for one
   drawable geometry node.
 - [`Primitive`]: resolved drawing primitive stored on a presentation node.
-- [`SurfacePrimitive`]: resolved surface fill/border intent.
+- [`SurfacePrimitive`]: resolved surface fill, border, padding, corner
+  shape, and shadow intent.
 - [`TextPrimitive`]: umbrella for resolved text drawing intent.
 - [`PlainTextPrimitive`]: resolved plain-text content, foreground brush,
   decorations, and `parlance`-based single-run style.
@@ -81,8 +82,10 @@ deduplicated and drained in first-dirty order with
 ## Feature flags
 
 - `default`: enables `libm` so the crate builds as `no_std` by default.
-- `libm`: forwards `peniko/libm` for `no_std` float math.
-- `std`: forwards `peniko/std` and `parlance/std`.
+- `libm`: forwards `peniko/libm` and `understory_box_decoration/libm`
+  for `no_std` float math.
+- `std`: forwards `peniko/std`, `parlance/std`, and
+  `understory_box_decoration/std`.
 
 If default features are disabled, callers must enable either `libm` or
 `std`.
@@ -96,7 +99,8 @@ cargo check -p understory_presentation --no-default-features --features std
 
 ```rust
 use understory_presentation::{
-    Brush, Color, PresentationStore, Primitive, RoundedRectRadii, TextContent,
+    Brush, Color, CornerRadii, CornerShape, CornerShapes, Edges,
+    PresentationStore, Primitive, TextContent,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -116,7 +120,9 @@ store.insert(label, source_content);
 
 let surface = store.surface_mut(root).unwrap();
 surface.set_background(Color::from_rgb8(38, 92, 142));
-surface.corner_radii = RoundedRectRadii::from_single_radius(6.0);
+surface.padding_widths = Edges::vertical_horizontal(4.0, 8.0);
+surface.corner_radii = CornerRadii::uniform(6.0);
+surface.corner_shapes = CornerShapes::all(CornerShape::squircle());
 
 let text = store.plain_text_mut(label).unwrap();
 text.content = TextContent::plain("Run");

--- a/understory_presentation/src/lib.rs
+++ b/understory_presentation/src/lib.rs
@@ -29,7 +29,8 @@
 //! - [`PresentationNode`]: source back-reference and primitive list for one
 //!   drawable geometry node.
 //! - [`Primitive`]: resolved drawing primitive stored on a presentation node.
-//! - [`SurfacePrimitive`]: resolved surface fill/border intent.
+//! - [`SurfacePrimitive`]: resolved surface fill, border, padding, corner
+//!   shape, and shadow intent.
 //! - [`TextPrimitive`]: umbrella for resolved text drawing intent.
 //! - [`PlainTextPrimitive`]: resolved plain-text content, foreground brush,
 //!   decorations, and `parlance`-based single-run style.
@@ -64,8 +65,10 @@
 //! ## Feature flags
 //!
 //! - `default`: enables `libm` so the crate builds as `no_std` by default.
-//! - `libm`: forwards `peniko/libm` for `no_std` float math.
-//! - `std`: forwards `peniko/std` and `parlance/std`.
+//! - `libm`: forwards `peniko/libm` and `understory_box_decoration/libm`
+//!   for `no_std` float math.
+//! - `std`: forwards `peniko/std`, `parlance/std`, and
+//!   `understory_box_decoration/std`.
 //!
 //! If default features are disabled, callers must enable either `libm` or
 //! `std`.
@@ -79,7 +82,8 @@
 //!
 //! ```rust
 //! use understory_presentation::{
-//!     Brush, Color, PresentationStore, Primitive, RoundedRectRadii, TextContent,
+//!     Brush, Color, CornerRadii, CornerShape, CornerShapes, Edges,
+//!     PresentationStore, Primitive, TextContent,
 //! };
 //!
 //! #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -99,7 +103,9 @@
 //!
 //! let surface = store.surface_mut(root).unwrap();
 //! surface.set_background(Color::from_rgb8(38, 92, 142));
-//! surface.corner_radii = RoundedRectRadii::from_single_radius(6.0);
+//! surface.padding_widths = Edges::vertical_horizontal(4.0, 8.0);
+//! surface.corner_radii = CornerRadii::uniform(6.0);
+//! surface.corner_shapes = CornerShapes::all(CornerShape::squircle());
 //!
 //! let text = store.plain_text_mut(label).unwrap();
 //! text.content = TextContent::plain("Run");
@@ -133,3 +139,7 @@ pub use primitive::{
     TextLineHeight, TextOverflow, TextPrimitive, TextStyle,
 };
 pub use store::{PresentationNode, PresentationStore};
+pub use understory_box_decoration::{
+    BorderSideGeometry, BoxArea, BoxContour, BoxDecorationGeometry, ContourSideSpan, CornerRadii,
+    CornerShape, CornerShapes, Corners, Edges, ResolvedCorner, Side, Superellipse,
+};

--- a/understory_presentation/src/lib.rs
+++ b/understory_presentation/src/lib.rs
@@ -12,6 +12,12 @@
 //! geometry tree, look up presentation entries, and lower primitives without
 //! reading properties or running style cascade resolution.
 //!
+//! When these values originate from dependency properties, use
+//! `understory_presentation_properties` as the upstream adapter. That crate
+//! registers canonical surface properties and resolves them into
+//! [`SurfacePrimitive`] values, while this crate remains a property-blind cache
+//! of drawing intent.
+//!
 //! This crate deliberately does **not** own layout bounds, scene traversal
 //! order, global transforms/clips, hit testing, style cascade, property
 //! storage, behavior dispatch, templates, or renderer command emission.

--- a/understory_presentation/src/primitive/surface.rs
+++ b/understory_presentation/src/primitive/surface.rs
@@ -3,14 +3,15 @@
 
 use smallvec::SmallVec;
 
-use crate::{Brush, Color};
-use peniko::kurbo::RoundedRectRadii;
+use crate::{BoxDecorationGeometry, Brush, Color, CornerRadii, CornerShapes, Edges};
+use peniko::kurbo::Rect;
 
 /// Resolved box-decoration drawing intent.
 ///
 /// Geometry such as bounds and transforms lives outside this crate. Surface
-/// backgrounds, borders, corner radii, and shadows are resolved inputs that a
-/// toolkit lowerer applies to the node's final geometry.
+/// backgrounds, borders, padding widths, corner shapes, and shadows are
+/// resolved inputs that a toolkit lowerer applies to the node's final
+/// geometry.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct SurfacePrimitive {
     /// Background layers, painted in list order.
@@ -19,8 +20,20 @@ pub struct SurfacePrimitive {
     /// Per-side border model.
     pub border: Border,
 
+    /// Physical padding widths in logical pixels.
+    ///
+    /// These widths are the decoration padding used to derive the content
+    /// contour in [`SurfacePrimitive::decoration_geometry`]. Toolkits that
+    /// also use padding during layout should resolve padding once and copy the
+    /// same values here; independently-resolved layout and decoration padding
+    /// can make content insets drift from painted contours.
+    pub padding_widths: Edges<f64>,
+
     /// Per-corner radii in logical pixels.
-    pub corner_radii: RoundedRectRadii,
+    pub corner_radii: CornerRadii,
+
+    /// Per-corner contour shapes.
+    pub corner_shapes: CornerShapes,
 
     /// Outer shadows, painted in list order.
     pub shadows: SmallVec<[Shadow; 1]>,
@@ -37,6 +50,27 @@ impl SurfacePrimitive {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.backgrounds.is_empty() && self.border.is_empty() && self.shadows.is_empty()
+    }
+
+    /// Resolve geometry for this surface's border box.
+    ///
+    /// Presentation stores decoration intent without owning layout bounds.
+    /// Call this from a lowerer once the caller's geometry tree has supplied
+    /// the surface's final border box. The returned geometry can be used to
+    /// fill or clip named box areas, ask for contour paths, or construct
+    /// renderer-specific border paths without storing materialized paths in
+    /// the presentation primitive. The content contour is derived from
+    /// [`SurfacePrimitive::padding_widths`], so callers should keep those
+    /// values in sync with any layout padding used for the same box.
+    #[must_use]
+    pub fn decoration_geometry(&self, border_box: Rect) -> BoxDecorationGeometry {
+        BoxDecorationGeometry::from_border_box(
+            border_box,
+            self.border.visible_widths(),
+            self.padding_widths,
+            self.corner_radii,
+            self.corner_shapes,
+        )
     }
 }
 
@@ -94,6 +128,38 @@ impl Border {
             && self.bottom.is_empty()
             && self.left.is_empty()
     }
+
+    /// Return the widths of visible border sides.
+    ///
+    /// A side with no brush is treated as width zero, matching
+    /// [`BorderSide::is_empty`]. The result is suitable for
+    /// [`BoxDecorationGeometry::from_border_box`].
+    #[must_use]
+    pub fn visible_widths(&self) -> Edges<f64> {
+        Edges::new(
+            self.top.visible_width(),
+            self.right.visible_width(),
+            self.bottom.visible_width(),
+            self.left.visible_width(),
+        )
+    }
+
+    /// Return the shared visible side when all four sides are equal.
+    ///
+    /// This is useful for lowerers that only have a uniform-border fast path.
+    /// Empty borders return `None`, and non-uniform side widths or brushes
+    /// also return `None`.
+    #[must_use]
+    pub fn uniform_visible_side(&self) -> Option<&BorderSide> {
+        if self.top.is_empty() {
+            return None;
+        }
+        if self.top == self.right && self.top == self.bottom && self.top == self.left {
+            Some(&self.top)
+        } else {
+            None
+        }
+    }
 }
 
 /// One side of a border.
@@ -117,9 +183,18 @@ impl BorderSide {
     }
 
     /// Returns true when the side should not draw.
+    ///
+    /// A side is visible only when it has a brush and a positive finite width.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.brush.is_none() || self.width <= 0.0
+        self.brush.is_none() || !self.width.is_finite() || self.width <= 0.0
+    }
+
+    /// Return the side width when the side has a brush and positive finite
+    /// width.
+    #[must_use]
+    pub fn visible_width(&self) -> f64 {
+        if self.is_empty() { 0.0 } else { self.width }
     }
 }
 
@@ -190,12 +265,75 @@ mod tests {
     }
 
     #[test]
+    fn non_finite_border_widths_are_empty() {
+        for width in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let side = BorderSide::new(Color::BLACK, width);
+            assert!(side.is_empty());
+            assert_eq!(side.visible_width(), 0.0);
+        }
+
+        let border = Border::uniform(Color::BLACK, f64::NAN);
+        assert!(border.is_empty());
+        assert_eq!(border.visible_widths(), Edges::ZERO);
+        assert_eq!(border.uniform_visible_side(), None);
+    }
+
+    #[test]
     fn corner_radii_alone_do_not_make_surface_visible() {
         let surface = SurfacePrimitive {
-            corner_radii: RoundedRectRadii::from_single_radius(8.0),
+            corner_radii: CornerRadii::uniform(8.0),
+            corner_shapes: CornerShapes::ROUND,
             ..SurfacePrimitive::default()
         };
 
         assert!(surface.is_empty());
+    }
+
+    #[test]
+    fn decoration_geometry_uses_visible_widths_and_corner_radii() {
+        let surface = SurfacePrimitive {
+            border: Border {
+                top: BorderSide::new(Color::BLACK, 2.0),
+                right: BorderSide {
+                    brush: None,
+                    width: 6.0,
+                },
+                bottom: BorderSide::new(Color::BLACK, -4.0),
+                left: BorderSide::new(Color::BLACK, 4.0),
+            },
+            padding_widths: Edges::new(1.0, 2.0, 3.0, 4.0),
+            corner_radii: CornerRadii::circular(10.0, 12.0, 14.0, 16.0),
+            corner_shapes: CornerShapes::all(crate::CornerShape::squircle()),
+            ..SurfacePrimitive::default()
+        };
+
+        let geometry = surface.decoration_geometry(Rect::new(0.0, 0.0, 100.0, 50.0));
+
+        assert_eq!(geometry.border_widths, Edges::new(2.0, 0.0, 0.0, 4.0));
+        assert_eq!(geometry.padding_widths, Edges::new(1.0, 2.0, 3.0, 4.0));
+        assert_eq!(geometry.padding_box, Rect::new(4.0, 2.0, 100.0, 50.0));
+        assert_eq!(geometry.content_box, Rect::new(8.0, 3.0, 98.0, 47.0));
+        assert_eq!(
+            geometry.border_edge.radii(),
+            CornerRadii::circular(10.0, 12.0, 14.0, 16.0)
+        );
+        assert_eq!(
+            geometry.border_edge.corners.top_left.shape,
+            crate::CornerShape::squircle()
+        );
+    }
+
+    #[test]
+    fn uniform_visible_side_requires_all_sides_to_match() {
+        let uniform = Border::uniform(Color::BLACK, 2.0);
+        assert_eq!(uniform.uniform_visible_side(), Some(&uniform.top));
+
+        let mixed = Border {
+            right: BorderSide::new(Color::WHITE, 2.0),
+            ..Border::uniform(Color::BLACK, 2.0)
+        };
+        assert_eq!(mixed.uniform_visible_side(), None);
+
+        assert_eq!(Border::default().uniform_visible_side(), None);
     }
 }

--- a/understory_presentation/src/store.rs
+++ b/understory_presentation/src/store.rs
@@ -467,7 +467,7 @@ mod tests {
     use alloc::vec;
 
     use super::*;
-    use crate::{Color, PathPrimitive, RoundedRectRadii, TextContent};
+    use crate::{Color, CornerRadii, PathPrimitive, TextContent};
     use peniko::kurbo::BezPath;
 
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -510,7 +510,7 @@ mod tests {
         surface.set_background(Color::from_rgb8(20, 30, 40));
 
         let surface = store.surface_mut(1).unwrap();
-        surface.corner_radii = RoundedRectRadii::from_single_radius(4.0);
+        surface.corner_radii = CornerRadii::uniform(4.0);
 
         assert!(store.node(1).unwrap().surface().is_some());
         assert_eq!(store.take_dirty().collect::<Vec<_>>(), vec![1]);

--- a/understory_presentation_properties/CHANGELOG.md
+++ b/understory_presentation_properties/CHANGELOG.md
@@ -1,0 +1,32 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+Understory Presentation Properties has not had a published release yet.
+
+## [Unreleased]
+
+### Added
+
+- Added the initial `understory_presentation_properties` crate with `no_std`
+  dependency-property integration for resolved presentation surfaces.
+- Added `SurfaceProperties` for registering canonical surface background,
+  border brush, border width, padding width, corner radius, and corner shape
+  properties.
+- Added `SurfacePropertyValues` and `SurfaceProperties::resolve_surface` for
+  resolving property/style/theme values into `understory_presentation`
+  `SurfacePrimitive` values.
+- Added `StyleMatch` as the named style resolver input instead of exposing the
+  raw `StyleCascade` and `MatchState` tuple in the happy path.
+- Added invalidation channel metadata for distinguishing paint-only properties
+  from geometry-and-paint surface properties.
+
+[Unreleased]: https://github.com/forest-rs/understory/compare/HEAD
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/understory_presentation_properties/Cargo.toml
+++ b/understory_presentation_properties/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "understory_presentation_properties"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Dependency-property integration for resolved presentation primitives"
+readme = "README.md"
+keywords = ["presentation", "property", "style", "ui", "no_std"]
+categories = ["gui", "graphics", "no-std"]
+
+[dependencies]
+invalidation.workspace = true
+kurbo.workspace = true
+understory_presentation.workspace = true
+understory_property.workspace = true
+understory_style.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["libm"]
+std = ["kurbo/std", "understory_presentation/std"]
+libm = ["kurbo/libm", "understory_presentation/libm"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_presentation_properties/LICENSE-APACHE
+++ b/understory_presentation_properties/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/understory_presentation_properties/LICENSE-MIT
+++ b/understory_presentation_properties/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/understory_presentation_properties/README.md
+++ b/understory_presentation_properties/README.md
@@ -1,0 +1,179 @@
+<div align="center">
+
+# Understory Presentation Properties
+
+**Dependency-property integration for resolved presentation primitives**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_presentation_properties.svg)](https://crates.io/crates/understory_presentation_properties)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_presentation_properties.svg)](https://docs.rs/understory_presentation_properties)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/forest-rs/understory/ci.yml?logo=github&label=CI)](https://github.com/forest-rs/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_presentation_properties --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Dependency-property integration for resolved presentation primitives.
+
+`understory_presentation_properties` registers canonical dependency
+properties for drawing surfaces and resolves them into
+[`understory_presentation`] primitives. It is the adapter between
+property/style resolution and the renderer-neutral presentation tree.
+
+The crate deliberately does **not** own property storage, selector matching,
+theme resources, layout bounds, hit testing, CSS parsing, or renderer command
+emission. Those responsibilities stay in `understory_property`,
+`understory_style`, layout/hit crates, and backend lowerers.
+
+## Why this crate exists
+
+Surface decoration spans several concerns:
+
+- property systems need typed longhands with defaults and invalidation
+  metadata;
+- style systems need independently-overridable values such as one border
+  edge, one padding side, one corner radius, or one corner shape;
+- presentation needs a resolved [`understory_presentation::SurfacePrimitive`]
+  that can be cached in a paint tree;
+- renderers need geometry helpers such as
+  [`understory_presentation::SurfacePrimitive::decoration_geometry`] when
+  final bounds are known.
+
+This crate owns the property-to-presentation step so callers do not need to
+invent parallel property names, defaults, or invalidation policy.
+
+## Surface pipeline
+
+```text
+understory_property + understory_style
+        |
+        v
+SurfaceProperties::resolve_surface
+        |
+        v
+understory_presentation::SurfacePrimitive
+        |
+        v
+understory_box_decoration geometry helpers
+```
+
+## Feature flags
+
+- `default`: enables `libm` so the crate builds as `no_std` by default.
+- `libm`: forwards `kurbo/libm` and `understory_presentation/libm`.
+- `std`: forwards `kurbo/std` and `understory_presentation/std`.
+
+If default features are disabled, callers must enable either `libm` or
+`std`.
+
+## Minimal example
+
+```rust
+use invalidation::Channel;
+use understory_presentation::{Brush, Color, CornerShape, Edges};
+use understory_presentation_properties::{
+    CornerRadius, StyleMatch, SurfacePropertyChannels, SurfaceProperties,
+};
+use understory_property::{DependencyObject, PropertyRegistry, PropertyStore};
+use understory_style::{
+    NoResolveParentLookup, ResolveCx, StyleBuilder, StyleCascadeBuilder,
+    StyleOrigin, ThemeBuilder,
+};
+
+const GEOMETRY: Channel = Channel::new(0);
+const PAINT: Channel = Channel::new(1);
+
+let mut registry = PropertyRegistry::new();
+let surface = SurfaceProperties::register(
+    &mut registry,
+    SurfacePropertyChannels::new(GEOMETRY.into_set(), PAINT.into_set()),
+);
+
+struct Element {
+    store: PropertyStore<u32>,
+}
+
+impl DependencyObject<u32> for Element {
+    fn property_store(&self) -> &PropertyStore<u32> { &self.store }
+    fn property_store_mut(&mut self) -> &mut PropertyStore<u32> { &mut self.store }
+    fn key(&self) -> u32 { self.store.owner() }
+    fn parent_key(&self) -> Option<u32> { None }
+}
+
+let element = Element { store: PropertyStore::new(1) };
+let style = StyleBuilder::new()
+    .set(surface.background, Some(Brush::from(Color::WHITE)))
+    .set(surface.border_widths.top, 2.0)
+    .set(surface.border_brushes.top, Some(Brush::from(Color::BLACK)))
+    .set(surface.padding_widths.top, 6.0)
+    .set(surface.corner_radii.top_left, CornerRadius::circular(6.0))
+    .set(surface.corner_shapes.top_left, CornerShape::squircle())
+    .build();
+let cascade = StyleCascadeBuilder::new()
+    .push_style(StyleOrigin::Base, style)
+    .build();
+let theme = ThemeBuilder::new().build();
+let cx = ResolveCx::new(&registry, &theme, NoResolveParentLookup);
+
+let primitive = surface.resolve_surface(
+    &cx,
+    &element,
+    Some(StyleMatch::new(&cascade, cascade.root_state())),
+);
+
+assert_eq!(primitive.backgrounds.len(), 1);
+assert_eq!(primitive.border.visible_widths(), Edges::new(2.0, 0.0, 0.0, 0.0));
+assert_eq!(primitive.padding_widths.top, 6.0);
+assert_eq!(primitive.corner_radii.top_left.width, 6.0);
+assert_eq!(primitive.corner_shapes.top_left, CornerShape::squircle());
+```
+
+## Roadmap
+
+The first slice covers resolved surface background, per-side border brushes
+and widths, physical padding widths, per-corner elliptical radii, and
+per-corner shapes. Future work should add length-percentage values,
+`border-shape`, richer background layers, shadow properties, and
+shape-related properties once a dedicated shape value crate exists. Those
+additions should keep the same pattern: properties are longhand, resolution
+produces presentation primitives, and geometry remains in
+`understory_box_decoration`.
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>), or
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>),
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+[LICENSE-APACHE]: https://github.com/forest-rs/understory/blob/main/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/forest-rs/understory/blob/main/LICENSE-MIT
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: https://github.com/forest-rs/understory/blob/main/AUTHORS

--- a/understory_presentation_properties/src/lib.rs
+++ b/understory_presentation_properties/src/lib.rs
@@ -1,0 +1,139 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=understory_presentation_properties --heading-base-level=0
+
+//! Dependency-property integration for resolved presentation primitives.
+//!
+//! `understory_presentation_properties` registers canonical dependency
+//! properties for drawing surfaces and resolves them into
+//! [`understory_presentation`] primitives. It is the adapter between
+//! property/style resolution and the renderer-neutral presentation tree.
+//!
+//! The crate deliberately does **not** own property storage, selector matching,
+//! theme resources, layout bounds, hit testing, CSS parsing, or renderer command
+//! emission. Those responsibilities stay in `understory_property`,
+//! `understory_style`, layout/hit crates, and backend lowerers.
+//!
+//! ## Why this crate exists
+//!
+//! Surface decoration spans several concerns:
+//!
+//! - property systems need typed longhands with defaults and invalidation
+//!   metadata;
+//! - style systems need independently-overridable values such as one border
+//!   edge, one padding side, one corner radius, or one corner shape;
+//! - presentation needs a resolved [`understory_presentation::SurfacePrimitive`]
+//!   that can be cached in a paint tree;
+//! - renderers need geometry helpers such as
+//!   [`understory_presentation::SurfacePrimitive::decoration_geometry`] when
+//!   final bounds are known.
+//!
+//! This crate owns the property-to-presentation step so callers do not need to
+//! invent parallel property names, defaults, or invalidation policy.
+//!
+//! ## Surface pipeline
+//!
+//! ```text
+//! understory_property + understory_style
+//!         |
+//!         v
+//! SurfaceProperties::resolve_surface
+//!         |
+//!         v
+//! understory_presentation::SurfacePrimitive
+//!         |
+//!         v
+//! understory_box_decoration geometry helpers
+//! ```
+//!
+//! ## Feature flags
+//!
+//! - `default`: enables `libm` so the crate builds as `no_std` by default.
+//! - `libm`: forwards `kurbo/libm` and `understory_presentation/libm`.
+//! - `std`: forwards `kurbo/std` and `understory_presentation/std`.
+//!
+//! If default features are disabled, callers must enable either `libm` or
+//! `std`.
+//!
+//! ## Minimal example
+//!
+//! ```rust
+//! use invalidation::Channel;
+//! use understory_presentation::{Brush, Color, CornerShape, Edges};
+//! use understory_presentation_properties::{
+//!     CornerRadius, StyleMatch, SurfacePropertyChannels, SurfaceProperties,
+//! };
+//! use understory_property::{DependencyObject, PropertyRegistry, PropertyStore};
+//! use understory_style::{
+//!     NoResolveParentLookup, ResolveCx, StyleBuilder, StyleCascadeBuilder,
+//!     StyleOrigin, ThemeBuilder,
+//! };
+//!
+//! const GEOMETRY: Channel = Channel::new(0);
+//! const PAINT: Channel = Channel::new(1);
+//!
+//! let mut registry = PropertyRegistry::new();
+//! let surface = SurfaceProperties::register(
+//!     &mut registry,
+//!     SurfacePropertyChannels::new(GEOMETRY.into_set(), PAINT.into_set()),
+//! );
+//!
+//! struct Element {
+//!     store: PropertyStore<u32>,
+//! }
+//!
+//! impl DependencyObject<u32> for Element {
+//!     fn property_store(&self) -> &PropertyStore<u32> { &self.store }
+//!     fn property_store_mut(&mut self) -> &mut PropertyStore<u32> { &mut self.store }
+//!     fn key(&self) -> u32 { self.store.owner() }
+//!     fn parent_key(&self) -> Option<u32> { None }
+//! }
+//!
+//! let element = Element { store: PropertyStore::new(1) };
+//! let style = StyleBuilder::new()
+//!     .set(surface.background, Some(Brush::from(Color::WHITE)))
+//!     .set(surface.border_widths.top, 2.0)
+//!     .set(surface.border_brushes.top, Some(Brush::from(Color::BLACK)))
+//!     .set(surface.padding_widths.top, 6.0)
+//!     .set(surface.corner_radii.top_left, CornerRadius::circular(6.0))
+//!     .set(surface.corner_shapes.top_left, CornerShape::squircle())
+//!     .build();
+//! let cascade = StyleCascadeBuilder::new()
+//!     .push_style(StyleOrigin::Base, style)
+//!     .build();
+//! let theme = ThemeBuilder::new().build();
+//! let cx = ResolveCx::new(&registry, &theme, NoResolveParentLookup);
+//!
+//! let primitive = surface.resolve_surface(
+//!     &cx,
+//!     &element,
+//!     Some(StyleMatch::new(&cascade, cascade.root_state())),
+//! );
+//!
+//! assert_eq!(primitive.backgrounds.len(), 1);
+//! assert_eq!(primitive.border.visible_widths(), Edges::new(2.0, 0.0, 0.0, 0.0));
+//! assert_eq!(primitive.padding_widths.top, 6.0);
+//! assert_eq!(primitive.corner_radii.top_left.width, 6.0);
+//! assert_eq!(primitive.corner_shapes.top_left, CornerShape::squircle());
+//! ```
+//!
+//! ## Roadmap
+//!
+//! The first slice covers resolved surface background, per-side border brushes
+//! and widths, physical padding widths, per-corner elliptical radii, and
+//! per-corner shapes. Future work should add length-percentage values,
+//! `border-shape`, richer background layers, shadow properties, and
+//! shape-related properties once a dedicated shape value crate exists. Those
+//! additions should keep the same pattern: properties are longhand, resolution
+//! produces presentation primitives, and geometry remains in
+//! `understory_box_decoration`.
+
+#![no_std]
+
+mod surface;
+
+pub use surface::{
+    CornerRadius, StyleMatch, SurfaceProperties, SurfacePropertyChannels, SurfacePropertyValues,
+};

--- a/understory_presentation_properties/src/surface.rs
+++ b/understory_presentation_properties/src/surface.rs
@@ -1,0 +1,630 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use invalidation::ChannelSet;
+use kurbo::Size;
+use understory_presentation::{
+    BackgroundLayer, Border, BorderSide, Brush, CornerRadii, CornerShape, CornerShapes, Corners,
+    Edges, SurfacePrimitive,
+};
+use understory_property::{DependencyObject, Property, PropertyMetadataBuilder, PropertyRegistry};
+use understory_style::{MatchState, ResolveCx, ResolveParentLookup, StyleCascade};
+
+/// Style cascade state passed to property resolution.
+///
+/// The [`StyleCascade`] and [`MatchState`] pair is produced by
+/// `understory_style` while walking the caller's subject tree. Keep this value
+/// with the object or part it was produced for, then pass `Some(style_match)`
+/// to [`SurfaceProperties::resolve_surface`].
+#[derive(Copy, Clone, Debug)]
+pub struct StyleMatch<'a> {
+    cascade: &'a StyleCascade,
+    state: MatchState,
+}
+
+impl<'a> StyleMatch<'a> {
+    /// Creates a style match from a cascade and a match state produced by that
+    /// cascade.
+    ///
+    /// `MatchState` handles are scoped to the [`StyleCascade`] that created
+    /// them. Passing a state from another cascade is a logic error enforced by
+    /// `understory_style` debug checks.
+    #[must_use]
+    pub const fn new(cascade: &'a StyleCascade, state: MatchState) -> Self {
+        Self { cascade, state }
+    }
+
+    /// Returns the style cascade.
+    #[must_use]
+    pub const fn cascade(self) -> &'a StyleCascade {
+        self.cascade
+    }
+
+    /// Returns the match state produced by [`StyleMatch::cascade`].
+    #[must_use]
+    pub const fn state(self) -> MatchState {
+        self.state
+    }
+
+    fn as_resolve_pair(self) -> (&'a StyleCascade, MatchState) {
+        (self.cascade, self.state)
+    }
+}
+
+impl<'a> From<(&'a StyleCascade, MatchState)> for StyleMatch<'a> {
+    fn from((cascade, state): (&'a StyleCascade, MatchState)) -> Self {
+        Self::new(cascade, state)
+    }
+}
+
+/// Invalidation channels used by the canonical surface properties.
+///
+/// Brush-only properties affect paint. Shape properties such as border widths,
+/// padding widths, corner radii, and corner shapes affect both `geometry` and
+/// `paint`, because they can change clipping, hit regions, border paths, and
+/// the pixels that are drawn.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct SurfacePropertyChannels {
+    /// Channels affected when the surface shape or decoration geometry changes.
+    pub geometry: ChannelSet,
+    /// Channels affected when only painted pixels need to be refreshed.
+    pub paint: ChannelSet,
+}
+
+impl SurfacePropertyChannels {
+    /// Creates surface property channel metadata.
+    #[must_use]
+    pub const fn new(geometry: ChannelSet, paint: ChannelSet) -> Self {
+        Self { geometry, paint }
+    }
+
+    /// Creates metadata where every surface property affects the same channels.
+    #[must_use]
+    pub const fn all(channels: ChannelSet) -> Self {
+        Self {
+            geometry: channels,
+            paint: channels,
+        }
+    }
+
+    const fn paint(self) -> ChannelSet {
+        self.paint
+    }
+
+    fn geometry_and_paint(self) -> ChannelSet {
+        self.geometry | self.paint
+    }
+}
+
+/// Elliptical radius value for one corner.
+///
+/// This is the property-level longhand value. It stores the horizontal and
+/// vertical radius before box-size-dependent fitting. Resolution combines four
+/// corner values into [`CornerRadii`], and `understory_box_decoration` scales
+/// those radii once a final border box is known.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct CornerRadius {
+    /// Horizontal radius in logical pixels.
+    pub horizontal: f64,
+    /// Vertical radius in logical pixels.
+    pub vertical: f64,
+}
+
+impl CornerRadius {
+    /// A zero radius.
+    pub const ZERO: Self = Self::new(0.0, 0.0);
+
+    /// Creates an elliptical corner radius.
+    #[must_use]
+    pub const fn new(horizontal: f64, vertical: f64) -> Self {
+        Self {
+            horizontal,
+            vertical,
+        }
+    }
+
+    /// Creates a circular corner radius.
+    #[must_use]
+    pub const fn circular(radius: f64) -> Self {
+        Self::new(radius, radius)
+    }
+
+    /// Returns this radius with negative and non-finite components set to zero.
+    #[must_use]
+    pub fn clamped_non_negative(self) -> Self {
+        Self::new(
+            finite_non_negative(self.horizontal),
+            finite_non_negative(self.vertical),
+        )
+    }
+
+    fn to_size(self) -> Size {
+        let radius = self.clamped_non_negative();
+        Size::new(radius.horizontal, radius.vertical)
+    }
+}
+
+impl From<f64> for CornerRadius {
+    fn from(radius: f64) -> Self {
+        Self::circular(radius)
+    }
+}
+
+impl From<Size> for CornerRadius {
+    fn from(radius: Size) -> Self {
+        Self::new(radius.width, radius.height)
+    }
+}
+
+/// Registered dependency properties for a surface primitive.
+///
+/// Register this once in the caller's [`PropertyRegistry`], then share the
+/// returned handles anywhere a widget, template part, or style rule needs to
+/// write surface decoration values.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SurfaceProperties {
+    /// Optional background brush for the first background layer.
+    pub background: Property<Option<Brush>>,
+    /// Per-side border brush properties.
+    pub border_brushes: Edges<Property<Option<Brush>>>,
+    /// Per-side border width properties.
+    pub border_widths: Edges<Property<f64>>,
+    /// Physical padding width properties.
+    ///
+    /// These should resolve to the same physical padding values a toolkit uses
+    /// for layout content insets when the same surface participates in layout.
+    /// Keeping separate layout and decoration padding sources can make
+    /// [`SurfacePrimitive::decoration_geometry`] disagree with actual content
+    /// placement.
+    pub padding_widths: Edges<Property<f64>>,
+    /// Per-corner radius properties.
+    pub corner_radii: Corners<Property<CornerRadius>>,
+    /// Per-corner shape properties.
+    pub corner_shapes: Corners<Property<CornerShape>>,
+}
+
+impl SurfaceProperties {
+    /// Registers canonical surface properties in `registry`.
+    ///
+    /// This uses stable property names prefixed with `Surface.`. Register the
+    /// bundle once per registry; registering it twice in the same registry will
+    /// panic through [`PropertyRegistry::register`]'s duplicate-name check.
+    #[must_use]
+    pub fn register(registry: &mut PropertyRegistry, channels: SurfacePropertyChannels) -> Self {
+        let paint = channels.paint();
+        let geometry_and_paint = channels.geometry_and_paint();
+
+        Self {
+            background: register_optional_brush(registry, "Surface.Background", paint),
+            border_brushes: Edges::new(
+                register_optional_brush(registry, "Surface.BorderTopBrush", paint),
+                register_optional_brush(registry, "Surface.BorderRightBrush", paint),
+                register_optional_brush(registry, "Surface.BorderBottomBrush", paint),
+                register_optional_brush(registry, "Surface.BorderLeftBrush", paint),
+            ),
+            border_widths: Edges::new(
+                register_length(registry, "Surface.BorderTopWidth", geometry_and_paint),
+                register_length(registry, "Surface.BorderRightWidth", geometry_and_paint),
+                register_length(registry, "Surface.BorderBottomWidth", geometry_and_paint),
+                register_length(registry, "Surface.BorderLeftWidth", geometry_and_paint),
+            ),
+            padding_widths: Edges::new(
+                register_length(registry, "Surface.PaddingTop", geometry_and_paint),
+                register_length(registry, "Surface.PaddingRight", geometry_and_paint),
+                register_length(registry, "Surface.PaddingBottom", geometry_and_paint),
+                register_length(registry, "Surface.PaddingLeft", geometry_and_paint),
+            ),
+            corner_radii: Corners::new(
+                register_corner_radius(registry, "Surface.CornerTopLeftRadius", geometry_and_paint),
+                register_corner_radius(
+                    registry,
+                    "Surface.CornerTopRightRadius",
+                    geometry_and_paint,
+                ),
+                register_corner_radius(
+                    registry,
+                    "Surface.CornerBottomRightRadius",
+                    geometry_and_paint,
+                ),
+                register_corner_radius(
+                    registry,
+                    "Surface.CornerBottomLeftRadius",
+                    geometry_and_paint,
+                ),
+            ),
+            corner_shapes: Corners::new(
+                register_corner_shape(registry, "Surface.CornerTopLeftShape", geometry_and_paint),
+                register_corner_shape(registry, "Surface.CornerTopRightShape", geometry_and_paint),
+                register_corner_shape(
+                    registry,
+                    "Surface.CornerBottomRightShape",
+                    geometry_and_paint,
+                ),
+                register_corner_shape(
+                    registry,
+                    "Surface.CornerBottomLeftShape",
+                    geometry_and_paint,
+                ),
+            ),
+        }
+    }
+
+    /// Resolves the registered properties into value types.
+    ///
+    /// Use this when a caller wants to inspect or transform the resolved
+    /// decoration before building a [`SurfacePrimitive`]. Passing `None` for
+    /// `style` resolves without style-layer values.
+    #[must_use]
+    pub fn resolve_values<'a, K, F, O>(
+        self,
+        cx: &ResolveCx<'a, K, F>,
+        object: &O,
+        style: Option<StyleMatch<'_>>,
+    ) -> SurfacePropertyValues
+    where
+        K: Copy + Eq + 'a,
+        F: ResolveParentLookup<'a, K>,
+        O: DependencyObject<K>,
+    {
+        let style = style.map(StyleMatch::as_resolve_pair);
+        SurfacePropertyValues {
+            background: cx.get_value(object, self.background, style),
+            border_brushes: Edges {
+                top: cx.get_value(object, self.border_brushes.top, style),
+                right: cx.get_value(object, self.border_brushes.right, style),
+                bottom: cx.get_value(object, self.border_brushes.bottom, style),
+                left: cx.get_value(object, self.border_brushes.left, style),
+            },
+            border_widths: Edges::new(
+                finite_non_negative(cx.get_value(object, self.border_widths.top, style)),
+                finite_non_negative(cx.get_value(object, self.border_widths.right, style)),
+                finite_non_negative(cx.get_value(object, self.border_widths.bottom, style)),
+                finite_non_negative(cx.get_value(object, self.border_widths.left, style)),
+            ),
+            padding_widths: Edges::new(
+                finite_non_negative(cx.get_value(object, self.padding_widths.top, style)),
+                finite_non_negative(cx.get_value(object, self.padding_widths.right, style)),
+                finite_non_negative(cx.get_value(object, self.padding_widths.bottom, style)),
+                finite_non_negative(cx.get_value(object, self.padding_widths.left, style)),
+            ),
+            corner_radii: CornerRadii::new(
+                cx.get_value(object, self.corner_radii.top_left, style)
+                    .to_size(),
+                cx.get_value(object, self.corner_radii.top_right, style)
+                    .to_size(),
+                cx.get_value(object, self.corner_radii.bottom_right, style)
+                    .to_size(),
+                cx.get_value(object, self.corner_radii.bottom_left, style)
+                    .to_size(),
+            ),
+            corner_shapes: CornerShapes::new(
+                cx.get_value(object, self.corner_shapes.top_left, style),
+                cx.get_value(object, self.corner_shapes.top_right, style),
+                cx.get_value(object, self.corner_shapes.bottom_right, style),
+                cx.get_value(object, self.corner_shapes.bottom_left, style),
+            ),
+        }
+    }
+
+    /// Resolves the registered properties into a presentation surface.
+    ///
+    /// Passing `None` for `style` resolves without style-layer values.
+    #[must_use]
+    pub fn resolve_surface<'a, K, F, O>(
+        self,
+        cx: &ResolveCx<'a, K, F>,
+        object: &O,
+        style: Option<StyleMatch<'_>>,
+    ) -> SurfacePrimitive
+    where
+        K: Copy + Eq + 'a,
+        F: ResolveParentLookup<'a, K>,
+        O: DependencyObject<K>,
+    {
+        self.resolve_values(cx, object, style).into_surface()
+    }
+}
+
+/// Resolved surface property values before they are packed into presentation.
+///
+/// This type is useful when a caller needs the property-level values for
+/// diagnostics, template decisions, or custom lowering. Use
+/// [`SurfacePropertyValues::into_surface`] for the standard presentation path.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SurfacePropertyValues {
+    /// Optional background brush for the first background layer.
+    pub background: Option<Brush>,
+    /// Resolved per-side border brushes.
+    pub border_brushes: Edges<Option<Brush>>,
+    /// Resolved per-side border widths in logical pixels.
+    pub border_widths: Edges<f64>,
+    /// Resolved physical padding widths in logical pixels.
+    pub padding_widths: Edges<f64>,
+    /// Resolved per-corner radii in logical pixels.
+    pub corner_radii: CornerRadii,
+    /// Resolved per-corner shapes.
+    pub corner_shapes: CornerShapes,
+}
+
+impl SurfacePropertyValues {
+    /// Converts resolved values into a presentation surface primitive.
+    #[must_use]
+    pub fn into_surface(self) -> SurfacePrimitive {
+        let mut surface = SurfacePrimitive {
+            border: Border {
+                top: BorderSide {
+                    brush: self.border_brushes.top,
+                    width: self.border_widths.top,
+                },
+                right: BorderSide {
+                    brush: self.border_brushes.right,
+                    width: self.border_widths.right,
+                },
+                bottom: BorderSide {
+                    brush: self.border_brushes.bottom,
+                    width: self.border_widths.bottom,
+                },
+                left: BorderSide {
+                    brush: self.border_brushes.left,
+                    width: self.border_widths.left,
+                },
+            },
+            padding_widths: self.padding_widths,
+            corner_radii: self.corner_radii,
+            corner_shapes: self.corner_shapes,
+            ..SurfacePrimitive::default()
+        };
+
+        if let Some(background) = self.background {
+            surface.backgrounds.push(BackgroundLayer::new(background));
+        }
+
+        surface
+    }
+}
+
+fn register_optional_brush(
+    registry: &mut PropertyRegistry,
+    name: &'static str,
+    channels: ChannelSet,
+) -> Property<Option<Brush>> {
+    registry.register(
+        name,
+        PropertyMetadataBuilder::new(None::<Brush>)
+            .affects_channels(channels)
+            .build(),
+    )
+}
+
+fn register_length(
+    registry: &mut PropertyRegistry,
+    name: &'static str,
+    channels: ChannelSet,
+) -> Property<f64> {
+    registry.register(
+        name,
+        PropertyMetadataBuilder::new(0.0_f64)
+            .affects_channels(channels)
+            .coerce(finite_non_negative)
+            .build(),
+    )
+}
+
+fn register_corner_radius(
+    registry: &mut PropertyRegistry,
+    name: &'static str,
+    channels: ChannelSet,
+) -> Property<CornerRadius> {
+    registry.register(
+        name,
+        PropertyMetadataBuilder::new(CornerRadius::ZERO)
+            .affects_channels(channels)
+            .coerce(CornerRadius::clamped_non_negative)
+            .build(),
+    )
+}
+
+fn register_corner_shape(
+    registry: &mut PropertyRegistry,
+    name: &'static str,
+    channels: ChannelSet,
+) -> Property<CornerShape> {
+    registry.register(
+        name,
+        PropertyMetadataBuilder::new(CornerShape::Round)
+            .affects_channels(channels)
+            .build(),
+    )
+}
+
+fn finite_non_negative(value: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use invalidation::Channel;
+    use understory_presentation::Color;
+    use understory_property::{DependencyObject, PropertyRegistry, PropertyStore};
+    use understory_style::{
+        NoResolveParentLookup, ResolveCx, StyleBuilder, StyleCascadeBuilder, StyleOrigin,
+        ThemeBuilder,
+    };
+
+    use super::*;
+
+    const GEOMETRY: Channel = Channel::new(0);
+    const PAINT: Channel = Channel::new(1);
+
+    #[derive(Debug)]
+    struct Element {
+        key: u32,
+        parent: Option<u32>,
+        store: PropertyStore<u32>,
+    }
+
+    impl Element {
+        fn new(key: u32) -> Self {
+            Self {
+                key,
+                parent: None,
+                store: PropertyStore::new(key),
+            }
+        }
+    }
+
+    impl DependencyObject<u32> for Element {
+        fn property_store(&self) -> &PropertyStore<u32> {
+            &self.store
+        }
+
+        fn property_store_mut(&mut self) -> &mut PropertyStore<u32> {
+            &mut self.store
+        }
+
+        fn key(&self) -> u32 {
+            self.key
+        }
+
+        fn parent_key(&self) -> Option<u32> {
+            self.parent
+        }
+    }
+
+    fn register_surface(registry: &mut PropertyRegistry) -> SurfaceProperties {
+        SurfaceProperties::register(
+            registry,
+            SurfacePropertyChannels::new(GEOMETRY.into_set(), PAINT.into_set()),
+        )
+    }
+
+    #[test]
+    fn register_assigns_invalidation_channels_by_property_kind() {
+        let mut registry = PropertyRegistry::new();
+        let surface = register_surface(&mut registry);
+
+        let background_channels = registry.affects_channels(surface.background.id());
+        assert!(!background_channels.contains(GEOMETRY));
+        assert!(background_channels.contains(PAINT));
+
+        let brush_channels = registry.affects_channels(surface.border_brushes.top.id());
+        assert!(!brush_channels.contains(GEOMETRY));
+        assert!(brush_channels.contains(PAINT));
+
+        let width_channels = registry.affects_channels(surface.border_widths.top.id());
+        assert!(width_channels.contains(GEOMETRY));
+        assert!(width_channels.contains(PAINT));
+
+        let padding_channels = registry.affects_channels(surface.padding_widths.top.id());
+        assert!(padding_channels.contains(GEOMETRY));
+        assert!(padding_channels.contains(PAINT));
+
+        let radius_channels = registry.affects_channels(surface.corner_radii.top_left.id());
+        assert!(radius_channels.contains(GEOMETRY));
+        assert!(radius_channels.contains(PAINT));
+
+        let shape_channels = registry.affects_channels(surface.corner_shapes.top_left.id());
+        assert!(shape_channels.contains(GEOMETRY));
+        assert!(shape_channels.contains(PAINT));
+    }
+
+    #[test]
+    fn defaults_resolve_to_empty_surface() {
+        let mut registry = PropertyRegistry::new();
+        let surface = register_surface(&mut registry);
+        let theme = ThemeBuilder::new().build();
+        let cx = ResolveCx::new(&registry, &theme, NoResolveParentLookup);
+        let element = Element::new(1);
+
+        let primitive = surface.resolve_surface(&cx, &element, None);
+
+        assert!(primitive.is_empty());
+        assert_eq!(primitive.border.visible_widths(), Edges::ZERO);
+        assert_eq!(primitive.padding_widths, Edges::ZERO);
+        assert_eq!(primitive.corner_radii, CornerRadii::ZERO);
+        assert_eq!(primitive.corner_shapes, CornerShapes::ROUND);
+    }
+
+    #[test]
+    fn style_values_resolve_into_surface_primitive() {
+        let mut registry = PropertyRegistry::new();
+        let surface = register_surface(&mut registry);
+        let theme = ThemeBuilder::new().build();
+        let cx = ResolveCx::new(&registry, &theme, NoResolveParentLookup);
+        let element = Element::new(1);
+
+        let style = StyleBuilder::new()
+            .set(surface.background, Some(Brush::from(Color::WHITE)))
+            .set(surface.border_widths.top, 2.0)
+            .set(surface.border_widths.right, 4.0)
+            .set(surface.border_widths.bottom, -8.0)
+            .set(surface.border_widths.left, f64::NAN)
+            .set(surface.border_brushes.top, Some(Brush::from(Color::BLACK)))
+            .set(
+                surface.border_brushes.right,
+                Some(Brush::from(Color::BLACK)),
+            )
+            .set(surface.padding_widths.top, 4.0)
+            .set(surface.padding_widths.right, f64::INFINITY)
+            .set(surface.padding_widths.bottom, 6.0)
+            .set(surface.padding_widths.left, -2.0)
+            .set(surface.corner_radii.top_left, CornerRadius::new(8.0, 4.0))
+            .set(
+                surface.corner_radii.bottom_right,
+                CornerRadius::new(f64::INFINITY, 10.0),
+            )
+            .set(surface.corner_shapes.top_left, CornerShape::squircle())
+            .set(surface.corner_shapes.bottom_right, CornerShape::scoop())
+            .build();
+        let cascade = StyleCascadeBuilder::new()
+            .push_style(StyleOrigin::Base, style)
+            .build();
+
+        let primitive = surface.resolve_surface(
+            &cx,
+            &element,
+            Some(StyleMatch::new(&cascade, cascade.root_state())),
+        );
+
+        assert_eq!(primitive.backgrounds.len(), 1);
+        assert_eq!(primitive.backgrounds[0].brush, Brush::from(Color::WHITE));
+        assert_eq!(
+            primitive.border.visible_widths(),
+            Edges::new(2.0, 4.0, 0.0, 0.0)
+        );
+        assert_eq!(primitive.padding_widths, Edges::new(4.0, 0.0, 6.0, 0.0));
+        assert_eq!(primitive.corner_radii.top_left, Size::new(8.0, 4.0));
+        assert_eq!(primitive.corner_radii.bottom_right, Size::new(0.0, 10.0));
+        assert_eq!(primitive.corner_shapes.top_left, CornerShape::squircle());
+        assert_eq!(primitive.corner_shapes.bottom_right, CornerShape::scoop());
+    }
+
+    #[test]
+    fn local_values_win_over_style_values() {
+        let mut registry = PropertyRegistry::new();
+        let surface = register_surface(&mut registry);
+        let theme = ThemeBuilder::new().build();
+        let mut element = Element::new(1);
+        element.store.set_local(surface.border_widths.top, 6.0);
+
+        let style = StyleBuilder::new()
+            .set(surface.border_widths.top, 2.0)
+            .build();
+        let cascade = StyleCascadeBuilder::new()
+            .push_style(StyleOrigin::Base, style)
+            .build();
+        let cx = ResolveCx::new(&registry, &theme, NoResolveParentLookup);
+
+        let primitive = surface.resolve_surface(
+            &cx,
+            &element,
+            Some(StyleMatch::new(&cascade, cascade.root_state())),
+        );
+
+        assert_eq!(primitive.border.top.width, 6.0);
+    }
+}


### PR DESCRIPTION
This adds a renderer-neutral box decoration geometry layer and wires surface presentation through it.

`understory_box_decoration` is a new `no_std` geometry kernel for resolved box decorations. It owns physical edge widths, border/padding/content contours, fitted radii, corner shapes, central side regions, and caller-owned Kurbo path emission. It does not own style parsing, logical-to-physical mapping, brushes, layout, hit policy, or renderer commands.

This also adds `understory_presentation_properties`, a small adapter crate that registers canonical `Surface.*` dependency properties and resolves property/style values into `understory_presentation::SurfacePrimitive`.

## What Changed

* Added `understory_box_decoration`.
* Added physical `Edges<T>` and `Corners<T>` containers.
* Added `BoxArea`, `Side`, `BoxContour`, `ResolvedCorner`, and `BoxDecorationGeometry`.
* Added `CornerShape` and `Superellipse` support for round, square, bevel, scoop, notch, and squircle-style corners.
* Store resolved contours and parameters instead of materialized paths.
* Added writer APIs for background clips and even-odd border ring paths.
* Updated `SurfacePrimitive` to carry padding widths and corner shapes.
* Added `understory_presentation_properties` for surface background, border, padding, radius, and corner-shape properties.
* Added docs, changelogs, README content, and examples for the new pipeline.

## Notes

`SurfacePrimitive::padding_widths` is decoration padding used to derive the content contour. Toolkits that also use padding for layout should resolve padding once and copy the same values into presentation so layout content insets and painted contours do not drift.

Border ring paths are compound paths containing the outer border contour and inner padding contour. Renderers must use an even-odd fill rule, or an equivalent path-difference operation, when painting them as hollow borders.