### PR TITLE
Add headless tiling crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ env:
     -p understory_responder
     -p understory_selection
     -p understory_style
+    -p understory_tiling
     -p understory_timing
     -p understory_transcript
     -p understory_view2d

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "understory_tiling"
+version = "0.1.0"
+dependencies = [
+ "kurbo",
+]
+
+[[package]]
 name = "understory_timeline_model"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "understory_selection",
   "understory_style",
   "understory_timing",
+  "understory_tiling",
   "understory_transcript",
   "understory_view2d",
   "understory_virtual_list",
@@ -77,6 +78,7 @@ understory_responder = { version = "0.1.0", path = "understory_responder", defau
 understory_selection = { version = "0.1.0", path = "understory_selection", default-features = false }
 understory_style = { version = "0.1.0", path = "understory_style", default-features = false }
 understory_timing = { version = "0.1.2", path = "understory_timing", default-features = false }
+understory_tiling = { version = "0.1.0", path = "understory_tiling", default-features = false }
 understory_timeline_model = { version = "0.1.0", path = "understory_timeline_model", default-features = false }
 understory_transcript = { version = "0.1.0", path = "understory_transcript", default-features = false }
 understory_view2d = { version = "0.1.0", path = "understory_view2d", default-features = false }

--- a/understory_tiling/CHANGELOG.md
+++ b/understory_tiling/CHANGELOG.md
@@ -1,0 +1,27 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+Understory Tiling has not had a published release yet.
+
+## [Unreleased]
+
+### Added
+
+- Added the initial `understory_tiling` crate with `no_std` headless tiling,
+  docking, layout frame, hit testing, operation, proposal, and interaction
+  primitives.
+- Added the persistent `TileTree` model with n-ary splits, tab groups, pane
+  leaves, normalization, semantic operations, and flattened layout solving.
+- Added basic drag/drop and resize proposal generation, validation and commit
+  helpers, snapshot and repair shells, and pure-data regression tests.
+
+[Unreleased]: https://github.com/forest-rs/understory/compare/HEAD
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/understory_tiling/Cargo.toml
+++ b/understory_tiling/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "understory_tiling"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "Headless tiling, docking, and layout interaction primitives."
+keywords = ["tiling", "docking", "layout", "ui", "no_std"]
+categories = ["gui", "data-structures", "no-std"]
+
+[dependencies]
+kurbo.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+
+# This crate is `no_std` + `alloc` without default features. Enable `libm` for
+# no_std targets that need Kurbo geometry math, or `std` for std builds.
+std = ["kurbo/std"]
+libm = ["kurbo/libm"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []

--- a/understory_tiling/LICENSE-APACHE
+++ b/understory_tiling/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/understory_tiling/LICENSE-MIT
+++ b/understory_tiling/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/understory_tiling/README.md
+++ b/understory_tiling/README.md
@@ -1,0 +1,128 @@
+<div align="center">
+
+# Understory Tiling
+
+**Headless tiling, docking, and layout interaction primitives**
+
+[![Latest published version.](https://img.shields.io/crates/v/understory_tiling.svg)](https://crates.io/crates/understory_tiling)
+[![Documentation build status.](https://img.shields.io/docsrs/understory_tiling.svg)](https://docs.rs/understory_tiling)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+\
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/forest-rs/understory/ci.yml?logo=github&label=CI)](https://github.com/forest-rs/understory/actions)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=understory_tiling --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs may be evaluated here. -->
+
+<!-- cargo-rdme start -->
+
+Understory Tiling: headless tiling, docking, and layout interaction primitives.
+
+This crate provides a small, renderer-agnostic core for persistent tiling
+trees and flattened layout frames. It is intended to sit underneath docking
+widgets and workbench shells without knowing about any particular renderer,
+widget system, document model, or window system.
+
+The core concepts are:
+
+- [`TileTree`]: persistent semantic tree of splits, tab groups, and panes.
+- [`LayoutFrame`]: flattened solved geometry for rendering and hit testing.
+- [`TileOp`]: semantic committed mutations such as split, move, activate,
+  reorder, and resize.
+- [`DockProposal`] and [`ResizeProposal`]: uncommitted interaction results
+  that can be previewed before they mutate the tree.
+- [`PaneId`] and [`TileId`]: opaque ids used to integrate with an embedding
+  application.
+
+This crate deliberately does **not** know about:
+
+- pane contents,
+- tab or button drawing,
+- themes or animation,
+- document save prompts,
+- native windows,
+- accessibility backends,
+- Overstory-specific integration.
+
+## Fence
+
+This crate owns semantic layout structure, layout solving, flattened frames,
+hit regions, semantic mutation operations, and proposal plumbing; it
+explicitly does not own pane contents, chrome drawing, app policy, document
+lifecycle, renderer integration, or widget behavior.
+
+## Minimal example
+
+```rust
+use kurbo::{Point, Rect, Size};
+use understory_tiling::{
+    hit_test, Axis, LayoutInput, PaneId, Placement, TileOp, TileTree,
+};
+
+let mut tree = TileTree::single_pane(PaneId(1));
+tree.apply(TileOp::SplitPane {
+    pane: PaneId(1),
+    axis: Axis::Horizontal,
+    new_pane: PaneId(2),
+    placement: Placement::After,
+    share: 0.5,
+})?;
+
+let frame = tree.layout(LayoutInput {
+    bounds: Rect::new(0.0, 0.0, 800.0, 600.0),
+    tab_bar_thickness: 28.0,
+    split_handle_thickness: 6.0,
+    min_pane_size: Size::new(80.0, 80.0),
+    generate_drop_targets: false,
+});
+
+assert_eq!(frame.panes.len(), 2);
+assert!(hit_test(&frame, Point::new(10.0, 10.0)).is_some());
+```
+
+This crate is `no_std` and uses `alloc` when built without default features.
+Enable the `libm` feature for no-std targets that need Kurbo geometry math.
+
+<!-- cargo-rdme end -->
+
+[`DockProposal`]: https://docs.rs/understory_tiling/latest/understory_tiling/enum.DockProposal.html
+[`LayoutFrame`]: https://docs.rs/understory_tiling/latest/understory_tiling/struct.LayoutFrame.html
+[`PaneId`]: https://docs.rs/understory_tiling/latest/understory_tiling/struct.PaneId.html
+[`ResizeProposal`]: https://docs.rs/understory_tiling/latest/understory_tiling/struct.ResizeProposal.html
+[`TileId`]: https://docs.rs/understory_tiling/latest/understory_tiling/struct.TileId.html
+[`TileOp`]: https://docs.rs/understory_tiling/latest/understory_tiling/enum.TileOp.html
+[`TileTree`]: https://docs.rs/understory_tiling/latest/understory_tiling/struct.TileTree.html
+
+## Minimum supported Rust Version (MSRV)
+
+This crate has been verified to compile with **Rust 1.88** and later.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://www.apache.org/licenses/LICENSE-2.0>), or
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>),
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you,
+as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+[LICENSE-APACHE]: https://github.com/forest-rs/understory/blob/main/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/forest-rs/understory/blob/main/LICENSE-MIT
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: https://github.com/forest-rs/understory/blob/main/AUTHORS

--- a/understory_tiling/src/frame.rs
+++ b/understory_tiling/src/frame.rs
@@ -1,0 +1,195 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec::Vec;
+
+use crate::{Axis, PaneId, Point, Rect, Revision, TabBarPlacement, TileId};
+
+/// Flattened output from a layout pass.
+///
+/// Returned by [`TileTree::layout`](crate::TileTree::layout). Renderers and hit
+/// testing should consume this flattened data instead of walking
+/// [`TileNode`](crate::TileNode) directly.
+#[derive(Clone, Debug, Default)]
+pub struct LayoutFrame {
+    /// Tree revision used for this frame.
+    pub revision: Revision,
+    /// Active pane rectangles.
+    pub panes: Vec<PaneFrame>,
+    /// Visible tab bar rectangles.
+    pub tab_bars: Vec<TabBarFrame>,
+    /// Individual tab rectangles.
+    pub tabs: Vec<TabFrame>,
+    /// Split handle rectangles.
+    pub split_handles: Vec<SplitHandleFrame>,
+    /// Hit-test regions in frame coordinates.
+    pub hit_regions: Vec<HitRegion>,
+    /// Pane focus order in semantic traversal order.
+    pub focus_order: Vec<PaneId>,
+    /// Paint order hints for renderers.
+    pub paint_order: Vec<FrameItemId>,
+}
+
+/// Flattened pane geometry.
+///
+/// Produced in [`LayoutFrame::panes`] for every visible pane body. Use `pane` to
+/// look up application content and `rect`/`clip` to place it.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PaneFrame {
+    /// Pane id.
+    pub pane: PaneId,
+    /// Tile that produced the pane.
+    pub tile: TileId,
+    /// Pane rectangle.
+    pub rect: Rect,
+    /// Pane clip rectangle.
+    pub clip: Rect,
+    /// Whether this pane is active in its group.
+    pub active: bool,
+}
+
+/// Flattened tab bar geometry.
+///
+/// Produced in [`LayoutFrame::tab_bars`] for tab groups whose
+/// [`TabBarPlacement`] is not hidden. Renderers use it for tab strip chrome and
+/// hit regions use it to start tab-group drags.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TabBarFrame {
+    /// Tab group tile id.
+    pub group: TileId,
+    /// Tab bar rectangle.
+    pub rect: Rect,
+    /// Tab bar placement.
+    pub placement: TabBarPlacement,
+    /// Active pane in this group, if any.
+    pub active_pane: Option<PaneId>,
+}
+
+/// Flattened tab geometry.
+///
+/// Produced in [`LayoutFrame::tabs`] for each tab in a visible tab group. Use it
+/// to render tab labels/chrome and to start tab drags or reorder gestures.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TabFrame {
+    /// Tab group tile id.
+    pub group: TileId,
+    /// Pane represented by this tab.
+    pub pane: PaneId,
+    /// Tab rectangle.
+    pub rect: Rect,
+    /// Tab index in the group.
+    pub index: usize,
+    /// Whether this tab is active.
+    pub active: bool,
+}
+
+/// Flattened split handle geometry.
+///
+/// Produced in [`LayoutFrame::split_handles`] between split children. Pass the
+/// hit result from these rectangles to [`begin_resize`](crate::begin_resize) to
+/// start a resize interaction.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SplitHandleFrame {
+    /// Split tile id.
+    pub split: TileId,
+    /// Handle index between child `handle` and `handle + 1`.
+    pub handle: usize,
+    /// Split axis.
+    pub axis: Axis,
+    /// Handle rectangle.
+    pub rect: Rect,
+}
+
+/// Identifier for a flattened frame item.
+///
+/// Returned in [`LayoutFrame::paint_order`] as an ordering hint for renderers
+/// that want a deterministic sequence matching the layout solver.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FrameItemId {
+    /// Pane item.
+    Pane(PaneId),
+    /// Tab item.
+    Tab {
+        /// Tab group.
+        group: TileId,
+        /// Pane represented by the tab.
+        pane: PaneId,
+    },
+    /// Tab bar item.
+    TabBar(TileId),
+    /// Split handle item.
+    SplitHandle {
+        /// Split tile.
+        split: TileId,
+        /// Handle index.
+        handle: usize,
+    },
+}
+
+/// Hit-test region.
+///
+/// Produced in [`LayoutFrame::hit_regions`] and consumed by [`hit_test`]. Most
+/// callers do not construct these manually unless they are building custom
+/// frame data for tests.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HitRegion {
+    /// Region rectangle.
+    pub rect: Rect,
+    /// Region z-order. Higher values win.
+    pub z: i16,
+    /// Region kind.
+    pub kind: HitKind,
+}
+
+/// Semantic hit-test result.
+///
+/// Returned by [`hit_test`] and used by interaction helpers such as
+/// [`begin_drag`](crate::begin_drag) and [`begin_resize`](crate::begin_resize)
+/// to decide which session to create.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HitKind {
+    /// A pane body.
+    Pane {
+        /// Hit pane.
+        pane: PaneId,
+    },
+    /// A tab.
+    Tab {
+        /// Hit group.
+        group: TileId,
+        /// Hit pane tab.
+        pane: PaneId,
+    },
+    /// A tab bar background.
+    TabBar {
+        /// Hit group.
+        group: TileId,
+    },
+    /// A split handle.
+    SplitHandle {
+        /// Hit split.
+        split: TileId,
+        /// Hit handle index.
+        handle: usize,
+    },
+    /// Empty layout space.
+    Empty,
+}
+
+/// Performs flattened-frame hit testing.
+#[must_use]
+pub fn hit_test(frame: &LayoutFrame, point: Point) -> Option<HitKind> {
+    let mut best: Option<(usize, HitRegion)> = None;
+    for (index, region) in frame.hit_regions.iter().copied().enumerate() {
+        if !region.rect.contains(point) {
+            continue;
+        }
+        match best {
+            Some((best_index, best_region))
+                if region.z < best_region.z
+                    || (region.z == best_region.z && index >= best_index) => {}
+            _ => best = Some((index, region)),
+        }
+    }
+    best.map(|(_, region)| region.kind)
+}

