### PR TITLE
ci: Pin cargo-rdme 1.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: install cargo-rdme
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-rdme
+          tool: cargo-rdme@1.5.1
 
       - name: check crate READMEs
         shell: bash


### PR DESCRIPTION
The 2.0 version has some pain around needing particular nightly compilers.