### PR TITLE
property: add erased clear-local APIs

### DIFF
--- a/understory_property/README.md
+++ b/understory_property/README.md
@@ -54,10 +54,13 @@ precedence order.
 ### Key Operations
 
 - `set_local(property, value)` - set a local value
+- `clear_local(property)` - clear the ordinary Local source slot
 - `set_animation(property, value)` - set an animation value
 - `get_effective_local(property, registry)` - Animation → Local → default
 - `set_local_notifying(property, value, registry)` - set a local value and
   return dirty channels when the effective local value changes
+- `clear_local_erased_notifying(id, registry)` - clear a Local slot from
+  type-erased binding/adaptor code and return conservative dirty channels
 
 ## Invalidation Integration
 

--- a/understory_property/src/lib.rs
+++ b/understory_property/src/lib.rs
@@ -37,10 +37,13 @@
 //! ### Key Operations
 //!
 //! - `set_local(property, value)` - set a local value
+//! - `clear_local(property)` - clear the ordinary Local source slot
 //! - `set_animation(property, value)` - set an animation value
 //! - `get_effective_local(property, registry)` - Animation → Local → default
 //! - `set_local_notifying(property, value, registry)` - set a local value and
 //!   return dirty channels when the effective local value changes
+//! - `clear_local_erased_notifying(id, registry)` - clear a Local slot from
+//!   type-erased binding/adaptor code and return conservative dirty channels
 //!
 //! ## Invalidation Integration
 //!

--- a/understory_property/src/object.rs
+++ b/understory_property/src/object.rs
@@ -9,7 +9,7 @@
 
 use invalidation::ChannelSet;
 
-use crate::id::Property;
+use crate::id::{Property, PropertyId};
 use crate::registry::PropertyRegistry;
 use crate::store::{LocalValueSource, PropertyStore};
 
