### PR TITLE
presentation: add brush transforms to paint primitives

### DIFF
--- a/understory_presentation/README.md
+++ b/understory_presentation/README.md
@@ -54,6 +54,8 @@ property/style resolution, behavior, or paint command emission.
 - [`Primitive`]: resolved drawing primitive stored on a presentation node.
 - [`SurfacePrimitive`]: resolved surface fill, border, padding, corner
   shape, and shadow intent.
+- [`unit_brush_transform`]: common unit-square to bounds transform for
+  brush fills authored in unit coordinates.
 - [`TextPrimitive`]: umbrella for resolved text drawing intent.
 - [`PlainTextPrimitive`]: resolved plain-text content, foreground brush,
   decorations, and `parlance`-based single-run style.

--- a/understory_presentation/src/lib.rs
+++ b/understory_presentation/src/lib.rs
@@ -37,6 +37,8 @@
 //! - [`Primitive`]: resolved drawing primitive stored on a presentation node.
 //! - [`SurfacePrimitive`]: resolved surface fill, border, padding, corner
 //!   shape, and shadow intent.
+//! - [`unit_brush_transform`]: common unit-square to bounds transform for
+//!   brush fills authored in unit coordinates.
 //! - [`TextPrimitive`]: umbrella for resolved text drawing intent.
 //! - [`PlainTextPrimitive`]: resolved plain-text content, foreground brush,
 //!   decorations, and `parlance`-based single-run style.
@@ -142,7 +144,7 @@ pub use primitive::{
     BackgroundLayer, Border, BorderSide, ImageFit, ImagePrimitive, ImageSlice, NineSlice, PathFill,
     PathPaintOrder, PathPrimitive, PathStroke, PlainTextPrimitive, Primitive, Shadow, SliceMode,
     SurfacePrimitive, TextAlign, TextContent, TextDecoration, TextDecorations, TextLayout,
-    TextLineHeight, TextOverflow, TextPrimitive, TextStyle,
+    TextLineHeight, TextOverflow, TextPrimitive, TextStyle, unit_brush_transform,
 };
 pub use store::{PresentationNode, PresentationStore};
 pub use understory_box_decoration::{

--- a/understory_presentation/src/primitive/image.rs
+++ b/understory_presentation/src/primitive/image.rs
@@ -1,7 +1,10 @@
 // Copyright 2026 the Understory Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use peniko::{ImageBrush, ImageSampler, kurbo::Insets};
+use peniko::{
+    ImageBrush, ImageSampler,
+    kurbo::{Affine, Insets},
+};
 
 /// Resolved image drawing intent.
 ///
@@ -16,6 +19,14 @@ use peniko::{ImageBrush, ImageSampler, kurbo::Insets};
 pub struct ImagePrimitive<ImageKey = u64> {
     /// Image resource and sampling parameters.
     pub brush: ImageBrush<ImageKey>,
+
+    /// Optional image-brush transform.
+    ///
+    /// `ImageFit` and [`ImageSlice`] still define the image's placement in the
+    /// primitive bounds. This optional transform is an additional renderer-facing
+    /// brush transform for animated or art-directed image sampling. `None`
+    /// preserves the placement implied by `fit` and `slice`.
+    pub brush_transform: Option<Affine>,
 
     /// How the image maps into the node bounds.
     pub fit: ImageFit,
@@ -33,9 +44,17 @@ impl<ImageKey> ImagePrimitive<ImageKey> {
                 image,
                 sampler: ImageSampler::default(),
             },
+            brush_transform: None,
             fit: ImageFit::default(),
             slice: ImageSlice::default(),
         }
+    }
+
+    /// Sets the optional image-brush transform.
+    #[must_use]
+    pub fn with_brush_transform(mut self, transform: Affine) -> Self {
+        self.brush_transform = Some(transform);
+        self
     }
 }
 
@@ -122,8 +141,17 @@ mod tests {
 
         assert_eq!(image.brush.image, "button-background");
         assert_eq!(image.brush.sampler, ImageSampler::default());
+        assert_eq!(image.brush_transform, None);
         assert_eq!(image.fit, ImageFit::Stretch);
         assert_eq!(image.slice, ImageSlice::None);
+    }
+
+    #[test]
+    fn image_primitive_can_carry_brush_transform() {
+        let transform = Affine::scale_non_uniform(64.0, 32.0);
+        let image = ImagePrimitive::new("button-background").with_brush_transform(transform);
+
+        assert_eq!(image.brush_transform, Some(transform));
     }
 
     #[test]