--- a/understory_tiling/src/ids.rs
+++ b/understory_tiling/src/ids.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Opaque identity for a tile node inside a [`TileTree`](crate::TileTree).
+///
+/// You usually get one from [`TileTree::root`](crate::TileTree::root),
+/// [`TileTree::node`](crate::TileTree::node), layout frames, hit results, or
+/// drop targets. Pass it back to operations such as
+/// [`TileOp::ReorderTab`](crate::TileOp::ReorderTab) or
+/// [`DockTarget::Split`](crate::DockTarget::Split); do not interpret the number
+/// as a stable arena index outside this crate.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TileId(
+    /// Numeric tile id assigned by the tree arena.
+    pub u32,
+);
+
+/// Opaque identity for an application-owned pane.
+///
+/// The embedding application creates these ids and passes them into
+/// [`TileTree::single_pane`](crate::TileTree::single_pane),
+/// [`TileNode::pane`](crate::TileNode::pane), and [`TileOp`](crate::TileOp)
+/// values. Layout, hit testing, and interaction frames return the same ids so
+/// the app can attach rendered chrome and pane contents.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct PaneId(
+    /// Numeric pane id assigned by the embedding application.
+    pub u32,
+);
+
+/// Opaque identity for an abstract layout surface.
+///
+/// Used by [`TileSurface`](crate::TileSurface) to reserve API space for root,
+/// floating, and external surfaces. The current layout pass only operates on
+/// the tree root.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct SurfaceId(
+    /// Numeric surface id assigned by the tiling core or embedding layer.
+    pub u32,
+);
+
+/// Monotonic revision token for layout tree changes.
+///
+/// Read it with [`TileTree::revision`](crate::TileTree::revision). Layout
+/// frames and interaction sessions copy the revision so commits such as
+/// [`commit_drag`](crate::commit_drag) can reject stale input.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Revision(
+    /// Numeric revision value.
+    pub u64,
+);

