### PR TITLE
animation: add `AnimationPlayback` controller

### DIFF
--- a/understory_animation/src/lib.rs
+++ b/understory_animation/src/lib.rs
@@ -59,7 +59,9 @@ mod stack;
 mod timing;
 
 pub use effect::{CompositeOperation, Keyframe, KeyframeEffect};
-pub use playback::{AnimationPlayState, FillMode, PlaybackDirection};
+pub use playback::{
+    AnimationPlayState, AnimationPlayback, AnimationPlaybackEventKind, FillMode, PlaybackDirection,
+};
 pub use stack::{StackEffect, TargetSample, TargetStack, sample_effects};
 pub use timing::{AnimationTiming, TimingPhase, TimingSample};
 

--- a/understory_animation/src/playback.rs
+++ b/understory_animation/src/playback.rs
@@ -1,6 +1,9 @@
 // Copyright 2026 the Understory Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use understory_animation_timeline::TimelineTime;
+use understory_timing::TimerDuration;
+
 /// Playback state for a retained animation instance.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AnimationPlayState {
@@ -13,6 +16,271 @@ pub enum AnimationPlayState {
     Paused,
     /// The animation has reached its natural end.
     Finished,
+}
+
+/// Event kind produced by playback state transitions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AnimationPlaybackEventKind {
+    /// Playback entered the running state from an inactive state.
+    Started,
+    /// Playback reached a natural or explicit endpoint.
+    Finished,
+    /// Playback was explicitly canceled and returned to idle.
+    Canceled,
+}
+
+/// Retained playback controller for one animation instance.
+///
+/// The controller maps absolute timeline time into local animation time. It
+/// does not own effects, target keys, event queues, property storage, or frame
+/// scheduling.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AnimationPlayback {
+    state: AnimationPlayState,
+    anchor_timeline_time: TimelineTime,
+    anchor_local_time: TimelineTime,
+    playback_rate: f64,
+}
+
+impl AnimationPlayback {
+    /// Creates an idle playback controller at local time zero.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            state: AnimationPlayState::Idle,
+            anchor_timeline_time: TimelineTime::ZERO,
+            anchor_local_time: TimelineTime::ZERO,
+            playback_rate: 1.0,
+        }
+    }
+
+    /// Creates a running playback controller starting at `timeline_time`.
+    #[must_use]
+    pub const fn running_at(timeline_time: TimelineTime) -> Self {
+        Self {
+            state: AnimationPlayState::Running,
+            anchor_timeline_time: timeline_time,
+            anchor_local_time: TimelineTime::ZERO,
+            playback_rate: 1.0,
+        }
+    }
+
+    /// Returns the current playback state.
+    #[must_use]
+    pub const fn state(self) -> AnimationPlayState {
+        self.state
+    }
+
+    /// Returns the playback rate.
+    #[must_use]
+    pub const fn playback_rate(self) -> f64 {
+        self.playback_rate
+    }
+
+    /// Returns whether this controller is running.
+    #[must_use]
+    pub const fn is_running(self) -> bool {
+        matches!(self.state, AnimationPlayState::Running)
+    }
+
+    /// Returns the current local animation time at `timeline_time`.
+    ///
+    /// Idle animations produce no local time. Running playback treats timeline
+    /// times before the current anchor as zero elapsed time; callers that need
+    /// arbitrary scrubbing should use [`AnimationPlayback::seek`] to establish
+    /// a new local-time anchor.
+    #[must_use]
+    pub fn current_time(self, timeline_time: TimelineTime) -> Option<TimelineTime> {
+        match self.state {
+            AnimationPlayState::Idle => None,
+            AnimationPlayState::Paused | AnimationPlayState::Finished => {
+                Some(self.anchor_local_time)
+            }
+            AnimationPlayState::Running => Some(self.running_time(timeline_time)),
+        }
+    }
+
+    /// Starts or resumes playback at `timeline_time`.
+    ///
+    /// Starting from [`AnimationPlayState::Idle`] or
+    /// [`AnimationPlayState::Finished`] begins at local time zero. If the
+    /// stored playback rate is negative or zero, it is normalized to a positive
+    /// finite rate so a fresh start does not immediately clamp at zero.
+    /// To play backward from an endpoint, seek to that endpoint and then call
+    /// [`AnimationPlayback::reverse`].
+    pub fn play(&mut self, timeline_time: TimelineTime) -> Option<AnimationPlaybackEventKind> {
+        match self.state {
+            AnimationPlayState::Running => None,
+            AnimationPlayState::Idle | AnimationPlayState::Finished => {
+                self.anchor_timeline_time = timeline_time;
+                self.anchor_local_time = TimelineTime::ZERO;
+                self.playback_rate = inactive_start_rate(self.playback_rate);
+                self.state = AnimationPlayState::Running;
+                Some(AnimationPlaybackEventKind::Started)
+            }
+            AnimationPlayState::Paused => {
+                self.anchor_timeline_time = timeline_time;
+                self.state = AnimationPlayState::Running;
+                None
+            }
+        }
+    }
+
+    /// Pauses playback, preserving the sampled local time at `timeline_time`.
+    pub fn pause(&mut self, timeline_time: TimelineTime) {
+        if self.state == AnimationPlayState::Running {
+            self.anchor_local_time = self.running_time(timeline_time);
+            self.anchor_timeline_time = timeline_time;
+            self.state = AnimationPlayState::Paused;
+        }
+    }
+
+    /// Seeks to `local_time`, preserving the current play state.
+    ///
+    /// Seeking an idle controller makes it paused at `local_time`, which gives
+    /// deterministic manual sampling without implicitly starting playback.
+    pub fn seek(&mut self, local_time: TimelineTime, timeline_time: TimelineTime) {
+        self.anchor_local_time = local_time;
+        self.anchor_timeline_time = timeline_time;
+        if self.state == AnimationPlayState::Idle {
+            self.state = AnimationPlayState::Paused;
+        }
+    }
+
+    /// Reverses playback direction while preserving local continuity.
+    ///
+    /// A zero playback rate is treated as `-1.0` so reverse always produces
+    /// motion when playback is running.
+    pub fn reverse(&mut self, timeline_time: TimelineTime) {
+        let local_time = self
+            .current_time(timeline_time)
+            .unwrap_or(TimelineTime::ZERO);
+        self.anchor_local_time = local_time;
+        self.anchor_timeline_time = timeline_time;
+        self.playback_rate = if self.playback_rate == 0.0 {
+            -1.0
+        } else {
+            -self.playback_rate
+        };
+        if self.state != AnimationPlayState::Idle {
+            self.state = AnimationPlayState::Running;
+        }
+    }
+
+    /// Sets the playback rate while preserving local continuity.
+    ///
+    /// Non-finite rates are ignored.
+    pub fn set_playback_rate(&mut self, playback_rate: f64, timeline_time: TimelineTime) {
+        if !playback_rate.is_finite() {
+            return;
+        }
+        if let Some(local_time) = self.current_time(timeline_time) {
+            self.anchor_local_time = local_time;
+            self.anchor_timeline_time = timeline_time;
+        }
+        self.playback_rate = playback_rate;
+    }
+
+    /// Finishes playback at `local_time`.
+    pub fn finish(&mut self, local_time: TimelineTime) -> Option<AnimationPlaybackEventKind> {
+        if matches!(
+            self.state,
+            AnimationPlayState::Idle | AnimationPlayState::Finished
+        ) {
+            return None;
+        }
+        self.anchor_local_time = local_time;
+        self.state = AnimationPlayState::Finished;
+        Some(AnimationPlaybackEventKind::Finished)
+    }
+
+    /// Cancels playback and returns to the idle state.
+    pub fn cancel(&mut self) -> Option<AnimationPlaybackEventKind> {
+        if self.state == AnimationPlayState::Idle {
+            return None;
+        }
+        self.state = AnimationPlayState::Idle;
+        self.anchor_local_time = TimelineTime::ZERO;
+        self.anchor_timeline_time = TimelineTime::ZERO;
+        Some(AnimationPlaybackEventKind::Canceled)
+    }
+
+    /// Samples local time and finishes when `finite_duration` is reached.
+    ///
+    /// `finite_duration` is the finite local playback duration to clamp to,
+    /// usually [`AnimationTiming::total_duration`](crate::AnimationTiming::total_duration).
+    /// Pass `None` for indefinite effects.
+    ///
+    /// Returns any event produced by the sampling step.
+    pub fn sample_with_completion(
+        &mut self,
+        timeline_time: TimelineTime,
+        finite_duration: Option<TimerDuration>,
+    ) -> (Option<TimelineTime>, Option<AnimationPlaybackEventKind>) {
+        let Some(local_time) = self.current_time(timeline_time) else {
+            return (None, None);
+        };
+
+        let Some(duration) = finite_duration else {
+            return (Some(local_time), None);
+        };
+
+        if self.state != AnimationPlayState::Running {
+            return (Some(local_time), None);
+        }
+
+        if self.playback_rate >= 0.0 && local_time.duration() >= duration {
+            let local_time = TimelineTime::from_duration(duration);
+            return (Some(local_time), self.finish(local_time));
+        }
+
+        if self.playback_rate < 0.0 && local_time == TimelineTime::ZERO {
+            return (Some(TimelineTime::ZERO), self.finish(TimelineTime::ZERO));
+        }
+
+        (Some(local_time), None)
+    }
+
+    fn running_time(self, timeline_time: TimelineTime) -> TimelineTime {
+        let elapsed = timeline_time.saturating_duration_since(self.anchor_timeline_time);
+        let scaled = scale_duration(elapsed, self.playback_rate.abs());
+        if self.playback_rate >= 0.0 {
+            self.anchor_local_time.saturating_add(scaled)
+        } else {
+            TimelineTime::from_duration(self.anchor_local_time.duration().saturating_sub(scaled))
+        }
+    }
+}
+
+fn inactive_start_rate(playback_rate: f64) -> f64 {
+    if playback_rate.is_finite() && playback_rate != 0.0 {
+        playback_rate.abs()
+    } else {
+        1.0
+    }
+}
+
+impl Default for AnimationPlayback {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "finite non-negative playback durations saturate before conversion"
+)]
+fn scale_duration(duration: TimerDuration, scale: f64) -> TimerDuration {
+    if !scale.is_finite() || scale <= 0.0 || duration == 0 {
+        0
+    } else {
+        let scaled = duration as f64 * scale;
+        if scaled >= TimerDuration::MAX as f64 {
+            TimerDuration::MAX
+        } else {
+            scaled as TimerDuration
+        }
+    }
 }
 
 /// Direction used to map iteration progress into effect progress.