--- a/understory_presentation/src/primitive/mod.rs
+++ b/understory_presentation/src/primitive/mod.rs
@@ -4,6 +4,7 @@
 //! Presentation primitives.
 
 use alloc::boxed::Box;
+use peniko::kurbo::{Affine, Rect, Vec2};
 
 mod image;
 mod path;
@@ -17,6 +18,18 @@ pub use text::{
     PlainTextPrimitive, TextAlign, TextContent, TextDecoration, TextDecorations, TextLayout,
     TextLineHeight, TextOverflow, TextPrimitive, TextStyle,
 };
+
+/// Returns a brush transform that maps the unit square into `bounds`.
+///
+/// This is the common base transform for gradients or image brushes authored in
+/// unit coordinates and fitted to a node's local bounds. Callers can compose an
+/// animated transform with this value before storing it on a brush-carrying
+/// primitive.
+#[must_use]
+pub fn unit_brush_transform(bounds: Rect) -> Affine {
+    Affine::translate(Vec2::new(bounds.x0, bounds.y0))
+        * Affine::scale_non_uniform(bounds.width(), bounds.height())
+}
 
 /// Resolved drawing primitive stored on a presentation node.
 ///
@@ -146,5 +159,19 @@ impl<ImageKey> Primitive<ImageKey> {
             Self::Surface(_) | Self::Text(_) | Self::Image(_) => None,
             Self::Path(path) => Some(path.as_mut()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use peniko::kurbo::Point;
+
+    #[test]
+    fn unit_brush_transform_maps_unit_square_to_bounds() {
+        let transform = unit_brush_transform(Rect::new(10.0, 20.0, 110.0, 70.0));
+
+        assert_eq!(transform * Point::new(0.0, 0.0), Point::new(10.0, 20.0));
+        assert_eq!(transform * Point::new(1.0, 1.0), Point::new(110.0, 70.0));
     }
 }

--- a/understory_presentation/src/primitive/path.rs
+++ b/understory_presentation/src/primitive/path.rs
@@ -90,6 +90,12 @@ pub struct PathFill {
     /// Brush used to fill the path interior.
     pub brush: Brush,
 
+    /// Optional brush-local to path-local transform.
+    ///
+    /// `None` means identity: the renderer samples the brush in path-local
+    /// coordinates without an additional brush transform.
+    pub brush_transform: Option<Affine>,
+
     /// Fill rule used to determine the path interior.
     pub rule: Fill,
 }
@@ -100,8 +106,16 @@ impl PathFill {
     pub fn new(brush: impl Into<Brush>) -> Self {
         Self {
             brush: brush.into(),
+            brush_transform: None,
             rule: Fill::NonZero,
         }
+    }
+
+    /// Sets the brush-local to path-local transform.
+    #[must_use]
+    pub fn with_brush_transform(mut self, transform: Affine) -> Self {
+        self.brush_transform = Some(transform);
+        self
     }
 
     /// Sets the fill rule.
@@ -118,6 +132,12 @@ pub struct PathStroke {
     /// Brush used to stroke the path outline.
     pub brush: Brush,
 
+    /// Optional brush-local to path-local transform.
+    ///
+    /// `None` means identity: the renderer samples the brush in path-local
+    /// coordinates without an additional brush transform.
+    pub brush_transform: Option<Affine>,
+
     /// Stroke style.
     pub stroke: Stroke,
 }
@@ -128,8 +148,16 @@ impl PathStroke {
     pub fn new(brush: impl Into<Brush>, width: f64) -> Self {
         Self {
             brush: brush.into(),
+            brush_transform: None,
             stroke: Stroke::new(width),
         }
+    }
+
+    /// Sets the brush-local to path-local transform.
+    #[must_use]
+    pub fn with_brush_transform(mut self, transform: Affine) -> Self {
+        self.brush_transform = Some(transform);
+        self
     }
 
     /// Replaces the stroke style.
@@ -170,6 +198,19 @@ mod tests {
             .stroke(PathStroke::new(Color::BLACK, 2.0));
 
         assert!(!path.is_empty());
+        assert_eq!(path.fill.as_ref().unwrap().brush_transform, None);
         assert_eq!(path.stroke.unwrap().stroke.width, 2.0);
+    }
+
+    #[test]
+    fn fill_and_stroke_can_carry_brush_transforms() {
+        let fill_transform = Affine::scale_non_uniform(8.0, 12.0);
+        let stroke_transform = Affine::translate((3.0, 5.0));
+
+        let fill = PathFill::new(Color::WHITE).with_brush_transform(fill_transform);
+        let stroke = PathStroke::new(Color::BLACK, 2.0).with_brush_transform(stroke_transform);
+
+        assert_eq!(fill.brush_transform, Some(fill_transform));
+        assert_eq!(stroke.brush_transform, Some(stroke_transform));
     }
 }

--- a/understory_presentation/src/primitive/surface.rs
+++ b/understory_presentation/src/primitive/surface.rs
@@ -4,7 +4,7 @@
 use smallvec::SmallVec;
 
 use crate::{BoxDecorationGeometry, Brush, Color, CornerRadii, CornerShapes, Edges};
-use peniko::kurbo::Rect;
+use peniko::kurbo::{Affine, Rect};
 
 /// Resolved box-decoration drawing intent.
 ///
@@ -79,6 +79,12 @@ impl SurfacePrimitive {
 pub struct BackgroundLayer {
     /// Brush used to fill the node's local bounds.
     pub brush: Brush,
+
+    /// Optional brush-local to node-local transform.
+    ///
+    /// `None` means identity: the renderer samples the brush in the primitive's
+    /// local coordinate space without an additional brush transform.
+    pub brush_transform: Option<Affine>,
 }
 
 impl BackgroundLayer {
@@ -87,7 +93,15 @@ impl BackgroundLayer {
     pub fn new(brush: impl Into<Brush>) -> Self {
         Self {
             brush: brush.into(),
+            brush_transform: None,
         }
+    }
+
+    /// Sets the brush-local to node-local transform.
+    #[must_use]
+    pub fn with_brush_transform(mut self, transform: Affine) -> Self {
+        self.brush_transform = Some(transform);
+        self
     }
 }
 
@@ -168,6 +182,12 @@ pub struct BorderSide {
     /// Border brush.
     pub brush: Option<Brush>,
 
+    /// Optional brush-local to node-local transform for this side.
+    ///
+    /// `None` means identity: the renderer samples the brush in the primitive's
+    /// local coordinate space without an additional brush transform.
+    pub brush_transform: Option<Affine>,
+
     /// Border width in logical pixels.
     pub width: f64,
 }
@@ -178,8 +198,16 @@ impl BorderSide {
     pub fn new(brush: impl Into<Brush>, width: f64) -> Self {
         Self {
             brush: Some(brush.into()),
+            brush_transform: None,
             width,
         }
+    }
+
+    /// Sets the brush-local to node-local transform.
+    #[must_use]
+    pub fn with_brush_transform(mut self, transform: Affine) -> Self {
+        self.brush_transform = Some(transform);
+        self
     }
 
     /// Returns true when the side should not draw.
@@ -250,6 +278,15 @@ mod tests {
             surface.backgrounds[0].brush,
             Brush::from(Color::from_rgb8(40, 50, 60))
         );
+        assert_eq!(surface.backgrounds[0].brush_transform, None);
+    }
+
+    #[test]
+    fn background_layer_can_carry_brush_transform() {
+        let transform = Affine::scale_non_uniform(12.0, 24.0);
+        let layer = BackgroundLayer::new(Color::BLACK).with_brush_transform(transform);
+
+        assert_eq!(layer.brush_transform, Some(transform));
     }
 
     #[test]
@@ -296,6 +333,7 @@ mod tests {
                 top: BorderSide::new(Color::BLACK, 2.0),
                 right: BorderSide {
                     brush: None,
+                    brush_transform: None,
                     width: 6.0,
                 },
                 bottom: BorderSide::new(Color::BLACK, -4.0),
@@ -335,5 +373,13 @@ mod tests {
         assert_eq!(mixed.uniform_visible_side(), None);
 
         assert_eq!(Border::default().uniform_visible_side(), None);
+    }
+
+    #[test]
+    fn border_side_can_carry_brush_transform() {
+        let transform = Affine::translate((3.0, 5.0));
+        let side = BorderSide::new(Color::BLACK, 2.0).with_brush_transform(transform);
+
+        assert_eq!(side.brush_transform, Some(transform));
     }
 }

--- a/understory_presentation/src/primitive/text.rs
+++ b/understory_presentation/src/primitive/text.rs
@@ -11,6 +11,7 @@ use parlance::{
 };
 
 use crate::Brush;
+use peniko::kurbo::Affine;
 
 /// Resolved text drawing intent.
 ///
@@ -66,6 +67,12 @@ pub struct PlainTextPrimitive {
 
     /// Optional foreground brush.
     pub foreground: Option<Brush>,
+
+    /// Optional brush-local to text-local transform for the foreground brush.
+    ///
+    /// `None` means identity: the lowerer samples the foreground brush in
+    /// text-local coordinates without an additional brush transform.
+    pub foreground_brush_transform: Option<Affine>,
 
     /// Resolved single-run font and typographic inputs.
     pub style: TextStyle,
@@ -322,6 +329,12 @@ pub struct TextDecoration {
 
     /// Optional decoration brush override.
     pub brush: Option<Brush>,
+
+    /// Optional brush-local to text-local transform for the decoration brush.
+    ///
+    /// `None` means identity: the lowerer samples the decoration brush in
+    /// text-local coordinates without an additional brush transform.
+    pub brush_transform: Option<Affine>,
 }
 
 /// Resolved underline and strikethrough decoration state.
@@ -552,6 +565,7 @@ mod tests {
             text.style.font_family,
             FontFamily::from(GenericFamily::SystemUi)
         );
+        assert_eq!(text.foreground_brush_transform, None);
         assert_eq!(text.style.font_width, FontWidth::NORMAL);
         assert_eq!(text.style.font_weight, FontWeight::NORMAL);
         assert!(text.style.font_features.is_empty());
@@ -630,11 +644,13 @@ mod tests {
 
     #[test]
     fn text_decoration_carries_paint_and_metrics() {
+        let transform = Affine::scale_non_uniform(2.0, 3.0);
         let decoration = TextDecoration {
             enabled: true,
             offset: Some(1.0),
             size: Some(2.0),
             brush: Some(Brush::from(crate::Color::WHITE)),
+            brush_transform: Some(transform),
         };
 
         let text = PlainTextPrimitive {
@@ -646,6 +662,19 @@ mod tests {
         };
 
         assert_eq!(text.decorations.underline, decoration);
+        assert_eq!(text.decorations.underline.brush_transform, Some(transform));
         assert!(!text.decorations.strikethrough.enabled);
+    }
+
+    #[test]
+    fn plain_text_can_carry_foreground_brush_transform() {
+        let transform = Affine::translate((4.0, 6.0));
+        let text = PlainTextPrimitive {
+            foreground: Some(Brush::from(crate::Color::WHITE)),
+            foreground_brush_transform: Some(transform),
+            ..PlainTextPrimitive::default()
+        };
+
+        assert_eq!(text.foreground_brush_transform, Some(transform));
     }
 }

--- a/understory_presentation_properties/src/surface.rs
+++ b/understory_presentation_properties/src/surface.rs
@@ -354,18 +354,22 @@ impl SurfacePropertyValues {
             border: Border {
                 top: BorderSide {
                     brush: self.border_brushes.top,
+                    brush_transform: None,
                     width: self.border_widths.top,
                 },
                 right: BorderSide {
                     brush: self.border_brushes.right,
+                    brush_transform: None,
                     width: self.border_widths.right,
                 },
                 bottom: BorderSide {
                     brush: self.border_brushes.bottom,
+                    brush_transform: None,
                     width: self.border_widths.bottom,
                 },
                 left: BorderSide {
                     brush: self.border_brushes.left,
+                    brush_transform: None,
                     width: self.border_widths.left,
                 },
             },


### PR DESCRIPTION
Add optional `Affine` brush transforms to presentation brush carriers so renderers can receive an explicit per-frame brush-local to primitive-local transform. `None` remains the identity/default path for existing callers.

Cover surface backgrounds and borders, path fills and strokes, image primitives, and text foreground/decorations. Add `unit_brush_transform` as the shared unit-square-to-bounds base transform for gradient and image fills authored in unit coordinates.

Keep image placement policy in `ImageFit` and slicing; `ImagePrimitive::brush_transform` is an additional brush sampling transform for animated or art-directed fills.