--- a/understory_tiling/src/interaction.rs
+++ b/understory_tiling/src/interaction.rs
@@ -1,0 +1,824 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+use crate::Placement;
+use crate::frame::hit_test;
+use crate::util::{rect_distance, repaired_shares};
+use crate::{
+    Axis, DockTarget, HitKind, LayoutFrame, PaneFrame, PaneId, Point, Rect, Revision, Size,
+    SplitHandleFrame, TabBarFrame, TabFrame, TileError, TileId, TileNode, TileOp, TileTree,
+};
+
+/// High-level drag intent.
+///
+/// Pass this to [`begin_drag`] with a pointer position in a [`LayoutFrame`] to
+/// choose what kind of drag session may start from the hit region.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DragIntent {
+    /// Move the hit pane, tab, or tab group.
+    Move,
+}
+
+/// Current interaction state.
+///
+/// Host applications may store this between pointer events if they want one
+/// enum for drag and resize state. The free functions also work if the host
+/// stores [`DragSession`] and [`ResizeSession`] separately.
+#[derive(Clone, Debug)]
+pub enum InteractionState {
+    /// No active interaction.
+    None,
+    /// Active drag session.
+    Drag(DragSession),
+    /// Active resize session.
+    Resize(ResizeSession),
+}
+
+/// Active drag session.
+///
+/// Returned by [`begin_drag`]. Pass it mutably to [`update_drag`] as the pointer
+/// moves, then pass it to [`commit_drag`] on pointer-up to apply the current
+/// proposal.
+#[derive(Clone, Debug)]
+pub struct DragSession {
+    /// Subject being dragged.
+    pub subject: DragSubject,
+    /// Source that started the drag.
+    pub source: DragSource,
+    /// Drag origin.
+    pub origin: Point,
+    /// Current pointer position.
+    pub current: Point,
+    /// Tree revision at drag start.
+    pub base_revision: Revision,
+    /// Current proposal.
+    pub proposal: Option<DockProposal>,
+}
+
+/// Subject of a drag.
+///
+/// Stored in [`DragSession`] and echoed in overlay frames so renderers know
+/// whether they are previewing one pane, one tab, or a whole tab group.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DragSubject {
+    /// Dragging a pane.
+    Pane(PaneId),
+    /// Dragging one tab.
+    Tab {
+        /// Source group.
+        group: TileId,
+        /// Pane represented by the tab.
+        pane: PaneId,
+    },
+    /// Dragging a whole tab group.
+    TabGroup(TileId),
+}
+
+/// Source region that started a drag.
+///
+/// Stored in [`DragSession`] for embedders that need to distinguish a tab drag
+/// from pane-chrome or tab-bar gestures.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DragSource {
+    /// Drag started on a tab.
+    Tab {
+        /// Source group.
+        group: TileId,
+        /// Pane represented by the tab.
+        pane: PaneId,
+    },
+    /// Drag started on a tab bar.
+    TabBar {
+        /// Source group.
+        group: TileId,
+    },
+    /// Drag started on pane chrome.
+    PaneChrome {
+        /// Source pane.
+        pane: PaneId,
+    },
+}
+
+/// Active resize session.
+///
+/// Returned by [`begin_resize`]. Pass it mutably to [`update_resize`] as the
+/// pointer moves, then pass it to [`commit_resize`] to apply the proposed split
+/// shares.
+#[derive(Clone, Debug)]
+pub struct ResizeSession {
+    /// Split being resized.
+    pub split: TileId,
+    /// Handle being moved.
+    pub handle: usize,
+    /// Split axis.
+    pub axis: Axis,
+    /// Resize origin.
+    pub origin: Point,
+    /// Current pointer position.
+    pub current: Point,
+    /// Tree revision at resize start.
+    pub base_revision: Revision,
+    /// Current resize proposal.
+    pub proposal: Option<ResizeProposal>,
+}
+
+/// Flattened interaction output.
+///
+/// Container for combined interaction rendering output. Current update
+/// functions return [`DragUpdate`] and [`ResizeUpdate`], whose fields map to
+/// this shape.
+#[derive(Clone, Debug, Default)]
+pub struct InteractionFrame {
+    /// Overlay geometry.
+    pub overlay: OverlayFrame,
+    /// Optional full preview frame.
+    pub preview: Option<PreviewFrame>,
+    /// Current proposal.
+    pub proposal: Option<Proposal>,
+}
+
+/// Overlay geometry produced during interactions.
+///
+/// Returned from [`update_drag`] and [`update_resize`] for rendering drop
+/// targets, ghosts, and active interaction affordances without mutating the
+/// committed [`TileTree`].
+#[derive(Clone, Debug, Default)]
+pub struct OverlayFrame {
+    /// Drop targets.
+    pub drop_targets: Vec<DropTargetFrame>,
+    /// Preview ghost rectangles.
+    pub ghost_rects: Vec<GhostFrame>,
+    /// Dragged subject geometry.
+    pub dragged: Option<DraggedFrame>,
+    /// Active drop target.
+    pub active_target: Option<DropTargetId>,
+    /// Overlay hit regions.
+    pub hit_regions: Vec<OverlayHitRegion>,
+}
+
+/// Overlay hit region.
+///
+/// Produced inside [`OverlayFrame::hit_regions`] so overlay hit testing can
+/// take precedence over the base [`LayoutFrame`] during drag/drop.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct OverlayHitRegion {
+    /// Region rectangle.
+    pub rect: Rect,
+    /// Region z-order.
+    pub z: i16,
+    /// Drop target id.
+    pub target: DropTargetId,
+}
+
+/// Opaque drop target id.
+///
+/// Returned in [`DropTargetFrame`] and [`OverlayFrame::active_target`] to give
+/// renderers a stable handle for highlighting one generated target.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct DropTargetId(
+    /// Numeric target id.
+    pub u32,
+);
+
+/// Candidate drop target.
+///
+/// Returned by [`drop_targets_for_drag`] and [`update_drag`]. Renderers draw the
+/// `rect` or `preview_rect`; commit code lowers the selected `target` into a
+/// [`TileOp`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DropTargetFrame {
+    /// Drop target id.
+    pub id: DropTargetId,
+    /// Hit rectangle.
+    pub rect: Rect,
+    /// Semantic dock target.
+    pub target: DockTarget,
+    /// Preview rectangle for overlays.
+    pub preview_rect: Rect,
+    /// Target priority. Higher values win.
+    pub priority: i16,
+    /// Distance from the pointer when generated.
+    pub distance: f64,
+    /// Whether this target accepts the current subject.
+    pub accepts: bool,
+}
+
+/// Preview ghost rectangle.
+///
+/// Produced in [`OverlayFrame::ghost_rects`] when an interaction wants a simple
+/// preview rectangle instead of a full [`PreviewFrame`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GhostFrame {
+    /// Ghost rectangle.
+    pub rect: Rect,
+    /// Ghost kind.
+    pub kind: GhostKind,
+}
+
+/// Kind of preview ghost.
+///
+/// Used by [`GhostFrame`] so renderers can style valid pane/group previews and
+/// invalid targets differently.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GhostKind {
+    /// Preview for one pane.
+    PreviewPane,
+    /// Preview for a group.
+    PreviewGroup,
+    /// Invalid-target preview.
+    Invalid,
+}
+
+/// Geometry for the dragged subject.
+///
+/// Returned in [`OverlayFrame::dragged`] from [`update_drag`] so renderers can
+/// draw the item following the pointer.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DraggedFrame {
+    /// Dragged subject.
+    pub subject: DragSubject,
+    /// Subject rectangle.
+    pub rect: Rect,
+}
+
+/// Optional full preview layout.
+///
+/// Reserved for interactions that want to preview a complete solved layout.
+/// Current MVP updates usually return simple overlay targets instead.
+#[derive(Clone, Debug, Default)]
+pub struct PreviewFrame {
+    /// Preview panes.
+    pub panes: Vec<PaneFrame>,
+    /// Preview tab bars.
+    pub tab_bars: Vec<TabBarFrame>,
+    /// Preview tabs.
+    pub tabs: Vec<TabFrame>,
+    /// Preview split handles.
+    pub split_handles: Vec<SplitHandleFrame>,
+}
+
+/// Uncommitted layout proposal.
+///
+/// Returned by interaction updates and passed to
+/// [`validate_proposal`](crate::validate_proposal) when the host wants policy
+/// validation before committing the corresponding [`TileOp`].
+#[derive(Clone, Debug)]
+pub enum Proposal {
+    /// Docking or move proposal.
+    Dock(DockProposal),
+    /// Resize proposal.
+    Resize(ResizeProposal),
+}
+
+/// Uncommitted docking proposal.
+///
+/// Returned from [`update_drag`] and stored in [`DragSession`]. It does not
+/// mutate the tree until [`commit_drag`] or
+/// [`validate_proposal`](crate::validate_proposal) lowers it to a [`TileOp`].
+#[derive(Clone, Debug)]
+pub enum DockProposal {
+    /// Move one pane.
+    MovePane {
+        /// Pane to move.
+        pane: PaneId,
+        /// Move target.
+        target: DockTarget,
+    },
+    /// Move a whole tab group.
+    MoveTabGroup {
+        /// Group to move.
+        group: TileId,
+        /// Move target.
+        target: DockTarget,
+    },
+    /// Reorder one tab.
+    ReorderTab {
+        /// Tab group.
+        group: TileId,
+        /// Pane tab to reorder.
+        pane: PaneId,
+        /// Target index.
+        index: usize,
+    },
+    /// Future float-pane proposal.
+    FloatPane {
+        /// Pane to float.
+        pane: PaneId,
+        /// Requested floating bounds.
+        bounds: Rect,
+    },
+}
+
+/// Uncommitted resize proposal.
+///
+/// Returned from [`update_resize`] and stored in [`ResizeSession`]. Commit it
+/// with [`commit_resize`] to apply the proposed split shares.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResizeProposal {
+    /// Split tile.
+    pub split: TileId,
+    /// Handle index.
+    pub handle: usize,
+    /// Pointer delta along the split axis.
+    ///
+    /// Expected to be finite.
+    pub delta: f64,
+    /// Proposed replacement shares.
+    pub new_shares: Vec<f64>,
+}
+
+/// Result of updating a drag session.
+///
+/// Returned by [`update_drag`] on every pointer move. Render `overlay`, inspect
+/// `proposal`, and leave the committed tree untouched until commit.
+#[derive(Clone, Debug)]
+pub struct DragUpdate {
+    /// Current proposal.
+    pub proposal: Option<DockProposal>,
+    /// Overlay geometry.
+    pub overlay: OverlayFrame,
+    /// Optional full preview.
+    pub preview: Option<PreviewFrame>,
+}
+
+/// Result of updating a resize session.
+///
+/// Returned by [`update_resize`] on pointer movement. Hosts may render the
+/// overlay immediately and choose whether to commit the proposal live or on
+/// pointer-up.
+#[derive(Clone, Debug)]
+pub struct ResizeUpdate {
+    /// Current proposal.
+    pub proposal: Option<ResizeProposal>,
+    /// Overlay geometry.
+    pub overlay: OverlayFrame,
+    /// Optional full preview.
+    pub preview: Option<PreviewFrame>,
+}
+
+/// Interaction commit behavior.
+///
+/// Store this in [`ResizeOptions`] to describe how the embedding layer plans to
+/// commit proposals. The core still returns proposals either way.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommitMode {
+    /// Commit on every pointer move.
+    OnEveryMove,
+    /// Commit only when the pointer is released.
+    OnPointerUp,
+}
+
+/// Resize options.
+///
+/// Construct this and pass it to [`update_resize`] to describe host resize
+/// policy and geometry constraints.
+#[derive(Clone, Copy, Debug)]
+pub struct ResizeOptions {
+    /// Minimum pane size.
+    ///
+    /// Expected to be finite and non-negative.
+    pub min_pane_size: Size,
+    /// Commit behavior preferred by the embedding layer.
+    pub commit_mode: CommitMode,
+}
+
+/// Drag/drop options.
+///
+/// Construct this and pass it to [`update_drag`] or [`drop_targets_for_drag`] to
+/// control which targets are generated for a drag session.
+#[derive(Clone, Copy, Debug)]
+pub struct DragOptions {
+    /// Fraction of a tile edge used for split targets.
+    ///
+    /// Expected to be finite and in the range `0.0..=0.5`.
+    pub edge_zone_fraction: f64,
+    /// Fraction used for tab insertion decisions.
+    ///
+    /// Expected to be finite.
+    pub tab_insert_threshold: f64,
+    /// Whether floating is allowed.
+    pub allow_float: bool,
+    /// Whether tab reordering is allowed.
+    pub allow_reorder_tabs: bool,
+    /// Whether split targets are allowed.
+    pub allow_split: bool,
+    /// Whether tab-into targets are allowed.
+    pub allow_tab_into: bool,
+}
+
+impl Default for DragOptions {
+    fn default() -> Self {
+        Self {
+            edge_zone_fraction: 0.25,
+            tab_insert_threshold: 0.5,
+            allow_float: true,
+            allow_reorder_tabs: true,
+            allow_split: true,
+            allow_tab_into: true,
+        }
+    }
+}
+
+/// Starts a drag session from a frame hit.
+#[must_use]
+pub fn begin_drag(frame: &LayoutFrame, point: Point, intent: DragIntent) -> Option<DragSession> {
+    debug_assert!(point.is_finite(), "point must be finite");
+    let hit = hit_test(frame, point)?;
+    match (intent, hit) {
+        (DragIntent::Move, HitKind::Tab { group, pane }) => Some(DragSession {
+            subject: DragSubject::Tab { group, pane },
+            source: DragSource::Tab { group, pane },
+            origin: point,
+            current: point,
+            base_revision: frame.revision,
+            proposal: None,
+        }),
+        (DragIntent::Move, HitKind::TabBar { group }) => Some(DragSession {
+            subject: DragSubject::TabGroup(group),
+            source: DragSource::TabBar { group },
+            origin: point,
+            current: point,
+            base_revision: frame.revision,
+            proposal: None,
+        }),
+        (DragIntent::Move, HitKind::Pane { pane }) => Some(DragSession {
+            subject: DragSubject::Pane(pane),
+            source: DragSource::PaneChrome { pane },
+            origin: point,
+            current: point,
+            base_revision: frame.revision,
+            proposal: None,
+        }),
+        _ => None,
+    }
+}
+
+/// Updates a drag session.
+#[must_use]
+pub fn update_drag(
+    tree: &TileTree,
+    frame: &LayoutFrame,
+    drag: &mut DragSession,
+    point: Point,
+    options: &DragOptions,
+) -> DragUpdate {
+    debug_assert!(point.is_finite(), "point must be finite");
+    drag.current = point;
+    let targets = drop_targets_for_drag(tree, frame, drag, options);
+    let active_target = pick_drop_target(&targets, point);
+    let proposal = active_target
+        .and_then(|id| targets.iter().find(|target| target.id == id))
+        .and_then(|target| proposal_for_drag(drag, target, options));
+    drag.proposal = proposal.clone();
+
+    DragUpdate {
+        proposal,
+        overlay: OverlayFrame {
+            active_target,
+            hit_regions: targets
+                .iter()
+                .map(|target| OverlayHitRegion {
+                    rect: target.rect,
+                    z: target.priority,
+                    target: target.id,
+                })
+                .collect(),
+            drop_targets: targets,
+            ghost_rects: Vec::new(),
+            dragged: Some(DraggedFrame {
+                subject: drag.subject,
+                rect: Rect::new(point.x - 8.0, point.y - 8.0, point.x + 8.0, point.y + 8.0),
+            }),
+        },
+        preview: None,
+    }
+}
+
+/// Commits a drag session.
+pub fn commit_drag(tree: &mut TileTree, drag: DragSession) -> Result<TileOp, TileError> {
+    if drag.base_revision != tree.revision() {
+        return Err(TileError::StaleInteraction);
+    }
+    let proposal = drag.proposal.ok_or(TileError::InvalidOperation)?;
+    let op = op_for_dock_proposal(proposal)?;
+    tree.apply(op.clone())?;
+    Ok(op)
+}
+
+/// Starts a resize session from a split handle hit.
+#[must_use]
+pub fn begin_resize(frame: &LayoutFrame, point: Point) -> Option<ResizeSession> {
+    debug_assert!(point.is_finite(), "point must be finite");
+    match hit_test(frame, point)? {
+        HitKind::SplitHandle { split, handle } => {
+            let handle_frame = frame
+                .split_handles
+                .iter()
+                .find(|candidate| candidate.split == split && candidate.handle == handle)?;
+            Some(ResizeSession {
+                split,
+                handle,
+                axis: handle_frame.axis,
+                origin: point,
+                current: point,
+                base_revision: frame.revision,
+                proposal: None,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Updates a resize session.
+#[must_use]
+pub fn update_resize(
+    tree: &TileTree,
+    _frame: &LayoutFrame,
+    resize: &mut ResizeSession,
+    point: Point,
+    _options: &ResizeOptions,
+) -> ResizeUpdate {
+    debug_assert!(point.is_finite(), "point must be finite");
+    resize.current = point;
+    let delta = match resize.axis {
+        Axis::Horizontal => point.x - resize.origin.x,
+        Axis::Vertical => point.y - resize.origin.y,
+    };
+    let new_shares = match tree.node(resize.split) {
+        Some(TileNode::Split(split)) => {
+            let mut shares = repaired_shares(split.children.len(), &split.shares);
+            if resize.handle + 1 < shares.len() {
+                let delta_share = delta / 100.0;
+                shares[resize.handle] = (shares[resize.handle] + delta_share).max(0.01);
+                shares[resize.handle + 1] = (shares[resize.handle + 1] - delta_share).max(0.01);
+            }
+            shares
+        }
+        _ => Vec::new(),
+    };
+    let proposal = (!new_shares.is_empty()).then_some(ResizeProposal {
+        split: resize.split,
+        handle: resize.handle,
+        delta,
+        new_shares,
+    });
+    resize.proposal = proposal.clone();
+    ResizeUpdate {
+        proposal,
+        overlay: OverlayFrame::default(),
+        preview: None,
+    }
+}
+
+/// Commits a resize session.
+pub fn commit_resize(tree: &mut TileTree, resize: ResizeSession) -> Result<TileOp, TileError> {
+    if resize.base_revision != tree.revision() {
+        return Err(TileError::StaleInteraction);
+    }
+    let proposal = resize.proposal.ok_or(TileError::InvalidOperation)?;
+    let op = TileOp::SetSplitShares {
+        split: proposal.split,
+        shares: proposal.new_shares,
+    };
+    tree.apply(op.clone())?;
+    Ok(op)
+}
+
+/// Generates candidate drop targets for a drag session.
+#[must_use]
+pub fn drop_targets_for_drag(
+    _tree: &TileTree,
+    frame: &LayoutFrame,
+    drag: &DragSession,
+    options: &DragOptions,
+) -> Vec<DropTargetFrame> {
+    let mut targets = Vec::new();
+    debug_assert!(
+        options.edge_zone_fraction.is_finite(),
+        "DragOptions::edge_zone_fraction must be finite",
+    );
+    debug_assert!(
+        (0.0..=0.5).contains(&options.edge_zone_fraction),
+        "DragOptions::edge_zone_fraction must be in 0.0..=0.5",
+    );
+    debug_assert!(
+        options.tab_insert_threshold.is_finite(),
+        "DragOptions::tab_insert_threshold must be finite",
+    );
+    let edge_fraction = options.edge_zone_fraction;
+
+    if options.allow_split {
+        for pane in &frame.panes {
+            push_edge_targets(
+                &mut targets,
+                pane.tile,
+                pane.rect,
+                drag.current,
+                edge_fraction,
+                true,
+            );
+        }
+    }
+
+    if options.allow_tab_into {
+        for bar in &frame.tab_bars {
+            let index = match drag.subject {
+                DragSubject::Tab { group, .. }
+                    if group == bar.group && options.allow_reorder_tabs =>
+                {
+                    tab_insert_index(frame, bar.group, drag.current)
+                }
+                _ => None,
+            };
+            let id =
+                DropTargetId(u32::try_from(targets.len()).expect("drop target arena exhausted"));
+            targets.push(DropTargetFrame {
+                id,
+                rect: bar.rect,
+                target: DockTarget::TabInto {
+                    group: bar.group,
+                    index,
+                },
+                preview_rect: bar.rect,
+                priority: 30,
+                distance: rect_distance(bar.rect, drag.current),
+                accepts: true,
+            });
+        }
+    }
+
+    targets
+}
+
+/// Picks the active drop target for a point.
+#[must_use]
+pub fn pick_drop_target(targets: &[DropTargetFrame], point: Point) -> Option<DropTargetId> {
+    let mut best: Option<(usize, DropTargetFrame)> = None;
+    for (index, target) in targets.iter().copied().enumerate() {
+        if !target.accepts || !target.rect.contains(point) {
+            continue;
+        }
+        match best {
+            Some((best_index, best_target))
+                if compare_target(target, index, best_target, best_index) != Ordering::Greater => {}
+            _ => best = Some((index, target)),
+        }
+    }
+    best.map(|(_, target)| target.id)
+}
+
+fn proposal_for_drag(
+    drag: &DragSession,
+    target: &DropTargetFrame,
+    options: &DragOptions,
+) -> Option<DockProposal> {
+    match drag.subject {
+        DragSubject::Pane(pane) | DragSubject::Tab { pane, .. } => match target.target {
+            DockTarget::TabInto { group, index }
+                if options.allow_reorder_tabs
+                    && matches!(drag.subject, DragSubject::Tab { group: source, .. } if source == group)
+                    && index.is_some() =>
+            {
+                Some(DockProposal::ReorderTab {
+                    group,
+                    pane,
+                    index: index.unwrap_or(0),
+                })
+            }
+            _ => Some(DockProposal::MovePane {
+                pane,
+                target: target.target,
+            }),
+        },
+        DragSubject::TabGroup(group) => Some(DockProposal::MoveTabGroup {
+            group,
+            target: target.target,
+        }),
+    }
+}
+
+pub(crate) fn op_for_dock_proposal(proposal: DockProposal) -> Result<TileOp, TileError> {
+    match proposal {
+        DockProposal::MovePane { pane, target } => Ok(TileOp::MovePane { pane, target }),
+        DockProposal::ReorderTab { group, pane, index } => {
+            Ok(TileOp::ReorderTab { group, pane, index })
+        }
+        DockProposal::FloatPane { pane, bounds } => Ok(TileOp::FloatPane { pane, bounds }),
+        DockProposal::MoveTabGroup { .. } => Err(TileError::Unsupported),
+    }
+}
+
+fn push_edge_targets(
+    targets: &mut Vec<DropTargetFrame>,
+    tile: TileId,
+    rect: Rect,
+    point: Point,
+    edge_fraction: f64,
+    accepts: bool,
+) {
+    let width = rect.width();
+    let height = rect.height();
+    debug_assert!(
+        width >= 0.0 && height >= 0.0,
+        "drop target generation requires non-negative pane dimensions",
+    );
+    let edge_w = width * edge_fraction;
+    let edge_h = height * edge_fraction;
+    let specs = [
+        (
+            Rect::new(rect.x0, rect.y0, rect.x0 + edge_w, rect.y1),
+            DockTarget::Split {
+                tile,
+                axis: Axis::Horizontal,
+                placement: Placement::Before,
+                ratio: 0.5,
+            },
+        ),
+        (
+            Rect::new(rect.x1 - edge_w, rect.y0, rect.x1, rect.y1),
+            DockTarget::Split {
+                tile,
+                axis: Axis::Horizontal,
+                placement: Placement::After,
+                ratio: 0.5,
+            },
+        ),
+        (
+            Rect::new(rect.x0, rect.y0, rect.x1, rect.y0 + edge_h),
+            DockTarget::Split {
+                tile,
+                axis: Axis::Vertical,
+                placement: Placement::Before,
+                ratio: 0.5,
+            },
+        ),
+        (
+            Rect::new(rect.x0, rect.y1 - edge_h, rect.x1, rect.y1),
+            DockTarget::Split {
+                tile,
+                axis: Axis::Vertical,
+                placement: Placement::After,
+                ratio: 0.5,
+            },
+        ),
+    ];
+
+    for (rect, target) in specs {
+        let id = DropTargetId(u32::try_from(targets.len()).expect("drop target arena exhausted"));
+        targets.push(DropTargetFrame {
+            id,
+            rect,
+            target,
+            preview_rect: rect,
+            priority: 20,
+            distance: rect_distance(rect, point),
+            accepts,
+        });
+    }
+}
+
+fn compare_target(
+    candidate: DropTargetFrame,
+    candidate_index: usize,
+    best: DropTargetFrame,
+    best_index: usize,
+) -> Ordering {
+    candidate
+        .priority
+        .cmp(&best.priority)
+        .then_with(|| {
+            best.distance
+                .partial_cmp(&candidate.distance)
+                .unwrap_or(Ordering::Equal)
+        })
+        .then_with(|| best_index.cmp(&candidate_index))
+}
+
+fn tab_insert_index(frame: &LayoutFrame, group: TileId, point: Point) -> Option<usize> {
+    let mut tabs: Vec<_> = frame
+        .tabs
+        .iter()
+        .filter(|tab| tab.group == group)
+        .copied()
+        .collect();
+    tabs.sort_by_key(|tab| tab.index);
+    if tabs.is_empty() {
+        return Some(0);
+    }
+    for tab in &tabs {
+        let horizontal = tab.rect.width() >= tab.rect.height();
+        let midpoint = if horizontal {
+            (tab.rect.x0 + tab.rect.x1) * 0.5
+        } else {
+            (tab.rect.y0 + tab.rect.y1) * 0.5
+        };
+        let coordinate = if horizontal { point.x } else { point.y };
+        if coordinate < midpoint {
+            return Some(tab.index);
+        }
+    }
+    Some(tabs.len())
+}

--- a/understory_tiling/src/lib.rs
+++ b/understory_tiling/src/lib.rs
@@ -1,0 +1,115 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// After you edit the crate's doc comment, run this command, then check README.md for any missing links
+// cargo rdme --workspace-project=understory_tiling --heading-base-level=0
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! Understory Tiling: headless tiling, docking, and layout interaction primitives.
+//!
+//! This crate provides a small, renderer-agnostic core for persistent tiling
+//! trees and flattened layout frames. It is intended to sit underneath docking
+//! widgets and workbench shells without knowing about any particular renderer,
+//! widget system, document model, or window system.
+//!
+//! The core concepts are:
+//!
+//! - [`TileTree`]: persistent semantic tree of splits, tab groups, and panes.
+//! - [`LayoutFrame`]: flattened solved geometry for rendering and hit testing.
+//! - [`TileOp`]: semantic committed mutations such as split, move, activate,
+//!   reorder, and resize.
+//! - [`DockProposal`] and [`ResizeProposal`]: uncommitted interaction results
+//!   that can be previewed before they mutate the tree.
+//! - [`PaneId`] and [`TileId`]: opaque ids used to integrate with an embedding
+//!   application.
+//!
+//! This crate deliberately does **not** know about:
+//!
+//! - pane contents,
+//! - tab or button drawing,
+//! - themes or animation,
+//! - document save prompts,
+//! - native windows,
+//! - accessibility backends,
+//! - Overstory-specific integration.
+//!
+//! ## Fence
+//!
+//! This crate owns semantic layout structure, layout solving, flattened frames,
+//! hit regions, semantic mutation operations, and proposal plumbing; it
+//! explicitly does not own pane contents, chrome drawing, app policy, document
+//! lifecycle, renderer integration, or widget behavior.
+//!
+//! ## Minimal example
+//!
+//! ```rust
+//! use kurbo::{Point, Rect, Size};
+//! use understory_tiling::{
+//!     hit_test, Axis, LayoutInput, PaneId, Placement, TileOp, TileTree,
+//! };
+//!
+//! let mut tree = TileTree::single_pane(PaneId(1));
+//! tree.apply(TileOp::SplitPane {
+//!     pane: PaneId(1),
+//!     axis: Axis::Horizontal,
+//!     new_pane: PaneId(2),
+//!     placement: Placement::After,
+//!     share: 0.5,
+//! })?;
+//!
+//! let frame = tree.layout(LayoutInput {
+//!     bounds: Rect::new(0.0, 0.0, 800.0, 600.0),
+//!     tab_bar_thickness: 28.0,
+//!     split_handle_thickness: 6.0,
+//!     min_pane_size: Size::new(80.0, 80.0),
+//!     generate_drop_targets: false,
+//! });
+//!
+//! assert_eq!(frame.panes.len(), 2);
+//! assert!(hit_test(&frame, Point::new(10.0, 10.0)).is_some());
+//! # Ok::<(), understory_tiling::TileError>(())
+//! ```
+//!
+//! This crate is `no_std` and uses `alloc` when built without default features.
+//! Enable the `libm` feature for no-std targets that need Kurbo geometry math.
+
+extern crate alloc;
+
+mod frame;
+mod ids;
+mod interaction;
+mod model;
+mod ops;
+mod policy;
+mod snapshot;
+#[cfg(test)]
+mod tests;
+mod tree;
+mod util;
+
+pub use frame::{
+    FrameItemId, HitKind, HitRegion, LayoutFrame, PaneFrame, SplitHandleFrame, TabBarFrame,
+    TabFrame, hit_test,
+};
+pub use ids::{PaneId, Revision, SurfaceId, TileId};
+pub use interaction::{
+    CommitMode, DockProposal, DragIntent, DragOptions, DragSession, DragSource, DragSubject,
+    DragUpdate, DraggedFrame, DropTargetFrame, DropTargetId, GhostFrame, GhostKind,
+    InteractionFrame, InteractionState, OverlayFrame, OverlayHitRegion, PreviewFrame, Proposal,
+    ResizeOptions, ResizeProposal, ResizeSession, ResizeUpdate, begin_drag, begin_resize,
+    commit_drag, commit_resize, drop_targets_for_drag, pick_drop_target, update_drag,
+    update_resize,
+};
+pub use kurbo::{Point, Rect, Size};
+pub use model::{
+    Axis, LayoutConstraints, LayoutInput, PaneNode, Placement, SplitConstraints, SplitNode,
+    SurfaceKind, TabBarPlacement, TabNode, TileNode, TileSurface,
+};
+pub use ops::{DockTarget, TileError, TileOp};
+pub use policy::{
+    DockPolicyData, EdgeSet, PaneCapabilities, ValidatedProposal, ZoneSet, commit_proposal,
+    validate_proposal,
+};
+pub use snapshot::{LayoutSnapshot, RepairAction, RepairReport, RestoreOptions, restore_snapshot};
+pub use tree::TileTree;

--- a/understory_tiling/src/model.rs
+++ b/understory_tiling/src/model.rs
@@ -1,0 +1,236 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::{PaneId, Rect, Size, SurfaceId, TileId};
+
+/// Major axis for split layout.
+///
+/// Pass this to [`TileOp::SplitPane`](crate::TileOp::SplitPane) or
+/// [`DockTarget::Split`](crate::DockTarget::Split) to choose whether children
+/// are arranged horizontally or vertically. Solved frames echo the axis on
+/// [`SplitHandleFrame`](crate::SplitHandleFrame) values so renderers know which
+/// direction a handle moves.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Axis {
+    /// Children are laid out left-to-right.
+    Horizontal,
+    /// Children are laid out top-to-bottom.
+    Vertical,
+}
+
+/// Placement relative to an existing tile or tab.
+///
+/// Used in split operations and dock targets to say whether a new pane or group
+/// should be inserted before or after the target tile.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Placement {
+    /// Place before the target in the relevant axis or order.
+    Before,
+    /// Place after the target in the relevant axis or order.
+    After,
+}
+
+/// Placement of a tab bar around a tab group.
+///
+/// Store this on a [`TabNode`] before layout.
+/// [`TileTree::layout`](crate::TileTree::layout) returns the chosen placement on
+/// [`TabBarFrame`](crate::TabBarFrame) so the renderer can draw the tab strip in
+/// the same place that the solver reserved geometry for it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TabBarPlacement {
+    /// Place tabs along the top edge.
+    Top,
+    /// Place tabs along the bottom edge.
+    Bottom,
+    /// Place tabs along the left edge.
+    Left,
+    /// Place tabs along the right edge.
+    Right,
+    /// Do not emit tab bar geometry.
+    Hidden,
+}
+
+/// Basic min/max layout constraints.
+///
+/// This is a data shape for caller-authored constraints. The current MVP keeps
+/// it in the model for forward compatibility; layout currently uses
+/// [`LayoutInput::min_pane_size`] as the global minimum.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct LayoutConstraints {
+    /// Minimum accepted size.
+    pub min_size: Size,
+    /// Optional maximum accepted size.
+    pub max_size: Option<Size>,
+}
+
+/// Per-child constraints for a split node.
+///
+/// Store this inside [`SplitNode`] when building or restoring a tree. The MVP
+/// normalizes the data but mostly uses [`LayoutInput::min_pane_size`] while the
+/// per-child constraint solver matures.
+#[derive(Clone, Debug, Default)]
+pub struct SplitConstraints {
+    /// Minimum major-axis length per child.
+    pub min_major: Vec<f64>,
+}
+
+/// A semantic tile node.
+///
+/// Construct these when creating a tree with [`TileTree::new`](crate::TileTree::new)
+/// or when building tests. Query existing nodes with
+/// [`TileTree::node`](crate::TileTree::node); renderers normally use the
+/// flattened [`LayoutFrame`](crate::LayoutFrame) instead of walking `TileNode`
+/// recursively.
+#[derive(Clone, Debug)]
+pub enum TileNode {
+    /// N-ary split node.
+    Split(SplitNode),
+    /// Tab group node.
+    Tabs(TabNode),
+    /// Single pane leaf node.
+    Pane(PaneNode),
+}
+
+/// N-ary split node.
+///
+/// Use this inside [`TileNode::Split`] when constructing a custom tree. Most
+/// callers create splits through [`TileOp::SplitPane`](crate::TileOp::SplitPane),
+/// then read the solved child and handle geometry from
+/// [`LayoutFrame`](crate::LayoutFrame).
+#[derive(Clone, Debug)]
+pub struct SplitNode {
+    /// Major axis used to place children.
+    pub axis: Axis,
+    /// Child tile ids.
+    pub children: Vec<TileId>,
+    /// Relative child shares.
+    ///
+    /// Shares loaded from snapshots are repaired by normalization. Callers that
+    /// construct valid trees directly should use finite positive shares.
+    pub shares: Vec<f64>,
+    /// Optional per-child split constraints.
+    pub constraints: SplitConstraints,
+}
+
+/// Tab group node.
+///
+/// Use this inside [`TileNode::Tabs`] to group multiple application panes under
+/// one tab strip. Layout returns one [`TabBarFrame`](crate::TabBarFrame), one
+/// [`TabFrame`](crate::TabFrame) per pane, and one active
+/// [`PaneFrame`](crate::PaneFrame) for the group.
+#[derive(Clone, Debug)]
+pub struct TabNode {
+    /// Panes in tab order.
+    pub panes: Vec<PaneId>,
+    /// Active tab index.
+    pub active: usize,
+    /// Tab bar placement.
+    pub placement: TabBarPlacement,
+}
+
+/// Single pane leaf node.
+///
+/// Use this inside [`TileNode::Pane`] when a tile directly hosts one
+/// application pane. Layout lowers it into a [`PaneFrame`](crate::PaneFrame).
+#[derive(Clone, Debug)]
+pub struct PaneNode {
+    /// Application-owned pane id.
+    pub pane: PaneId,
+}
+
+/// Abstract surface kind.
+///
+/// Used by [`TileSurface`] to describe future root, floating, external-window,
+/// or auto-hide surfaces. The MVP layout API only solves the root tree.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SurfaceKind {
+    /// Primary root surface.
+    Root,
+    /// Future floating surface.
+    Floating,
+    /// Future external window surface.
+    ExternalWindow,
+    /// Future auto-hide strip surface.
+    AutoHide,
+}
+
+/// Abstract surface record.
+///
+/// Keep this in persisted or host-side state when modelling more than one
+/// surface. Current layout entry points take [`LayoutInput`] and solve the root
+/// tree directly; they do not open windows or manage floating surfaces.
+#[derive(Clone, Debug)]
+pub struct TileSurface {
+    /// Surface id.
+    pub id: SurfaceId,
+    /// Surface kind.
+    pub kind: SurfaceKind,
+    /// Root tile for this surface.
+    pub root: TileId,
+    /// Surface bounds.
+    ///
+    /// Bounds supplied to layout APIs are expected to be finite.
+    pub bounds: Rect,
+}
+
+/// Geometry-affecting input for layout solving.
+///
+/// Construct this at render time and pass it to
+/// [`TileTree::layout`](crate::TileTree::layout). It is not stored in the tree;
+/// changing it produces a new [`LayoutFrame`](crate::LayoutFrame) without
+/// mutating semantic layout.
+#[derive(Clone, Copy, Debug)]
+pub struct LayoutInput {
+    /// Bounds available to the root tile.
+    ///
+    /// Coordinates are expected to be finite. Bounds are normalized before
+    /// layout, so reversed edges are accepted.
+    pub bounds: Rect,
+    /// Thickness reserved for visible tab bars.
+    ///
+    /// Expected to be finite and non-negative.
+    pub tab_bar_thickness: f64,
+    /// Thickness reserved for split handles.
+    ///
+    /// Expected to be finite and non-negative.
+    pub split_handle_thickness: f64,
+    /// Minimum pane size used by the split solver.
+    ///
+    /// Expected to be finite and non-negative.
+    pub min_pane_size: Size,
+    /// Whether callers want drag/drop target generation from layout.
+    pub generate_drop_targets: bool,
+}
+
+impl TileNode {
+    /// Creates a pane leaf node.
+    #[must_use]
+    pub const fn pane(pane: PaneId) -> Self {
+        Self::Pane(PaneNode { pane })
+    }
+
+    /// Creates a tab group with the first pane active.
+    #[must_use]
+    pub fn tabs(panes: Vec<PaneId>) -> Self {
+        Self::Tabs(TabNode {
+            panes,
+            active: 0,
+            placement: TabBarPlacement::Top,
+        })
+    }
+
+    /// Creates a split node with equal shares.
+    #[must_use]
+    pub fn split(axis: Axis, children: Vec<TileId>) -> Self {
+        let len = children.len();
+        Self::Split(SplitNode {
+            axis,
+            children,
+            shares: vec![1.0; len],
+            constraints: SplitConstraints::default(),
+        })
+    }
+}