@@ -564,7 +564,7 @@ pub trait DependencyObjectExt<K: Copy + Eq>: DependencyObject<K> {
         // winner and no animation is masking the layer. If a lower source
         // shadowed by `source` happens to hold an equal value, this still
         // contributes channels — bulk-clear doesn't compare typed values.
-        let ids_affected: alloc::vec::Vec<crate::id::PropertyId> = store
+        let ids_affected: alloc::vec::Vec<PropertyId> = store
             .local_property_ids_at_source(source)
             .filter(|id| {
                 // Animation masks the local layer entirely.
@@ -599,6 +599,18 @@ pub trait DependencyObjectExt<K: Copy + Eq>: DependencyObject<K> {
         self.property_store_mut().clear_local(property)
     }
 
+    /// Clears the value in the [`LocalValueSource::Local`] slot for a type-erased property id.
+    ///
+    /// This is useful for binding hosts and adapters that carry runtime
+    /// [`PropertyId`] values rather than typed [`Property<T>`] handles. Lower
+    /// local-layer source slots are untouched and may become the new winning
+    /// local value.
+    ///
+    /// Returns `true` if a value was removed.
+    fn clear_local_erased(&mut self, id: PropertyId) -> bool {
+        self.property_store_mut().clear_local_erased(id)
+    }
+
     /// Clears the value at a specific local-layer source for `property`.
     ///
     /// Returns `true` if a value was removed.
@@ -609,6 +621,17 @@ pub trait DependencyObjectExt<K: Copy + Eq>: DependencyObject<K> {
     ) -> bool {
         self.property_store_mut()
             .clear_local_at_source(property, source)
+    }
+
+    /// Clears a source slot for a type-erased property id.
+    ///
+    /// This is the erased twin of
+    /// [`clear_local_at_source`](Self::clear_local_at_source).
+    ///
+    /// Returns `true` if a value was removed.
+    fn clear_local_erased_at_source(&mut self, id: PropertyId, source: LocalValueSource) -> bool {
+        self.property_store_mut()
+            .clear_local_erased_at_source(id, source)
     }
 
     /// Clears every value (every local source and animation) for `property`.
@@ -661,6 +684,23 @@ pub trait DependencyObjectExt<K: Copy + Eq>: DependencyObject<K> {
         ChannelSet::empty()
     }
 
+    /// Clears the [`LocalValueSource::Local`] slot for a type-erased property id
+    /// and returns affected channels.
+    ///
+    /// This is conservative: it returns `affects_channels` when clearing Local
+    /// may change the effective local value, but it does not run typed
+    /// `on_changed` callbacks or compare the value revealed underneath. Use
+    /// [`clear_local_notifying`](Self::clear_local_notifying) when the caller
+    /// has a typed property handle and needs exact callback behavior.
+    fn clear_local_erased_notifying(
+        &mut self,
+        id: PropertyId,
+        registry: &PropertyRegistry,
+    ) -> ChannelSet {
+        self.property_store_mut()
+            .clear_local_erased_notifying(id, registry)
+    }
+
     /// Clears the value at `source` for `property` and notifies if the
     /// effective value changed.
     ///
@@ -705,6 +745,22 @@ pub trait DependencyObjectExt<K: Copy + Eq>: DependencyObject<K> {
         }
 
         ChannelSet::empty()
+    }
+
+    /// Clears a source slot for a type-erased property id and returns affected channels.
+    ///
+    /// This is the erased twin of
+    /// [`clear_local_at_source_notifying`](Self::clear_local_at_source_notifying).
+    /// It returns a conservative channel set and does not run typed
+    /// `on_changed` callbacks.
+    fn clear_local_erased_at_source_notifying(
+        &mut self,
+        id: PropertyId,
+        source: LocalValueSource,
+        registry: &PropertyRegistry,
+    ) -> ChannelSet {
+        self.property_store_mut()
+            .clear_local_erased_at_source_notifying(id, source, registry)
     }
 
     /// Clears the animation value.
@@ -877,6 +933,22 @@ mod tests {
 
         assert!(element.clear_local(width));
         assert!(!element.has_local(width));
+    }
+
+    #[test]
+    fn ext_clear_local_erased() {
+        let (_, width) = setup_registry();
+        let mut element = TestElement::new(1, None);
+
+        element.set_local_with_source(width, 25.0, LocalValueSource::TemplateBinding);
+        element.set_local(width, 100.0);
+
+        assert!(element.clear_local_erased(width.id()));
+        assert_eq!(element.get_local_value(width), Some(&25.0));
+        assert_eq!(
+            element.get_local_source(width),
+            Some(LocalValueSource::TemplateBinding)
+        );
     }
 
     #[test]
@@ -1173,6 +1245,43 @@ mod tests {
         assert!(element.get_local_value(width).is_none());
         assert_eq!(element.get_effective_local(width, &registry), 50.0);
         assert_eq!(callback_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn ext_clear_local_erased_notifying_returns_conservative_channels() {
+        use alloc::sync::Arc;
+        use core::sync::atomic::{AtomicUsize, Ordering};
+        use invalidation::Channel;
+
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .on_changed({
+                    let callback_count = Arc::clone(&callback_count);
+                    move |_, _| {
+                        callback_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        element.set_local(width, 10.0);
+
+        let channels = element.clear_local_erased_notifying(width.id(), &registry);
+
+        assert!(channels.contains(LAYOUT));
+        assert!(element.get_local_value(width).is_none());
+        assert_eq!(
+            callback_count.load(Ordering::Relaxed),
+            0,
+            "erased clear reports channels but cannot run typed callbacks"
+        );
     }
 
     #[test]
@@ -1690,6 +1799,37 @@ mod tests {
         );
 
         assert!(channels.is_empty());
+    }
+
+    #[test]
+    fn ext_clear_local_erased_at_source_notifying_clears_shadowed_slot_without_channels() {
+        use invalidation::Channel;
+
+        let mut registry = PropertyRegistry::new();
+        let width = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(Channel::new(0).into_set())
+                .build(),
+        );
+
+        let mut element = TestElement::new(1, None);
+        element.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+        element.set_local(width, 99.0);
+
+        let channels = element.clear_local_erased_at_source_notifying(
+            width.id(),
+            LocalValueSource::TemplateBinding,
+            &registry,
+        );
+
+        assert!(channels.is_empty());
+        assert_eq!(element.get_effective_local(width, &registry), 99.0);
+        assert!(
+            !element
+                .property_store()
+                .has_local_at_source(width, LocalValueSource::TemplateBinding)
+        );
     }
 
     #[test]

--- a/understory_property/src/store.rs
+++ b/understory_property/src/store.rs
@@ -561,6 +561,20 @@ impl<K: Copy + Eq> PropertyStore<K> {
         self.slot_clear_id(property.id(), LocalValueSource::Local)
     }
 
+    /// Clears the value at [`LocalValueSource::Local`] for a type-erased property id.
+    ///
+    /// This is the erased twin of [`Self::clear_local`]. It is useful for
+    /// binding hosts and adapters that carry [`PropertyId`] values rather than
+    /// typed [`Property<T>`] handles.
+    ///
+    /// Other source slots are untouched and may become the new winning local
+    /// value after this call.
+    ///
+    /// Returns `true` if a Local entry was removed.
+    pub fn clear_local_erased(&mut self, id: PropertyId) -> bool {
+        self.slot_clear_id(id, LocalValueSource::Local)
+    }
+
     /// Clears the value at a specific local-layer source for `property`.
     ///
     /// Returns `true` if a value was removed from that source's slot.
@@ -570,6 +584,65 @@ impl<K: Copy + Eq> PropertyStore<K> {
         source: LocalValueSource,
     ) -> bool {
         self.slot_clear_id(property.id(), source)
+    }
+
+    /// Clears the value at a specific local-layer source for a type-erased property id.
+    ///
+    /// This is the erased twin of [`Self::clear_local_at_source`].
+    ///
+    /// Returns `true` if a value was removed from that source's slot.
+    pub fn clear_local_erased_at_source(
+        &mut self,
+        id: PropertyId,
+        source: LocalValueSource,
+    ) -> bool {
+        self.slot_clear_id(id, source)
+    }
+
+    /// Clears the Local slot for a type-erased property id and returns affected channels.
+    ///
+    /// This is the erased twin of [`Self::clear_local_erased`]. It returns a
+    /// conservative `affects_channels` set when clearing the Local slot may
+    /// change the effective local value. It does not run typed
+    /// `on_changed` callbacks or compare the value revealed underneath; callers
+    /// that need exact callback behavior should use typed
+    /// [`DependencyObjectExt::clear_local_notifying`](crate::DependencyObjectExt::clear_local_notifying).
+    pub fn clear_local_erased_notifying(
+        &mut self,
+        id: PropertyId,
+        registry: &PropertyRegistry,
+    ) -> ChannelSet {
+        self.clear_local_erased_at_source_notifying(id, LocalValueSource::Local, registry)
+    }
+
+    /// Clears a source slot for a type-erased property id and returns affected channels.
+    ///
+    /// A property contributes channels only when `source` currently wins the
+    /// local layer and no animation value masks it. The result is conservative:
+    /// if clearing `source` reveals an equal value from a lower source, this
+    /// still returns the property's channels because the erased path cannot do
+    /// typed equality. Use typed
+    /// [`DependencyObjectExt::clear_local_at_source_notifying`](crate::DependencyObjectExt::clear_local_at_source_notifying)
+    /// for exact value comparison and changed callbacks.
+    pub fn clear_local_erased_at_source_notifying(
+        &mut self,
+        id: PropertyId,
+        source: LocalValueSource,
+        registry: &PropertyRegistry,
+    ) -> ChannelSet {
+        if self.slot_get(id, source).is_none() {
+            return ChannelSet::empty();
+        }
+
+        let may_affect =
+            !self.animation_entries_has(id) && self.winning_local_source_for_id(id) == Some(source);
+        self.slot_clear_id(id, source);
+
+        if may_affect {
+            registry.affects_channels(id)
+        } else {
+            ChannelSet::empty()
+        }
     }
 
     /// Clears every value held by the given source.
@@ -1133,6 +1206,107 @@ mod tests {
             store.get_local_source(width),
             Some(LocalValueSource::TemplateBinding)
         );
+    }
+
+    #[test]
+    fn clear_local_erased_reveals_template_binding() {
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+        store.set_local(width, 30.0);
+
+        assert!(store.clear_local_erased(width.id()));
+        assert_eq!(store.get_local(width), Some(&20.0));
+        assert_eq!(
+            store.get_local_source(width),
+            Some(LocalValueSource::TemplateBinding)
+        );
+        assert!(!store.clear_local_erased(width.id()));
+    }
+
+    #[test]
+    fn clear_local_erased_at_source_targets_one_slot() {
+        let (_, width, _) = setup_registry();
+        let mut store = PropertyStore::<u32>::new(1);
+
+        store.set_local_with_source(width, 10.0, LocalValueSource::TemplateDefault);
+        store.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+
+        assert!(store.clear_local_erased_at_source(width.id(), LocalValueSource::TemplateBinding));
+        assert_eq!(store.get_local(width), Some(&10.0));
+        assert_eq!(
+            store.get_local_source(width),
+            Some(LocalValueSource::TemplateDefault)
+        );
+    }
+
+    #[test]
+    fn clear_local_erased_notifying_reports_visible_local_change() {
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let width: Property<f64> = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .build(),
+        );
+        let mut store = PropertyStore::<u32>::new(1);
+        store.set_local(width, 30.0);
+
+        let channels = store.clear_local_erased_notifying(width.id(), &registry);
+
+        assert!(channels.contains(LAYOUT));
+        assert!(!store.has_local(width));
+    }
+
+    #[test]
+    fn clear_local_erased_at_source_notifying_skips_masked_slots() {
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let width: Property<f64> = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .build(),
+        );
+        let mut store = PropertyStore::<u32>::new(1);
+        store.set_local(width, 30.0);
+        store.set_local_with_source(width, 20.0, LocalValueSource::TemplateBinding);
+
+        let channels = store.clear_local_erased_at_source_notifying(
+            width.id(),
+            LocalValueSource::TemplateBinding,
+            &registry,
+        );
+
+        assert!(channels.is_empty());
+        assert_eq!(store.get_local(width), Some(&30.0));
+        assert!(!store.has_local_at_source(width, LocalValueSource::TemplateBinding));
+    }
+
+    #[test]
+    fn clear_local_erased_notifying_skips_animation_masked_local() {
+        const LAYOUT: Channel = Channel::new(0);
+
+        let mut registry = PropertyRegistry::new();
+        let width: Property<f64> = registry.register(
+            "Width",
+            PropertyMetadataBuilder::new(0.0_f64)
+                .affects_channels(LAYOUT.into_set())
+                .build(),
+        );
+        let mut store = PropertyStore::<u32>::new(1);
+        store.set_local(width, 30.0);
+        store.set_animation(width, 50.0);
+
+        let channels = store.clear_local_erased_notifying(width.id(), &registry);
+
+        assert!(channels.is_empty());
+        assert!(!store.has_local_at_source(width, LocalValueSource::Local));
+        assert_eq!(store.get_effective_local(width, &registry), 50.0);
     }
 
     #[test]


### PR DESCRIPTION
Add `PropertyStore` and `DependencyObjectExt` helpers for clearing the ordinary Local slot from type-erased `PropertyId` call sites, plus source-specific erased clear helpers for layered local values.

The notifying variants return conservative affected channels when the cleared slot may change the effective local value, while typed `clear_local_notifying` remains the exact path for equality checks and changed callbacks. This gives binding hosts and adapters a clean clear path without requiring a typed `Property<T>` handle.

Document the new operation in the crate overview and add tests for lower-source reveal behavior, shadowed-slot clears, animation masking, and conservative erased notification.