--- a/understory_animation/src/tests.rs
+++ b/understory_animation/src/tests.rs
@@ -6,8 +6,9 @@ use alloc::vec;
 use understory_animation_timeline::{AnimationTimeline, ManualTimeline, TimelineTime};
 
 use crate::{
-    AnimationTiming, CompositeOperation, FillMode, Keyframe, KeyframeEffect, PlaybackDirection,
-    StackEffect, TargetStack, TimingPhase, sample_effects,
+    AnimationPlayState, AnimationPlayback, AnimationPlaybackEventKind, AnimationTiming,
+    CompositeOperation, FillMode, Keyframe, KeyframeEffect, PlaybackDirection, StackEffect,
+    TargetStack, TimingPhase, sample_effects,
 };
 
 const MS: u64 = 1_000_000;
@@ -148,4 +149,148 @@ fn additive_and_accumulative_effects_fold_into_current_value() {
     assert_eq!(sample.value, 1.0 + 3.0 + 15.0);
     assert_eq!(sample.active_effects, 2);
     assert_eq!(sample.unsupported_composites, 0);
+}
+
+#[test]
+fn playback_maps_timeline_time_to_local_time() {
+    let playback = AnimationPlayback::running_at(at_ms(10));
+
+    assert_eq!(playback.state(), AnimationPlayState::Running);
+    assert_eq!(playback.current_time(at_ms(10)), Some(at_ms(0)));
+    assert_eq!(playback.current_time(at_ms(35)), Some(at_ms(25)));
+}
+
+#[test]
+fn playback_pause_holds_and_play_resumes_from_hold_time() {
+    let mut playback = AnimationPlayback::running_at(at_ms(10));
+
+    playback.pause(at_ms(35));
+    assert_eq!(playback.state(), AnimationPlayState::Paused);
+    assert_eq!(playback.current_time(at_ms(80)), Some(at_ms(25)));
+
+    assert_eq!(playback.play(at_ms(80)), None);
+    assert_eq!(playback.current_time(at_ms(95)), Some(at_ms(40)));
+}
+
+#[test]
+fn playback_seek_reanchors_without_forcing_running_state() {
+    let mut playback = AnimationPlayback::new();
+
+    playback.seek(at_ms(40), at_ms(10));
+
+    assert_eq!(playback.state(), AnimationPlayState::Paused);
+    assert_eq!(playback.current_time(at_ms(100)), Some(at_ms(40)));
+
+    assert_eq!(playback.play(at_ms(100)), None);
+    assert_eq!(playback.current_time(at_ms(125)), Some(at_ms(65)));
+}
+
+#[test]
+fn playback_rate_and_reverse_preserve_local_continuity() {
+    let mut playback = AnimationPlayback::running_at(at_ms(0));
+
+    playback.set_playback_rate(2.0, at_ms(20));
+    assert_eq!(playback.current_time(at_ms(30)), Some(at_ms(40)));
+
+    playback.reverse(at_ms(30));
+    assert_eq!(playback.playback_rate(), -2.0);
+    assert_eq!(playback.current_time(at_ms(35)), Some(at_ms(30)));
+}
+
+#[test]
+fn playback_fractional_rate_does_not_sample_ahead() {
+    let mut playback = AnimationPlayback::running_at(at_ms(0));
+
+    playback.set_playback_rate(0.5, at_ms(0));
+
+    // Local time may lag by sub-nanosecond truncation, but it must not round
+    // ahead of the timeline. Early samples can finish or fire cues too soon.
+    assert_eq!(
+        playback.current_time(TimelineTime::from_duration(3)),
+        Some(TimelineTime::from_duration(1))
+    );
+}
+
+#[test]
+fn playback_completion_finishes_at_boundaries() {
+    let mut playback = AnimationPlayback::running_at(at_ms(0));
+
+    let (local_time, event) = playback
+        .sample_with_completion(at_ms(150), AnimationTiming::new(100 * MS).total_duration());
+
+    assert_eq!(local_time, Some(at_ms(100)));
+    assert_eq!(event, Some(AnimationPlaybackEventKind::Finished));
+    assert_eq!(playback.state(), AnimationPlayState::Finished);
+    assert_eq!(playback.current_time(at_ms(300)), Some(at_ms(100)));
+}
+
+#[test]
+fn playback_from_inactive_normalizes_non_positive_rate() {
+    let mut playback = AnimationPlayback::new();
+
+    playback.set_playback_rate(-2.0, at_ms(0));
+    assert_eq!(playback.playback_rate(), -2.0);
+    assert_eq!(
+        playback.play(at_ms(10)),
+        Some(AnimationPlaybackEventKind::Started)
+    );
+    assert_eq!(playback.playback_rate(), 2.0);
+    assert_eq!(playback.current_time(at_ms(20)), Some(at_ms(20)));
+
+    assert_eq!(
+        playback.cancel(),
+        Some(AnimationPlaybackEventKind::Canceled)
+    );
+    playback.set_playback_rate(0.0, at_ms(20));
+    assert_eq!(
+        playback.play(at_ms(30)),
+        Some(AnimationPlaybackEventKind::Started)
+    );
+    assert_eq!(playback.playback_rate(), 1.0);
+}
+
+#[test]
+fn playback_reverse_completion_finishes_at_zero_from_sought_endpoint() {
+    let mut playback = AnimationPlayback::new();
+
+    playback.seek(at_ms(100), at_ms(0));
+    playback.reverse(at_ms(0));
+    let (local_time, event) = playback
+        .sample_with_completion(at_ms(150), AnimationTiming::new(100 * MS).total_duration());
+
+    assert_eq!(playback.playback_rate(), -1.0);
+    assert_eq!(local_time, Some(TimelineTime::ZERO));
+    assert_eq!(event, Some(AnimationPlaybackEventKind::Finished));
+    assert_eq!(playback.state(), AnimationPlayState::Finished);
+}
+
+#[test]
+fn playback_cancel_returns_to_idle() {
+    let mut playback = AnimationPlayback::running_at(at_ms(0));
+
+    assert_eq!(
+        playback.cancel(),
+        Some(AnimationPlaybackEventKind::Canceled)
+    );
+
+    assert_eq!(playback.state(), AnimationPlayState::Idle);
+    assert_eq!(playback.current_time(at_ms(40)), None);
+    assert_eq!(playback.cancel(), None);
+}
+
+#[test]
+fn playback_cancel_from_finished_returns_to_idle() {
+    let mut playback = AnimationPlayback::running_at(at_ms(0));
+
+    assert_eq!(
+        playback.finish(at_ms(100)),
+        Some(AnimationPlaybackEventKind::Finished)
+    );
+    assert_eq!(
+        playback.cancel(),
+        Some(AnimationPlaybackEventKind::Canceled)
+    );
+
+    assert_eq!(playback.state(), AnimationPlayState::Idle);
+    assert_eq!(playback.current_time(at_ms(100)), None);
 }


### PR DESCRIPTION
Add a reusable playback controller for retained animation instances. It maps timeline time to local animation time and covers play, pause, seek, reverse, playback-rate changes, finish, cancel, and finite-duration completion reporting without knowing about UI targets, property storage, frame scheduling, or renderer writes.