--- a/understory_tiling/src/ops.rs
+++ b/understory_tiling/src/ops.rs
@@ -1,0 +1,158 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec::Vec;
+
+use crate::{Axis, LayoutSnapshot, PaneId, Placement, Rect, TileId};
+
+/// Target for a dock or move operation.
+///
+/// Construct this when building [`TileOp::MovePane`] directly, or read it from
+/// [`DropTargetFrame`](crate::DropTargetFrame) and
+/// [`DockProposal`](crate::DockProposal) during drag/drop. It describes the
+/// semantic destination; layout code later turns the committed tree into
+/// geometry.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DockTarget {
+    /// Root-level target.
+    Root,
+    /// Split relative to an existing tile.
+    Split {
+        /// Target tile.
+        tile: TileId,
+        /// Split axis.
+        axis: Axis,
+        /// Placement relative to the target tile.
+        placement: Placement,
+        /// Share assigned to the moved or inserted pane.
+        ///
+        /// Expected to be finite and strictly between `0.0` and `1.0`.
+        ratio: f64,
+    },
+    /// Insert as a tab in an existing group.
+    TabInto {
+        /// Target tab group.
+        group: TileId,
+        /// Optional insertion index.
+        index: Option<usize>,
+    },
+    /// Replace a target tile.
+    Replace {
+        /// Target tile.
+        tile: TileId,
+    },
+    /// Future floating target.
+    Float {
+        /// Requested floating bounds.
+        bounds: Rect,
+    },
+}
+
+/// Semantic mutation applied to a [`TileTree`](crate::TileTree).
+///
+/// Construct one and pass it to [`TileTree::apply`](crate::TileTree::apply) for
+/// command-driven changes. Interaction commit helpers such as
+/// [`commit_drag`](crate::commit_drag) and
+/// [`commit_resize`](crate::commit_resize) also return the operation they
+/// applied so callers can log, undo, or mirror the semantic change.
+#[derive(Clone, Debug)]
+pub enum TileOp {
+    /// Activate a pane within its tab group.
+    ActivatePane {
+        /// Pane to activate.
+        pane: PaneId,
+    },
+    /// Close a pane.
+    ClosePane {
+        /// Pane to close.
+        pane: PaneId,
+    },
+    /// Split around a pane or its containing tab group.
+    SplitPane {
+        /// Existing pane used as the split target.
+        pane: PaneId,
+        /// Split axis.
+        axis: Axis,
+        /// New pane to insert.
+        new_pane: PaneId,
+        /// Placement relative to the target.
+        placement: Placement,
+        /// Share assigned to the new pane.
+        ///
+        /// Expected to be finite and strictly between `0.0` and `1.0`.
+        share: f64,
+    },
+    /// Move a pane to a dock target.
+    MovePane {
+        /// Pane to move.
+        pane: PaneId,
+        /// Move target.
+        target: DockTarget,
+    },
+    /// Reorder a tab inside a group.
+    ReorderTab {
+        /// Target tab group.
+        group: TileId,
+        /// Pane tab to move.
+        pane: PaneId,
+        /// New tab index.
+        index: usize,
+    },
+    /// Resize a split by moving one handle.
+    ResizeSplit {
+        /// Split tile.
+        split: TileId,
+        /// Handle index.
+        handle: usize,
+        /// Pointer delta along the split axis.
+        ///
+        /// Expected to be finite.
+        delta: f64,
+    },
+    /// Set split shares directly.
+    SetSplitShares {
+        /// Split tile.
+        split: TileId,
+        /// Replacement shares.
+        shares: Vec<f64>,
+    },
+    /// Future operation for floating a pane.
+    FloatPane {
+        /// Pane to float.
+        pane: PaneId,
+        /// Requested floating bounds.
+        bounds: Rect,
+    },
+    /// Restore a saved layout snapshot.
+    RestoreLayout {
+        /// Snapshot to restore.
+        snapshot: LayoutSnapshot,
+    },
+}
+
+/// Error returned by mutation and commit APIs.
+///
+/// Returned from [`TileTree::apply`](crate::TileTree::apply), interaction
+/// commits, proposal validation, and snapshot restore when an id, target,
+/// policy, or interaction revision is invalid.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TileError {
+    /// The operation referenced a missing tile.
+    InvalidTileId,
+    /// The operation referenced a missing pane.
+    InvalidPaneId,
+    /// The operation is structurally invalid.
+    InvalidOperation,
+    /// The target cannot accept the requested operation.
+    InvalidTarget,
+    /// The interaction was based on an old tree revision.
+    StaleInteraction,
+    /// Policy data rejected the operation.
+    PolicyRejected,
+    /// The operation would leave no panes.
+    EmptyTree,
+    /// The operation tried to close the last pane.
+    CannotCloseLastPane,
+    /// The operation is reserved but not implemented in this slice.
+    Unsupported,
+}

--- a/understory_tiling/src/policy.rs
+++ b/understory_tiling/src/policy.rs
@@ -1,0 +1,142 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::interaction::op_for_dock_proposal;
+use crate::{Proposal, TileError, TileOp, TileTree};
+
+/// Pane behavior capabilities.
+///
+/// Store this in [`DockPolicyData`] when validating proposals. The current MVP
+/// mostly exposes the shape; future validation can use these flags to accept or
+/// reject close, move, tab, split, and float requests.
+#[derive(Clone, Copy, Debug)]
+pub struct PaneCapabilities {
+    /// Whether pane close operations are allowed.
+    pub closable: bool,
+    /// Whether pane move operations are allowed.
+    pub movable: bool,
+    /// Whether pane float operations are allowed.
+    pub floatable: bool,
+    /// Whether pane pinning is allowed by future APIs.
+    pub pinnable: bool,
+    /// Whether the pane may join tab groups.
+    pub tabbable: bool,
+    /// Whether the pane may be used as a split target.
+    pub split_target: bool,
+    /// Edges allowed for edge docking.
+    pub allowed_edges: EdgeSet,
+    /// Zones allowed for docking.
+    pub allowed_zones: ZoneSet,
+}
+
+/// Bitset of allowed dock edges.
+///
+/// Use these constants in [`PaneCapabilities::allowed_edges`] to describe which
+/// edge split targets a pane may dock into.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EdgeSet(
+    /// Edge bitset.
+    pub u8,
+);
+
+/// Bitset of allowed dock zones.
+///
+/// Use these constants in [`PaneCapabilities::allowed_zones`] to describe which
+/// broad docking zones a pane may use.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ZoneSet(
+    /// Zone bitset.
+    pub u8,
+);
+
+/// Data-driven docking policy.
+///
+/// Construct this and pass it to [`validate_proposal`] before committing a drag,
+/// resize, or command-generated proposal. The core uses data rather than
+/// callbacks so validation remains deterministic and testable.
+#[derive(Clone, Debug, Default)]
+pub struct DockPolicyData {
+    /// Default capabilities used for panes without per-pane data.
+    pub default_pane_capabilities: PaneCapabilities,
+    /// Whether the layout is locked against mutation.
+    pub locked_layout: bool,
+}
+
+/// A proposal paired with the operation it lowers to.
+///
+/// Returned by [`validate_proposal`]. Pass it to [`commit_proposal`] to apply
+/// the already-validated operation without re-lowering the proposal.
+#[derive(Clone, Debug)]
+pub struct ValidatedProposal {
+    /// Original proposal.
+    pub proposal: Proposal,
+    /// Operation to commit.
+    pub op: TileOp,
+}
+
+impl Default for PaneCapabilities {
+    fn default() -> Self {
+        Self {
+            closable: true,
+            movable: true,
+            floatable: true,
+            pinnable: true,
+            tabbable: true,
+            split_target: true,
+            allowed_edges: EdgeSet::ALL,
+            allowed_zones: ZoneSet::ALL,
+        }
+    }
+}
+
+impl EdgeSet {
+    /// Left edge.
+    pub const LEFT: Self = Self(0b0001);
+    /// Right edge.
+    pub const RIGHT: Self = Self(0b0010);
+    /// Top edge.
+    pub const TOP: Self = Self(0b0100);
+    /// Bottom edge.
+    pub const BOTTOM: Self = Self(0b1000);
+    /// All edges.
+    pub const ALL: Self = Self(0b1111);
+}
+
+impl ZoneSet {
+    /// Split zone.
+    pub const SPLIT: Self = Self(0b0001);
+    /// Tab-into zone.
+    pub const TAB: Self = Self(0b0010);
+    /// Floating zone.
+    pub const FLOAT: Self = Self(0b0100);
+    /// All zones.
+    pub const ALL: Self = Self(0b0111);
+}
+
+/// Validates a proposal and lowers it to a semantic operation.
+pub fn validate_proposal(
+    _tree: &TileTree,
+    proposal: Proposal,
+    policy: &DockPolicyData,
+) -> Result<ValidatedProposal, TileError> {
+    if policy.locked_layout {
+        return Err(TileError::PolicyRejected);
+    }
+    let op = match proposal.clone() {
+        Proposal::Dock(dock) => op_for_dock_proposal(dock)?,
+        Proposal::Resize(resize) => TileOp::SetSplitShares {
+            split: resize.split,
+            shares: resize.new_shares,
+        },
+    };
+    Ok(ValidatedProposal { proposal, op })
+}
+
+/// Commits a validated proposal.
+pub fn commit_proposal(
+    tree: &mut TileTree,
+    proposal: ValidatedProposal,
+) -> Result<TileOp, TileError> {
+    tree.apply(proposal.op.clone())?;
+    Ok(proposal.op)
+}

--- a/understory_tiling/src/snapshot.rs
+++ b/understory_tiling/src/snapshot.rs
@@ -1,0 +1,79 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec::Vec;
+
+use crate::{PaneId, TileError, TileId, TileTree};
+
+/// Saved layout snapshot.
+///
+/// Construct this when persisting a layout, then pass it to
+/// [`restore_snapshot`] or [`TileOp::RestoreLayout`](crate::TileOp::RestoreLayout)
+/// when loading saved state. The tree is normalized during restore when
+/// requested by [`RestoreOptions`].
+#[derive(Clone, Debug)]
+pub struct LayoutSnapshot {
+    /// Snapshot schema version.
+    pub schema_version: u16,
+    /// Saved tree.
+    pub tree: TileTree,
+    /// Active pane known by the embedding layer.
+    pub active_pane: Option<PaneId>,
+    /// Pane ids that were closed by the layout layer.
+    pub closed_panes: Vec<PaneId>,
+}
+
+/// Restore behavior for saved snapshots.
+///
+/// Construct this and pass it to [`restore_snapshot`] to choose how aggressively
+/// persisted data should be normalized or repaired before it becomes a live
+/// [`TileTree`].
+#[derive(Clone, Copy, Debug)]
+pub struct RestoreOptions {
+    /// Repair references to missing panes when possible.
+    pub repair_missing_panes: bool,
+    /// Drop unknown panes when the embedding layer reports them.
+    pub drop_unknown_panes: bool,
+    /// Normalize the restored tree.
+    pub normalize: bool,
+}
+
+/// Report returned by repair operations.
+///
+/// Returned by [`TileTree::repair`]. The MVP currently normalizes the tree and
+/// leaves detailed actions mostly reserved for future repair reporting.
+#[derive(Clone, Debug, Default)]
+pub struct RepairReport {
+    /// Repair actions performed.
+    pub actions: Vec<RepairAction>,
+}
+
+/// A single repair action.
+///
+/// Values of this enum appear in [`RepairReport::actions`] to explain what was
+/// changed while making a persisted or host-edited tree usable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RepairAction {
+    /// Removed an invalid node.
+    RemovedInvalidNode(TileId),
+    /// Removed a missing pane.
+    RemovedMissingPane(PaneId),
+    /// Repaired a tab group's active index.
+    RepairedActiveTab(TileId),
+    /// Repaired invalid split shares.
+    RepairedShares(TileId),
+    /// Collapsed a split.
+    CollapsedSplit(TileId),
+}
+
+/// Restores a layout snapshot.
+pub fn restore_snapshot(
+    snapshot: LayoutSnapshot,
+    options: RestoreOptions,
+) -> Result<TileTree, TileError> {
+    let mut tree = snapshot.tree;
+    if options.normalize || options.repair_missing_panes || options.drop_unknown_panes {
+        tree.normalize();
+    }
+    Ok(tree)
+}

--- a/understory_tiling/src/tests.rs
+++ b/understory_tiling/src/tests.rs
@@ -1,0 +1,250 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec;
+
+use crate::*;
+
+fn input() -> LayoutInput {
+    LayoutInput {
+        bounds: Rect::new(0.0, 0.0, 300.0, 200.0),
+        tab_bar_thickness: 20.0,
+        split_handle_thickness: 10.0,
+        min_pane_size: Size::new(20.0, 20.0),
+        generate_drop_targets: false,
+    }
+}
+
+#[test]
+fn single_pane_fills_bounds() {
+    let tree = TileTree::single_pane(PaneId(1));
+    let frame = tree.layout(input());
+    assert_eq!(frame.panes.len(), 1);
+    assert_eq!(frame.panes[0].rect, input().bounds);
+}
+
+#[test]
+fn split_pane_creates_two_panes_and_handle() {
+    let mut tree = TileTree::single_pane(PaneId(1));
+    tree.apply(TileOp::SplitPane {
+        pane: PaneId(1),
+        axis: Axis::Horizontal,
+        new_pane: PaneId(2),
+        placement: Placement::After,
+        share: 0.5,
+    })
+    .unwrap();
+
+    let frame = tree.layout(input());
+    assert_eq!(frame.panes.len(), 2);
+    assert_eq!(frame.split_handles.len(), 1);
+    assert_eq!(frame.panes[0].rect.width(), 145.0);
+    assert_eq!(frame.split_handles[0].rect.width(), 10.0);
+    assert_eq!(frame.panes[1].rect.width(), 145.0);
+}
+
+#[test]
+fn tabs_emit_bar_tabs_and_active_pane() {
+    let tree = TileTree::new(TileNode::tabs(vec![PaneId(1), PaneId(2)]));
+    let frame = tree.layout(input());
+    assert_eq!(frame.tab_bars.len(), 1);
+    assert_eq!(frame.tabs.len(), 2);
+    assert_eq!(frame.panes.len(), 1);
+    assert_eq!(frame.panes[0].pane, PaneId(1));
+    assert_eq!(frame.panes[0].rect.y0, 20.0);
+}
+
+#[test]
+fn activate_pane_changes_active_tab() {
+    let mut tree = TileTree::new(TileNode::tabs(vec![PaneId(1), PaneId(2)]));
+    tree.apply(TileOp::ActivatePane { pane: PaneId(2) })
+        .unwrap();
+    let frame = tree.layout(input());
+    assert_eq!(frame.panes[0].pane, PaneId(2));
+    assert_eq!(tree.revision(), Revision(1));
+}
+
+#[test]
+fn hit_test_prefers_split_handle() {
+    let mut tree = TileTree::single_pane(PaneId(1));
+    tree.apply(TileOp::SplitPane {
+        pane: PaneId(1),
+        axis: Axis::Horizontal,
+        new_pane: PaneId(2),
+        placement: Placement::After,
+        share: 0.5,
+    })
+    .unwrap();
+    let frame = tree.layout(input());
+    assert!(matches!(
+        hit_test(&frame, Point::new(150.0, 50.0)),
+        Some(HitKind::SplitHandle { .. })
+    ));
+}
+
+#[test]
+fn reorder_tab_moves_pane() {
+    let mut tree = TileTree::new(TileNode::tabs(vec![PaneId(1), PaneId(2), PaneId(3)]));
+    let group = tree.root();
+    tree.apply(TileOp::ReorderTab {
+        group,
+        pane: PaneId(3),
+        index: 0,
+    })
+    .unwrap();
+    let Some(TileNode::Tabs(tabs)) = tree.node(group) else {
+        panic!("root should be tabs");
+    };
+    assert_eq!(tabs.panes, vec![PaneId(3), PaneId(1), PaneId(2)]);
+}
+
+#[test]
+fn move_pane_into_tab_group() {
+    let mut tree = TileTree::new(TileNode::tabs(vec![PaneId(1)]));
+    let group = tree.root();
+    tree.apply(TileOp::SplitPane {
+        pane: PaneId(1),
+        axis: Axis::Horizontal,
+        new_pane: PaneId(2),
+        placement: Placement::After,
+        share: 0.5,
+    })
+    .unwrap();
+    tree.apply(TileOp::MovePane {
+        pane: PaneId(2),
+        target: DockTarget::TabInto {
+            group,
+            index: Some(1),
+        },
+    })
+    .unwrap();
+    let Some(TileNode::Tabs(tabs)) = tree.node(group) else {
+        panic!("group should still be tabs");
+    };
+    assert_eq!(tabs.panes, vec![PaneId(1), PaneId(2)]);
+}
+
+#[test]
+fn set_split_shares_repairs_bad_input() {
+    let mut tree = TileTree::single_pane(PaneId(1));
+    tree.apply(TileOp::SplitPane {
+        pane: PaneId(1),
+        axis: Axis::Horizontal,
+        new_pane: PaneId(2),
+        placement: Placement::After,
+        share: 0.5,
+    })
+    .unwrap();
+    let split = tree.root();
+    tree.apply(TileOp::SetSplitShares {
+        split,
+        shares: vec![f64::NAN],
+    })
+    .unwrap();
+    let Some(TileNode::Split(node)) = tree.node(split) else {
+        panic!("root should be split");
+    };
+    assert_eq!(node.shares, vec![1.0, 1.0]);
+}
+
+#[test]
+fn split_pane_rejects_invalid_share() {
+    let mut tree = TileTree::single_pane(PaneId(1));
+
+    assert!(matches!(
+        tree.apply(TileOp::SplitPane {
+            pane: PaneId(1),
+            axis: Axis::Horizontal,
+            new_pane: PaneId(2),
+            placement: Placement::After,
+            share: f64::NAN,
+        }),
+        Err(TileError::InvalidOperation)
+    ));
+    assert!(matches!(
+        tree.apply(TileOp::SplitPane {
+            pane: PaneId(1),
+            axis: Axis::Horizontal,
+            new_pane: PaneId(2),
+            placement: Placement::After,
+            share: 1.0,
+        }),
+        Err(TileError::InvalidOperation)
+    ));
+}
+
+#[test]
+fn move_pane_rejects_invalid_split_ratio() {
+    let mut tree = TileTree::single_pane(PaneId(1));
+    tree.apply(TileOp::SplitPane {
+        pane: PaneId(1),
+        axis: Axis::Horizontal,
+        new_pane: PaneId(2),
+        placement: Placement::After,
+        share: 0.5,
+    })
+    .unwrap();
+    let target = tree.root();
+
+    assert!(matches!(
+        tree.apply(TileOp::MovePane {
+            pane: PaneId(2),
+            target: DockTarget::Split {
+                tile: target,
+                axis: Axis::Horizontal,
+                placement: Placement::After,
+                ratio: f64::INFINITY,
+            },
+        }),
+        Err(TileError::InvalidTarget)
+    ));
+}
+
+#[test]
+fn drag_update_proposes_move() {
+    let mut tree = TileTree::single_pane(PaneId(1));
+    tree.apply(TileOp::SplitPane {
+        pane: PaneId(1),
+        axis: Axis::Horizontal,
+        new_pane: PaneId(2),
+        placement: Placement::After,
+        share: 0.5,
+    })
+    .unwrap();
+    let frame = tree.layout(input());
+    let mut drag = begin_drag(&frame, Point::new(20.0, 20.0), DragIntent::Move).unwrap();
+    let update = update_drag(
+        &tree,
+        &frame,
+        &mut drag,
+        Point::new(290.0, 50.0),
+        &DragOptions::default(),
+    );
+    assert!(matches!(
+        update.proposal,
+        Some(DockProposal::MovePane { .. })
+    ));
+}
+
+#[test]
+fn stale_drag_commit_is_rejected() {
+    let mut tree = TileTree::single_pane(PaneId(1));
+    let frame = tree.layout(input());
+    let mut drag = begin_drag(&frame, Point::new(20.0, 20.0), DragIntent::Move).unwrap();
+    drag.proposal = Some(DockProposal::MovePane {
+        pane: PaneId(1),
+        target: DockTarget::Root,
+    });
+    tree.apply(TileOp::SplitPane {
+        pane: PaneId(1),
+        axis: Axis::Horizontal,
+        new_pane: PaneId(2),
+        placement: Placement::After,
+        share: 0.5,
+    })
+    .unwrap();
+    assert!(matches!(
+        commit_drag(&mut tree, drag),
+        Err(TileError::StaleInteraction)
+    ));
+}

--- a/understory_tiling/src/tree.rs
+++ b/understory_tiling/src/tree.rs
@@ -1,0 +1,829 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::util::{
+    is_valid_split_fraction, repaired_shares, solve_lengths, split_tab_bar, tab_rects,
+};
+use crate::{
+    Axis, DockTarget, FrameItemId, HitKind, HitRegion, LayoutFrame, LayoutInput, PaneFrame, PaneId,
+    Placement, Rect, RepairReport, Revision, SplitConstraints, SplitHandleFrame, SplitNode,
+    TabBarFrame, TabBarPlacement, TabFrame, TabNode, TileError, TileId, TileNode, TileOp,
+};
+
+/// Persistent semantic tree of splits, tab groups, and pane leaves.
+///
+/// Create one with [`TileTree::new`] or [`TileTree::single_pane`], mutate it
+/// with [`TileTree::apply`], and call [`TileTree::layout`] whenever the host
+/// needs a fresh [`LayoutFrame`] for rendering, hit testing, or interactions.
+#[derive(Clone, Debug)]
+pub struct TileTree {
+    root: TileId,
+    revision: Revision,
+    nodes: Vec<NodeSlot>,
+}
+
+#[derive(Clone, Debug)]
+struct NodeSlot {
+    node: Option<TileNode>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum PaneLocation {
+    Tile { tile: TileId },
+    InTabs { group: TileId, index: usize },
+}
+
+impl TileTree {
+    /// Creates a tree from a root node.
+    #[must_use]
+    pub fn new(root: TileNode) -> Self {
+        let mut tree = Self {
+            root: TileId(0),
+            revision: Revision(0),
+            nodes: Vec::new(),
+        };
+        tree.root = tree.push_node(root);
+        tree.normalize();
+        tree
+    }
+
+    /// Creates a tree containing one pane.
+    #[must_use]
+    pub fn single_pane(pane: PaneId) -> Self {
+        Self::new(TileNode::pane(pane))
+    }
+
+    /// Returns the root tile id.
+    #[must_use]
+    pub const fn root(&self) -> TileId {
+        self.root
+    }
+
+    /// Returns the current tree revision.
+    #[must_use]
+    pub const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    /// Returns a tile node by id.
+    #[must_use]
+    pub fn node(&self, id: TileId) -> Option<&TileNode> {
+        self.get_node(id)
+    }
+
+    /// Applies a semantic operation atomically.
+    pub fn apply(&mut self, op: TileOp) -> Result<(), TileError> {
+        let mut next = self.clone();
+        let changed = next.apply_inner(op)?;
+        if changed {
+            next.revision.0 = next.revision.0.saturating_add(1);
+            next.normalize();
+            *self = next;
+        }
+        Ok(())
+    }
+
+    /// Normalizes the tree in place.
+    pub fn normalize(&mut self) {
+        if self.nodes.is_empty() {
+            self.root = self.push_node(TileNode::Tabs(TabNode {
+                panes: Vec::new(),
+                active: 0,
+                placement: TabBarPlacement::Hidden,
+            }));
+            return;
+        }
+
+        let mut visiting = vec![false; self.nodes.len()];
+        let root = self.normalize_node(self.root, &mut visiting);
+        self.root = root.unwrap_or_else(|| {
+            self.push_node(TileNode::Tabs(TabNode {
+                panes: Vec::new(),
+                active: 0,
+                placement: TabBarPlacement::Hidden,
+            }))
+        });
+
+        let mut reachable = vec![false; self.nodes.len()];
+        self.mark_reachable(self.root, &mut reachable);
+        for (index, slot) in self.nodes.iter_mut().enumerate() {
+            if !reachable.get(index).copied().unwrap_or(false) {
+                slot.node = None;
+            }
+        }
+    }
+
+    /// Repairs a tree and reports high-level repair actions.
+    pub fn repair(&mut self) -> RepairReport {
+        self.normalize();
+        RepairReport {
+            actions: Vec::new(),
+        }
+    }
+
+    /// Solves layout and returns a flattened frame.
+    ///
+    /// `input` scalar geometry is expected to be finite. Thicknesses and minimum
+    /// pane sizes are expected to be non-negative.
+    #[must_use]
+    pub fn layout(&self, input: LayoutInput) -> LayoutFrame {
+        debug_assert!(
+            input.bounds.is_finite(),
+            "LayoutInput::bounds must be finite",
+        );
+        debug_assert!(
+            input.tab_bar_thickness.is_finite() && input.tab_bar_thickness >= 0.0,
+            "LayoutInput::tab_bar_thickness must be finite and non-negative",
+        );
+        debug_assert!(
+            input.split_handle_thickness.is_finite() && input.split_handle_thickness >= 0.0,
+            "LayoutInput::split_handle_thickness must be finite and non-negative",
+        );
+        debug_assert!(
+            input.min_pane_size.is_finite()
+                && input.min_pane_size.width >= 0.0
+                && input.min_pane_size.height >= 0.0,
+            "LayoutInput::min_pane_size must be finite and non-negative",
+        );
+        let mut frame = LayoutFrame {
+            revision: self.revision,
+            ..LayoutFrame::default()
+        };
+        let mut visiting = vec![false; self.nodes.len()];
+        self.layout_tile(
+            self.root,
+            input.bounds.abs(),
+            &input,
+            &mut frame,
+            &mut visiting,
+        );
+        frame
+    }
+
+    fn apply_inner(&mut self, op: TileOp) -> Result<bool, TileError> {
+        match op {
+            TileOp::ActivatePane { pane } => self.activate_pane(pane),
+            TileOp::ClosePane { pane } => self.close_pane(pane),
+            TileOp::SplitPane {
+                pane,
+                axis,
+                new_pane,
+                placement,
+                share,
+            } => self.split_pane(pane, axis, new_pane, placement, share),
+            TileOp::MovePane { pane, target } => self.move_pane(pane, target),
+            TileOp::ReorderTab { group, pane, index } => self.reorder_tab(group, pane, index),
+            TileOp::ResizeSplit {
+                split,
+                handle,
+                delta,
+            } => self.resize_split(split, handle, delta),
+            TileOp::SetSplitShares { split, shares } => self.set_split_shares(split, shares),
+            TileOp::FloatPane { .. } => Err(TileError::Unsupported),
+            TileOp::RestoreLayout { snapshot } => {
+                *self = snapshot.tree;
+                self.normalize();
+                Ok(true)
+            }
+        }
+    }
+
+    fn push_node(&mut self, node: TileNode) -> TileId {
+        let id = TileId(u32::try_from(self.nodes.len()).expect("tile arena exhausted"));
+        self.nodes.push(NodeSlot { node: Some(node) });
+        id
+    }
+
+    fn get_node(&self, id: TileId) -> Option<&TileNode> {
+        self.nodes.get(id.0 as usize)?.node.as_ref()
+    }
+
+    fn get_node_mut(&mut self, id: TileId) -> Option<&mut TileNode> {
+        self.nodes.get_mut(id.0 as usize)?.node.as_mut()
+    }
+
+    fn set_node(&mut self, id: TileId, node: TileNode) -> Result<(), TileError> {
+        let slot = self
+            .nodes
+            .get_mut(id.0 as usize)
+            .ok_or(TileError::InvalidTileId)?;
+        slot.node = Some(node);
+        Ok(())
+    }
+
+    fn clear_node(&mut self, id: TileId) {
+        if let Some(slot) = self.nodes.get_mut(id.0 as usize) {
+            slot.node = None;
+        }
+    }
+
+    fn activate_pane(&mut self, pane: PaneId) -> Result<bool, TileError> {
+        let location = self.find_pane(pane).ok_or(TileError::InvalidPaneId)?;
+        match location {
+            PaneLocation::InTabs { group, index } => {
+                let Some(TileNode::Tabs(tabs)) = self.get_node_mut(group) else {
+                    return Err(TileError::InvalidTileId);
+                };
+                if tabs.active == index {
+                    return Ok(false);
+                }
+                tabs.active = index;
+                Ok(true)
+            }
+            PaneLocation::Tile { .. } => Ok(false),
+        }
+    }
+
+    fn close_pane(&mut self, pane: PaneId) -> Result<bool, TileError> {
+        if self.count_panes() <= 1 {
+            return Err(TileError::CannotCloseLastPane);
+        }
+        self.remove_pane(pane)?;
+        Ok(true)
+    }
+
+    fn split_pane(
+        &mut self,
+        pane: PaneId,
+        axis: Axis,
+        new_pane: PaneId,
+        placement: Placement,
+        share: f64,
+    ) -> Result<bool, TileError> {
+        if !is_valid_split_fraction(share) {
+            return Err(TileError::InvalidOperation);
+        }
+        let location = self.find_pane(pane).ok_or(TileError::InvalidPaneId)?;
+        let target = match location {
+            PaneLocation::Tile { tile } => tile,
+            PaneLocation::InTabs { group, .. } => group,
+        };
+        let new_tile = self.push_node(TileNode::pane(new_pane));
+        self.insert_tile_near(target, axis, new_tile, placement, share)?;
+        Ok(true)
+    }
+
+    fn move_pane(&mut self, pane: PaneId, target: DockTarget) -> Result<bool, TileError> {
+        if !self.contains_pane(pane) {
+            return Err(TileError::InvalidPaneId);
+        }
+        self.validate_target(target)?;
+        self.remove_pane(pane)?;
+        let tile = self.push_node(TileNode::pane(pane));
+        self.insert_tile_at_target(tile, pane, target)?;
+        Ok(true)
+    }
+
+    fn reorder_tab(
+        &mut self,
+        group: TileId,
+        pane: PaneId,
+        index: usize,
+    ) -> Result<bool, TileError> {
+        let Some(TileNode::Tabs(tabs)) = self.get_node_mut(group) else {
+            return Err(TileError::InvalidTileId);
+        };
+        let Some(from) = tabs.panes.iter().position(|candidate| *candidate == pane) else {
+            return Err(TileError::InvalidPaneId);
+        };
+        let active_pane = tabs.panes.get(tabs.active).copied();
+        let pane = tabs.panes.remove(from);
+        let to = index.min(tabs.panes.len());
+        tabs.panes.insert(to, pane);
+        if let Some(active) = active_pane {
+            tabs.active = tabs
+                .panes
+                .iter()
+                .position(|candidate| *candidate == active)
+                .unwrap_or(0);
+        }
+        Ok(from != to)
+    }
+
+    fn resize_split(
+        &mut self,
+        split: TileId,
+        handle: usize,
+        delta: f64,
+    ) -> Result<bool, TileError> {
+        let Some(TileNode::Split(node)) = self.get_node_mut(split) else {
+            return Err(TileError::InvalidTileId);
+        };
+        if handle + 1 >= node.children.len() {
+            return Err(TileError::InvalidOperation);
+        }
+        if !delta.is_finite() {
+            return Err(TileError::InvalidOperation);
+        }
+        let mut shares = repaired_shares(node.children.len(), &node.shares);
+        let delta_share = delta / 100.0;
+        let left = (shares[handle] + delta_share).max(0.01);
+        let right = (shares[handle + 1] - delta_share).max(0.01);
+        shares[handle] = left;
+        shares[handle + 1] = right;
+        node.shares = shares;
+        Ok(delta_share != 0.0)
+    }
+
+    fn set_split_shares(&mut self, split: TileId, shares: Vec<f64>) -> Result<bool, TileError> {
+        let Some(TileNode::Split(node)) = self.get_node_mut(split) else {
+            return Err(TileError::InvalidTileId);
+        };
+        let repaired = repaired_shares(node.children.len(), &shares);
+        if node.shares == repaired {
+            return Ok(false);
+        }
+        node.shares = repaired;
+        Ok(true)
+    }
+
+    fn validate_target(&self, target: DockTarget) -> Result<(), TileError> {
+        match target {
+            DockTarget::Root => Ok(()),
+            DockTarget::Split { tile, ratio, .. } => {
+                if !is_valid_split_fraction(ratio) {
+                    return Err(TileError::InvalidTarget);
+                }
+                self.get_node(tile).ok_or(TileError::InvalidTileId)?;
+                Ok(())
+            }
+            DockTarget::Replace { tile } => {
+                self.get_node(tile).ok_or(TileError::InvalidTileId)?;
+                Ok(())
+            }
+            DockTarget::TabInto { group, .. } => match self.get_node(group) {
+                Some(TileNode::Tabs(_)) => Ok(()),
+                Some(_) => Err(TileError::InvalidTarget),
+                None => Err(TileError::InvalidTileId),
+            },
+            DockTarget::Float { .. } => Err(TileError::Unsupported),
+        }
+    }
+
+    fn insert_tile_at_target(
+        &mut self,
+        tile: TileId,
+        pane: PaneId,
+        target: DockTarget,
+    ) -> Result<(), TileError> {
+        match target {
+            DockTarget::Root => {
+                let group = self.push_node(TileNode::tabs(vec![pane]));
+                self.insert_tile_near(self.root, Axis::Horizontal, group, Placement::After, 0.5)
+            }
+            DockTarget::Split {
+                tile: target,
+                axis,
+                placement,
+                ratio,
+            } => self.insert_tile_near(target, axis, tile, placement, ratio),
+            DockTarget::TabInto { group, index } => {
+                let Some(TileNode::Tabs(tabs)) = self.get_node_mut(group) else {
+                    return Err(TileError::InvalidTarget);
+                };
+                let index = index.unwrap_or(tabs.panes.len()).min(tabs.panes.len());
+                tabs.panes.insert(index, pane);
+                tabs.active = index;
+                self.clear_node(tile);
+                Ok(())
+            }
+            DockTarget::Replace { tile: target } => {
+                self.set_node(target, TileNode::pane(pane))?;
+                self.clear_node(tile);
+                Ok(())
+            }
+            DockTarget::Float { .. } => Err(TileError::Unsupported),
+        }
+    }
+
+    fn insert_tile_near(
+        &mut self,
+        target: TileId,
+        axis: Axis,
+        inserted: TileId,
+        placement: Placement,
+        share: f64,
+    ) -> Result<(), TileError> {
+        debug_assert!(
+            is_valid_split_fraction(share),
+            "internal split insertion requires a finite fraction in 0.0..1.0",
+        );
+        self.get_node(target).ok_or(TileError::InvalidTileId)?;
+        let parent = self.find_parent(target);
+        if let Some((parent_id, child_index)) = parent {
+            let Some(TileNode::Split(parent_split)) = self.get_node_mut(parent_id) else {
+                return Err(TileError::InvalidOperation);
+            };
+            if parent_split.axis == axis {
+                let old_shares = repaired_shares(parent_split.children.len(), &parent_split.shares);
+                parent_split.shares = old_shares;
+                let old_share = parent_split.shares[child_index];
+                let inserted_share = (old_share * share).max(0.01);
+                let target_share = (old_share - inserted_share).max(0.01);
+                parent_split.shares[child_index] = target_share;
+                let insert_index = match placement {
+                    Placement::Before => child_index,
+                    Placement::After => child_index + 1,
+                };
+                parent_split.children.insert(insert_index, inserted);
+                parent_split.shares.insert(insert_index, inserted_share);
+                return Ok(());
+            }
+        }
+
+        let (children, shares) = match placement {
+            Placement::Before => (
+                vec![inserted, target],
+                vec![share.max(0.01), (1.0 - share).max(0.01)],
+            ),
+            Placement::After => (
+                vec![target, inserted],
+                vec![(1.0 - share).max(0.01), share.max(0.01)],
+            ),
+        };
+        let split = self.push_node(TileNode::Split(SplitNode {
+            axis,
+            children,
+            shares,
+            constraints: SplitConstraints::default(),
+        }));
+
+        if target == self.root {
+            self.root = split;
+            Ok(())
+        } else if let Some((parent_id, child_index)) = parent {
+            let Some(TileNode::Split(parent_split)) = self.get_node_mut(parent_id) else {
+                return Err(TileError::InvalidOperation);
+            };
+            parent_split.children[child_index] = split;
+            Ok(())
+        } else {
+            Err(TileError::InvalidOperation)
+        }
+    }
+
+    fn remove_pane(&mut self, pane: PaneId) -> Result<(), TileError> {
+        match self.find_pane(pane).ok_or(TileError::InvalidPaneId)? {
+            PaneLocation::Tile { tile } => {
+                self.clear_node(tile);
+            }
+            PaneLocation::InTabs { group, index } => {
+                let Some(TileNode::Tabs(tabs)) = self.get_node_mut(group) else {
+                    return Err(TileError::InvalidTileId);
+                };
+                tabs.panes.remove(index);
+                if tabs.panes.is_empty() {
+                    tabs.active = 0;
+                } else if tabs.active >= tabs.panes.len() {
+                    tabs.active = tabs.panes.len() - 1;
+                } else if index <= tabs.active && tabs.active > 0 {
+                    tabs.active -= 1;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn normalize_node(&mut self, id: TileId, visiting: &mut [bool]) -> Option<TileId> {
+        let index = id.0 as usize;
+        if index >= self.nodes.len() || visiting.get(index).copied().unwrap_or(false) {
+            self.clear_node(id);
+            return None;
+        }
+        self.get_node(id)?;
+
+        visiting[index] = true;
+        let node = self.get_node(id).cloned()?;
+        let result = match node {
+            TileNode::Pane(_) => Some(id),
+            TileNode::Tabs(mut tabs) => {
+                if tabs.panes.is_empty() {
+                    self.clear_node(id);
+                    None
+                } else {
+                    if tabs.active >= tabs.panes.len() {
+                        tabs.active = 0;
+                    }
+                    let _ = self.set_node(id, TileNode::Tabs(tabs));
+                    Some(id)
+                }
+            }
+            TileNode::Split(split) => self.normalize_split(id, split, visiting),
+        };
+        visiting[index] = false;
+        result
+    }
+
+    fn normalize_split(
+        &mut self,
+        id: TileId,
+        split: SplitNode,
+        visiting: &mut [bool],
+    ) -> Option<TileId> {
+        let old_shares = repaired_shares(split.children.len(), &split.shares);
+        let mut children = Vec::new();
+        let mut shares = Vec::new();
+
+        for (child_index, child) in split.children.iter().copied().enumerate() {
+            let Some(child) = self.normalize_node(child, visiting) else {
+                continue;
+            };
+            let share = old_shares.get(child_index).copied().unwrap_or(1.0);
+            if let Some(TileNode::Split(child_split)) = self.get_node(child).cloned()
+                && child_split.axis == split.axis
+            {
+                let child_shares = repaired_shares(child_split.children.len(), &child_split.shares);
+                for (grand_index, grandchild) in child_split.children.iter().copied().enumerate() {
+                    children.push(grandchild);
+                    shares.push(share * child_shares.get(grand_index).copied().unwrap_or(1.0));
+                }
+                self.clear_node(child);
+                continue;
+            }
+            children.push(child);
+            shares.push(share);
+        }
+
+        match children.len() {
+            0 => {
+                self.clear_node(id);
+                None
+            }
+            1 => {
+                self.clear_node(id);
+                children.first().copied()
+            }
+            _ => {
+                let shares = repaired_shares(children.len(), &shares);
+                let _ = self.set_node(
+                    id,
+                    TileNode::Split(SplitNode {
+                        axis: split.axis,
+                        children,
+                        shares,
+                        constraints: split.constraints,
+                    }),
+                );
+                Some(id)
+            }
+        }
+    }
+
+    fn mark_reachable(&self, id: TileId, reachable: &mut [bool]) {
+        let index = id.0 as usize;
+        if index >= reachable.len() || reachable[index] {
+            return;
+        }
+        reachable[index] = true;
+        if let Some(TileNode::Split(split)) = self.get_node(id) {
+            for child in &split.children {
+                self.mark_reachable(*child, reachable);
+            }
+        }
+    }
+
+    fn layout_tile(
+        &self,
+        id: TileId,
+        rect: Rect,
+        input: &LayoutInput,
+        frame: &mut LayoutFrame,
+        visiting: &mut [bool],
+    ) {
+        let index = id.0 as usize;
+        if index >= self.nodes.len() || visiting.get(index).copied().unwrap_or(false) {
+            return;
+        }
+        let Some(node) = self.get_node(id) else {
+            return;
+        };
+        visiting[index] = true;
+        match node {
+            TileNode::Pane(pane) => {
+                frame.focus_order.push(pane.pane);
+                frame.panes.push(PaneFrame {
+                    pane: pane.pane,
+                    tile: id,
+                    rect,
+                    clip: rect,
+                    active: true,
+                });
+                frame.hit_regions.push(HitRegion {
+                    rect,
+                    z: 0,
+                    kind: HitKind::Pane { pane: pane.pane },
+                });
+                frame.paint_order.push(FrameItemId::Pane(pane.pane));
+            }
+            TileNode::Tabs(tabs) => self.layout_tabs(id, tabs, rect, input, frame),
+            TileNode::Split(split) => self.layout_split(id, split, rect, input, frame, visiting),
+        }
+        visiting[index] = false;
+    }
+
+    fn layout_tabs(
+        &self,
+        id: TileId,
+        tabs: &TabNode,
+        rect: Rect,
+        input: &LayoutInput,
+        frame: &mut LayoutFrame,
+    ) {
+        for pane in &tabs.panes {
+            frame.focus_order.push(*pane);
+        }
+        if tabs.panes.is_empty() {
+            return;
+        }
+        let active_index = tabs.active.min(tabs.panes.len() - 1);
+        let active_pane = tabs.panes[active_index];
+        let (bar_rect, pane_rect) = split_tab_bar(rect, tabs.placement, input.tab_bar_thickness);
+
+        if tabs.placement != TabBarPlacement::Hidden {
+            let bar = TabBarFrame {
+                group: id,
+                rect: bar_rect,
+                placement: tabs.placement,
+                active_pane: Some(active_pane),
+            };
+            frame.tab_bars.push(bar);
+            frame.hit_regions.push(HitRegion {
+                rect: bar_rect,
+                z: 5,
+                kind: HitKind::TabBar { group: id },
+            });
+            frame.paint_order.push(FrameItemId::TabBar(id));
+
+            let tab_rects = tab_rects(bar_rect, tabs.placement, tabs.panes.len());
+            for (index, pane) in tabs.panes.iter().copied().enumerate() {
+                let rect = tab_rects[index];
+                frame.tabs.push(TabFrame {
+                    group: id,
+                    pane,
+                    rect,
+                    index,
+                    active: index == active_index,
+                });
+                frame.hit_regions.push(HitRegion {
+                    rect,
+                    z: 10,
+                    kind: HitKind::Tab { group: id, pane },
+                });
+                frame.paint_order.push(FrameItemId::Tab { group: id, pane });
+            }
+        }
+
+        frame.panes.push(PaneFrame {
+            pane: active_pane,
+            tile: id,
+            rect: pane_rect,
+            clip: pane_rect,
+            active: true,
+        });
+        frame.hit_regions.push(HitRegion {
+            rect: pane_rect,
+            z: 0,
+            kind: HitKind::Pane { pane: active_pane },
+        });
+        frame.paint_order.push(FrameItemId::Pane(active_pane));
+    }
+
+    fn layout_split(
+        &self,
+        id: TileId,
+        split: &SplitNode,
+        rect: Rect,
+        input: &LayoutInput,
+        frame: &mut LayoutFrame,
+        visiting: &mut [bool],
+    ) {
+        let children: Vec<_> = split
+            .children
+            .iter()
+            .copied()
+            .filter(|child| self.get_node(*child).is_some())
+            .collect();
+        if children.is_empty() {
+            return;
+        }
+        if children.len() == 1 {
+            self.layout_tile(children[0], rect, input, frame, visiting);
+            return;
+        }
+
+        let handle = input.split_handle_thickness;
+        let major = match split.axis {
+            Axis::Horizontal => rect.width(),
+            Axis::Vertical => rect.height(),
+        };
+        let handle_total = handle * (children.len() - 1) as f64;
+        let child_total = (major - handle_total).max(0.0);
+        let shares = repaired_shares(children.len(), &split.shares);
+        let min_major = match split.axis {
+            Axis::Horizontal => input.min_pane_size.width,
+            Axis::Vertical => input.min_pane_size.height,
+        };
+        let lengths = solve_lengths(child_total, &shares, min_major);
+        let mut cursor = match split.axis {
+            Axis::Horizontal => rect.x0,
+            Axis::Vertical => rect.y0,
+        };
+
+        for (index, child) in children.iter().copied().enumerate() {
+            let length = lengths[index];
+            let child_rect = match split.axis {
+                Axis::Horizontal => Rect::new(cursor, rect.y0, cursor + length, rect.y1),
+                Axis::Vertical => Rect::new(rect.x0, cursor, rect.x1, cursor + length),
+            };
+            self.layout_tile(child, child_rect, input, frame, visiting);
+            cursor += length;
+            if index + 1 < children.len() {
+                let handle_rect = match split.axis {
+                    Axis::Horizontal => Rect::new(cursor, rect.y0, cursor + handle, rect.y1),
+                    Axis::Vertical => Rect::new(rect.x0, cursor, rect.x1, cursor + handle),
+                };
+                frame.split_handles.push(SplitHandleFrame {
+                    split: id,
+                    handle: index,
+                    axis: split.axis,
+                    rect: handle_rect,
+                });
+                frame.hit_regions.push(HitRegion {
+                    rect: handle_rect,
+                    z: 20,
+                    kind: HitKind::SplitHandle {
+                        split: id,
+                        handle: index,
+                    },
+                });
+                frame.paint_order.push(FrameItemId::SplitHandle {
+                    split: id,
+                    handle: index,
+                });
+                cursor += handle;
+            }
+        }
+    }
+
+    fn find_pane(&self, pane: PaneId) -> Option<PaneLocation> {
+        self.find_pane_from(self.root, pane)
+    }
+
+    fn find_pane_from(&self, tile: TileId, pane: PaneId) -> Option<PaneLocation> {
+        match self.get_node(tile)? {
+            TileNode::Pane(node) => (node.pane == pane).then_some(PaneLocation::Tile { tile }),
+            TileNode::Tabs(tabs) => tabs
+                .panes
+                .iter()
+                .position(|candidate| *candidate == pane)
+                .map(|index| PaneLocation::InTabs { group: tile, index }),
+            TileNode::Split(split) => split
+                .children
+                .iter()
+                .find_map(|child| self.find_pane_from(*child, pane)),
+        }
+    }
+
+    fn find_parent(&self, target: TileId) -> Option<(TileId, usize)> {
+        self.find_parent_from(self.root, target)
+    }
+
+    fn find_parent_from(&self, tile: TileId, target: TileId) -> Option<(TileId, usize)> {
+        let TileNode::Split(split) = self.get_node(tile)? else {
+            return None;
+        };
+        for (index, child) in split.children.iter().copied().enumerate() {
+            if child == target {
+                return Some((tile, index));
+            }
+            if let Some(found) = self.find_parent_from(child, target) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn contains_pane(&self, pane: PaneId) -> bool {
+        self.find_pane(pane).is_some()
+    }
+
+    fn count_panes(&self) -> usize {
+        self.count_panes_from(self.root)
+    }
+
+    fn count_panes_from(&self, tile: TileId) -> usize {
+        match self.get_node(tile) {
+            Some(TileNode::Pane(_)) => 1,
+            Some(TileNode::Tabs(tabs)) => tabs.panes.len(),
+            Some(TileNode::Split(split)) => split
+                .children
+                .iter()
+                .map(|child| self.count_panes_from(*child))
+                .sum(),
+            None => 0,
+        }
+    }
+}

--- a/understory_tiling/src/util.rs
+++ b/understory_tiling/src/util.rs
@@ -1,0 +1,207 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::{Point, Rect, TabBarPlacement};
+
+pub(crate) fn split_tab_bar(
+    rect: Rect,
+    placement: TabBarPlacement,
+    thickness: f64,
+) -> (Rect, Rect) {
+    debug_assert!(rect.is_finite(), "rectangle must be finite");
+    debug_assert!(
+        rect.width() >= 0.0 && rect.height() >= 0.0,
+        "tab bar splitting requires a normalized rectangle",
+    );
+    debug_assert!(
+        thickness.is_finite() && thickness >= 0.0,
+        "tab bar thickness must be finite and non-negative",
+    );
+    match placement {
+        TabBarPlacement::Hidden => (Rect::default(), rect),
+        TabBarPlacement::Top => {
+            let thickness = thickness.min(rect.height());
+            (
+                Rect::new(rect.x0, rect.y0, rect.x1, rect.y0 + thickness),
+                Rect::new(rect.x0, rect.y0 + thickness, rect.x1, rect.y1),
+            )
+        }
+        TabBarPlacement::Bottom => {
+            let thickness = thickness.min(rect.height());
+            (
+                Rect::new(rect.x0, rect.y1 - thickness, rect.x1, rect.y1),
+                Rect::new(rect.x0, rect.y0, rect.x1, rect.y1 - thickness),
+            )
+        }
+        TabBarPlacement::Left => {
+            let thickness = thickness.min(rect.width());
+            (
+                Rect::new(rect.x0, rect.y0, rect.x0 + thickness, rect.y1),
+                Rect::new(rect.x0 + thickness, rect.y0, rect.x1, rect.y1),
+            )
+        }
+        TabBarPlacement::Right => {
+            let thickness = thickness.min(rect.width());
+            (
+                Rect::new(rect.x1 - thickness, rect.y0, rect.x1, rect.y1),
+                Rect::new(rect.x0, rect.y0, rect.x1 - thickness, rect.y1),
+            )
+        }
+    }
+}
+
+pub(crate) fn tab_rects(rect: Rect, placement: TabBarPlacement, count: usize) -> Vec<Rect> {
+    debug_assert!(rect.is_finite(), "rectangle must be finite");
+    debug_assert!(
+        rect.width() >= 0.0 && rect.height() >= 0.0,
+        "tab rectangle generation requires a normalized rectangle",
+    );
+    if count == 0 {
+        return Vec::new();
+    }
+    let mut rects = Vec::with_capacity(count);
+    match placement {
+        TabBarPlacement::Top | TabBarPlacement::Bottom | TabBarPlacement::Hidden => {
+            let width = rect.width() / count as f64;
+            for index in 0..count {
+                let x0 = rect.x0 + width * index as f64;
+                let x1 = if index + 1 == count {
+                    rect.x1
+                } else {
+                    x0 + width
+                };
+                rects.push(Rect::new(x0, rect.y0, x1, rect.y1));
+            }
+        }
+        TabBarPlacement::Left | TabBarPlacement::Right => {
+            let height = rect.height() / count as f64;
+            for index in 0..count {
+                let y0 = rect.y0 + height * index as f64;
+                let y1 = if index + 1 == count {
+                    rect.y1
+                } else {
+                    y0 + height
+                };
+                rects.push(Rect::new(rect.x0, y0, rect.x1, y1));
+            }
+        }
+    }
+    rects
+}
+
+pub(crate) fn solve_lengths(total: f64, shares: &[f64], min_major: f64) -> Vec<f64> {
+    let count = shares.len();
+    if count == 0 {
+        return Vec::new();
+    }
+    debug_assert!(
+        total.is_finite() && total >= 0.0,
+        "split solver total length must be finite and non-negative",
+    );
+    debug_assert!(
+        min_major.is_finite() && min_major >= 0.0,
+        "split solver minimum length must be finite and non-negative",
+    );
+    if total == 0.0 {
+        return vec![0.0; count];
+    }
+
+    let min_total = min_major * count as f64;
+    if min_major > 0.0 && min_total >= total {
+        return vec![total / count as f64; count];
+    }
+
+    debug_assert!(
+        shares.iter().all(|share| share.is_finite() && *share > 0.0),
+        "split solver shares must be finite and positive",
+    );
+    let share_sum = shares.iter().copied().sum::<f64>();
+    let mut lengths: Vec<_> = shares
+        .iter()
+        .map(|share| total * (*share / share_sum))
+        .collect();
+
+    if min_major <= 0.0 {
+        return lengths;
+    }
+
+    let mut fixed = vec![false; count];
+    loop {
+        let mut changed = false;
+        let mut fixed_total = 0.0;
+        let mut flexible_share_total = 0.0;
+        for (index, length) in lengths.iter_mut().enumerate() {
+            if fixed[index] {
+                fixed_total += *length;
+            } else if *length < min_major {
+                *length = min_major;
+                fixed[index] = true;
+                fixed_total += min_major;
+                changed = true;
+            } else {
+                flexible_share_total += shares[index];
+            }
+        }
+        if !changed {
+            break;
+        }
+        let remaining = (total - fixed_total).max(0.0);
+        if flexible_share_total <= 0.0 {
+            break;
+        }
+        for (index, length) in lengths.iter_mut().enumerate() {
+            if !fixed[index] {
+                *length = remaining * (shares[index] / flexible_share_total);
+            }
+        }
+    }
+
+    lengths
+}
+
+pub(crate) fn repaired_shares(count: usize, shares: &[f64]) -> Vec<f64> {
+    if count == 0 {
+        return Vec::new();
+    }
+    if shares.len() != count {
+        return vec![1.0; count];
+    }
+    let mut repaired = Vec::with_capacity(count);
+    let mut valid = false;
+    for share in shares {
+        if share.is_finite() && *share > 0.0 {
+            valid = true;
+            repaired.push(*share);
+        } else {
+            repaired.push(1.0);
+        }
+    }
+    if valid { repaired } else { vec![1.0; count] }
+}
+
+pub(crate) fn is_valid_split_fraction(value: f64) -> bool {
+    value.is_finite() && value > 0.0 && value < 1.0
+}
+
+pub(crate) fn rect_distance(rect: Rect, point: Point) -> f64 {
+    debug_assert!(rect.is_finite(), "rectangle must be finite");
+    debug_assert!(point.is_finite(), "point must be finite");
+    let dx = if point.x < rect.x0 {
+        rect.x0 - point.x
+    } else if point.x > rect.x1 {
+        point.x - rect.x1
+    } else {
+        0.0
+    };
+    let dy = if point.y < rect.y0 {
+        rect.y0 - point.y
+    } else if point.y > rect.y1 {
+        point.y - rect.y1
+    } else {
+        0.0
+    };
+    dx * dx + dy * dy
+}


### PR DESCRIPTION
Introduce `understory_tiling` as a `no_std`-compatible, renderer-agnostic tiling and docking core. The crate owns semantic tile trees, operation-driven mutation, flattened layout frames, hit testing, and basic drag/resize proposal plumbing while keeping pane contents, rendering, app policy, and window integration outside the core.

The initial implementation covers n-ary splits, tab groups, panes, layout solving, normalization, snapshots, policy validation stubs, and focused pure-data tests.