### PR TITLE
box-decoration: carry resolved border styles

### DIFF
--- a/understory_box_decoration/CHANGELOG.md
+++ b/understory_box_decoration/CHANGELOG.md
@@ -17,9 +17,10 @@ Understory Box Decoration has not had a published release yet.
 - Added the initial `understory_box_decoration` crate with `no_std` resolved
   geometry primitives for CSS-style box decorations.
 - Added `Edges`, `Corners`, `CornerRadii`, `CornerShape`, `Superellipse`,
-  `BoxContour`, and `BoxDecorationGeometry` for resolved physical edge widths,
-  fitted elliptical corner radii, shaped corner contours, derived
-  border/padding/content geometry, and on-demand Kurbo path writing.
+  `BorderStyle`, `BoxContour`, and `BoxDecorationGeometry` for resolved
+  physical edge widths, fitted elliptical corner radii, shaped corner contours,
+  per-side border styles, derived border/padding/content geometry, and
+  on-demand Kurbo path writing.
 - Added `Side`, `BoxArea`, and `BorderSideGeometry` for physical box-area
   selection and central border-side regions.
 - Added CSS specification baseline documentation for CSS Backgrounds and

--- a/understory_box_decoration/README.md
+++ b/understory_box_decoration/README.md
@@ -26,19 +26,20 @@ Renderer-neutral box decoration geometry primitives.
 `understory_box_decoration` owns resolved geometry for painted boxes:
 physical edge widths, box-area contours, corner shapes, side regions, and
 on-demand path emission. It deliberately leaves style cascade, CSS parsing,
-layout, brushes, images, hit policy, and renderer command emission to
-higher-level crates.
+layout, brushes, images, border-style paint lowering, hit policy, and
+renderer command emission to higher-level crates.
 
 If those values come from dependency properties, use
 `understory_presentation_properties` to register canonical surface
 properties and resolve them into `understory_presentation` primitives before
 asking this crate for final geometry.
 
-The first implemented contour family covers CSS-style box contours with
-elliptical radii and shaped corners. It supports round, square, bevel, and
-superellipse-based corner shapes, scales adjacent radii with the CSS
-smallest factor rule when they would overlap a side, and derives padding
-and content contours from concrete border and padding widths.
+The first implemented contour family covers CSS box contours with
+elliptical radii, shaped corners, and per-side border styles. It supports
+round, square, bevel, and superellipse-based corner shapes, scales adjacent
+radii with the CSS smallest factor rule when they would overlap a side, and
+derives padding and content contours from concrete border and padding
+widths.
 
 ## Specification baseline
 
@@ -92,6 +93,8 @@ Constructors harden those inputs for geometry consumers:
 
 - rectangles are normalized to non-negative width and height;
 - negative or non-finite border widths become zero;
+- border widths with [`BorderStyle::None`] or [`BorderStyle::Hidden`]
+  become zero;
 - negative or non-finite padding widths become zero;
 - negative or non-finite radii become zero;
 - border-edge radii are scaled so top, right, bottom, and left side pairs
@@ -99,10 +102,10 @@ Constructors harden those inputs for geometry consumers:
 - padding and content edge radii are derived from the previous contour's
   radii and then scaled to fit their own boxes.
 
-The crate itself is `#![no_std]`. The default `libm` feature forwards to
-Kurbo's libm-backed floating point helpers so ordinary builds remain
-`no_std`-friendly. Enable the `std` feature when an application wants
-Kurbo's standard-library support.
+The crate itself is `#![no_std]`. The default `libm` feature enables local
+libm-backed floating point helpers and forwards to Kurbo's `libm` support so
+ordinary builds remain `no_std`-friendly. Enable the `std` feature when an
+application wants standard-library support.
 
 ## Roadmap
 

--- a/understory_box_decoration/src/contour.rs
+++ b/understory_box_decoration/src/contour.rs
@@ -125,9 +125,8 @@ impl BoxContour {
     /// Returns the straight span on one side between adjacent corner areas.
     ///
     /// This is useful for side-oriented border lowering. It deliberately names
-    /// only the central side span; corner transition regions are separate
-    /// future geometry, because CSS leaves color/style transitions in rounded
-    /// corners implementation-defined.
+    /// only the central side span; corner transition regions and border-style
+    /// paint lowering are separate future geometry.
     #[must_use]
     pub fn side_span(self, side: Side) -> ContourSideSpan {
         let rect = self.rect;

--- a/understory_box_decoration/src/edges.rs
+++ b/understory_box_decoration/src/edges.rs
@@ -8,7 +8,7 @@ use crate::util::finite_non_negative;
 /// The field names follow CSS and Kurbo's usual y-down coordinate naming:
 /// `top` is the smaller y edge and `bottom` is the larger y edge. `Edges<f64>`
 /// is used for border widths, but the type is generic so callers can use the
-/// same shape for edge-associated metadata.
+/// same shape for edge-associated metadata such as per-side border styles.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Edges<T> {
     /// Value associated with the top edge.

--- a/understory_box_decoration/src/geometry.rs
+++ b/understory_box_decoration/src/geometry.rs
@@ -4,7 +4,9 @@
 use kurbo::{BezPath, Point, Rect, Size};
 
 use crate::util::{finite_non_negative, normalize_rect};
-use crate::{BoxArea, BoxContour, CornerRadii, CornerShape, CornerShapes, Edges, Side};
+use crate::{
+    BorderStyle, BoxArea, BoxContour, CornerRadii, CornerShape, CornerShapes, Edges, Side,
+};
 
 /// Fully resolved geometry for a single box decoration.
 ///
@@ -23,6 +25,12 @@ pub struct BoxDecorationGeometry {
     pub content_box: Rect,
     /// Non-negative border widths for each side.
     pub border_widths: Edges<f64>,
+    /// Border style for each side.
+    ///
+    /// The style is stored for renderer lowering. This geometry crate treats
+    /// [`BorderStyle::None`] and [`BorderStyle::Hidden`] as non-painting but
+    /// does not implement the paint algorithms for the visible styles.
+    pub border_styles: Edges<BorderStyle>,
     /// Non-negative padding widths for each side.
     pub padding_widths: Edges<f64>,
     /// Resolved contour for the border edge.
@@ -37,10 +45,15 @@ impl BoxDecorationGeometry {
     /// Resolve decoration geometry from a border box, edge widths, corner
     /// radii, and corner shapes.
     ///
-    /// This is the common entry point for UI presentation layers: layout
-    /// supplies a border box, style supplies physical border/padding widths
-    /// plus corner parameters, and this crate derives the contours a renderer
-    /// needs to paint fills, clips, shadows, and borders.
+    /// This convenience constructor records every border side as
+    /// [`BorderStyle::Solid`]. UI presentation layers with resolved
+    /// `border-style` values should use
+    /// [`BoxDecorationGeometry::from_styled_border_box`] instead.
+    ///
+    /// This is the common entry point for geometry-only callers: layout
+    /// supplies a border box, callers supply resolved physical border/padding
+    /// widths plus corner parameters, and this crate derives the contours a
+    /// renderer needs to paint fills, clips, shadows, and borders.
     pub fn from_border_box(
         border_box: Rect,
         border_widths: Edges<f64>,
@@ -48,8 +61,33 @@ impl BoxDecorationGeometry {
         requested_radii: CornerRadii,
         corner_shapes: CornerShapes,
     ) -> Self {
+        Self::from_styled_border_box(
+            border_box,
+            border_widths,
+            Edges::all(BorderStyle::Solid),
+            padding_widths,
+            requested_radii,
+            corner_shapes,
+        )
+    }
+
+    /// Resolve decoration geometry with per-side border styles.
+    ///
+    /// This is the entry point for callers that have resolved CSS
+    /// `border-style` values. The styles are stored with the geometry and
+    /// copied into [`BorderSideGeometry`]; renderer/backend code remains
+    /// responsible for lowering each style into drawing commands.
+    pub fn from_styled_border_box(
+        border_box: Rect,
+        border_widths: Edges<f64>,
+        border_styles: Edges<BorderStyle>,
+        padding_widths: Edges<f64>,
+        requested_radii: CornerRadii,
+        corner_shapes: CornerShapes,
+    ) -> Self {
         let border_box = normalize_rect(border_box);
-        let border_widths = border_widths.clamped_non_negative();
+        let border_widths =
+            visible_border_widths(border_widths.clamped_non_negative(), border_styles);
         let padding_widths = padding_widths.clamped_non_negative();
         let border_radii = requested_radii.scale_to_fit(border_box);
         let padding_box = inset_rect(border_box, border_widths);
@@ -68,6 +106,7 @@ impl BoxDecorationGeometry {
             padding_box,
             content_box,
             border_widths,
+            border_styles,
             padding_widths,
             border_edge,
             padding_edge,
@@ -83,9 +122,10 @@ impl BoxDecorationGeometry {
         padding_widths: Edges<f64>,
         requested_radii: CornerRadii,
     ) -> Self {
-        Self::from_border_box(
+        Self::from_styled_border_box(
             border_box,
             border_widths,
+            Edges::all(BorderStyle::Solid),
             padding_widths,
             requested_radii,
             CornerShapes::ROUND,
@@ -97,7 +137,16 @@ impl BoxDecorationGeometry {
         self.border_widths.any_positive()
     }
 
-    /// Returns the resolved contour for a CSS-style box area.
+    /// Return true when the border has any positive-width side with a painting
+    /// style.
+    pub const fn has_visible_border(self) -> bool {
+        (self.border_styles.top.paints_border() && self.border_widths.top > 0.0)
+            || (self.border_styles.right.paints_border() && self.border_widths.right > 0.0)
+            || (self.border_styles.bottom.paints_border() && self.border_widths.bottom > 0.0)
+            || (self.border_styles.left.paints_border() && self.border_widths.left > 0.0)
+    }
+
+    /// Returns the resolved contour for a CSS box area.
     #[must_use]
     pub const fn contour(self, area: BoxArea) -> BoxContour {
         match area {
@@ -117,6 +166,10 @@ impl BoxDecorationGeometry {
     ///
     /// The method appends to `out` so hot paths can reuse path storage instead
     /// of allocating a new path for every box.
+    ///
+    /// This method does not apply [`BorderStyle`]. Use
+    /// [`BoxDecorationGeometry::border_side_region`] when a lowerer needs
+    /// side-specific style data.
     pub fn write_border_ring_path(self, out: &mut BezPath) {
         self.border_edge.write_path(out);
         self.padding_edge.write_path(out);
@@ -143,8 +196,7 @@ impl BoxDecorationGeometry {
     ///
     /// The returned region spans between the matching straight side spans of
     /// the border and padding contours. It intentionally does not include
-    /// corner transition regions, because CSS leaves rounded-corner
-    /// color/style transitions implementation-defined.
+    /// corner transition regions or border-style paint lowering.
     #[must_use]
     pub fn border_side_region(self, side: Side) -> BorderSideGeometry {
         let outer = self.border_edge.side_span(side);
@@ -155,9 +207,16 @@ impl BoxDecorationGeometry {
             Side::Bottom => self.border_widths.bottom,
             Side::Left => self.border_widths.left,
         };
+        let style = match side {
+            Side::Top => self.border_styles.top,
+            Side::Right => self.border_styles.right,
+            Side::Bottom => self.border_styles.bottom,
+            Side::Left => self.border_styles.left,
+        };
 
         BorderSideGeometry {
             side,
+            style,
             width,
             outer_start: outer.start,
             outer_end: outer.end,
@@ -177,6 +236,8 @@ impl BoxDecorationGeometry {
 pub struct BorderSideGeometry {
     /// Physical side represented by this region.
     pub side: Side,
+    /// Resolved style for this border side.
+    pub style: BorderStyle,
     /// Visible border width for this side.
     pub width: f64,
     /// First point on the outer contour side span.
@@ -195,7 +256,7 @@ impl BorderSideGeometry {
     /// Returns true when this side has no positive border width.
     #[must_use]
     pub fn is_empty(self) -> bool {
-        !self.width.is_finite() || self.width <= 0.0
+        !self.style.paints_border() || !self.width.is_finite() || self.width <= 0.0
     }
 
     /// Appends this side region as a closed quadrilateral.
@@ -286,6 +347,19 @@ fn is_concave_corner(shape: CornerShape) -> bool {
         CornerShape::Superellipse(superellipse) => superellipse.parameter() < 0.0,
         CornerShape::Round | CornerShape::Square | CornerShape::Bevel => false,
     }
+}
+
+const fn visible_border_widths(widths: Edges<f64>, styles: Edges<BorderStyle>) -> Edges<f64> {
+    Edges::new(
+        visible_border_width(widths.top, styles.top),
+        visible_border_width(widths.right, styles.right),
+        visible_border_width(widths.bottom, styles.bottom),
+        visible_border_width(widths.left, styles.left),
+    )
+}
+
+const fn visible_border_width(width: f64, style: BorderStyle) -> f64 {
+    if style.paints_border() { width } else { 0.0 }
 }
 
 #[cfg(test)]
@@ -485,6 +559,7 @@ mod tests {
         let top = geometry.border_side_region(Side::Top);
 
         assert_eq!(top.width, 4.0);
+        assert_eq!(top.style, BorderStyle::Solid);
         assert!(!top.is_empty());
         assert_eq!(top.outer_start, Point::new(12.0, 0.0));
         assert_eq!(top.outer_end, Point::new(88.0, 0.0));
@@ -529,6 +604,7 @@ mod tests {
     fn side_regions_with_non_finite_widths_are_empty() {
         let side = BorderSideGeometry {
             side: Side::Top,
+            style: BorderStyle::Solid,
             width: f64::NAN,
             outer_start: Point::ZERO,
             outer_end: Point::ZERO,
@@ -538,6 +614,34 @@ mod tests {
         };
 
         assert!(side.is_empty());
+    }
+
+    #[test]
+    fn styled_geometry_preserves_per_side_styles() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 100.0, 50.0),
+            Edges::all(4.0),
+            Edges::new(
+                BorderStyle::Solid,
+                BorderStyle::Dashed,
+                BorderStyle::None,
+                BorderStyle::Hidden,
+            ),
+            Edges::ZERO,
+            CornerRadii::ZERO,
+            CornerShapes::ROUND,
+        );
+
+        assert!(geometry.has_border_width());
+        assert!(geometry.has_visible_border());
+        assert_eq!(geometry.border_widths, Edges::new(4.0, 4.0, 0.0, 0.0));
+        assert_eq!(geometry.border_styles.right, BorderStyle::Dashed);
+        assert_eq!(
+            geometry.border_side_region(Side::Right).style,
+            BorderStyle::Dashed
+        );
+        assert!(geometry.border_side_region(Side::Bottom).is_empty());
+        assert!(geometry.border_side_region(Side::Left).is_empty());
     }
 
     fn path_is_finite(path: &BezPath) -> bool {

--- a/understory_box_decoration/src/lib.rs
+++ b/understory_box_decoration/src/lib.rs
@@ -9,19 +9,20 @@
 //! `understory_box_decoration` owns resolved geometry for painted boxes:
 //! physical edge widths, box-area contours, corner shapes, side regions, and
 //! on-demand path emission. It deliberately leaves style cascade, CSS parsing,
-//! layout, brushes, images, hit policy, and renderer command emission to
-//! higher-level crates.
+//! layout, brushes, images, border-style paint lowering, hit policy, and
+//! renderer command emission to higher-level crates.
 //!
 //! If those values come from dependency properties, use
 //! `understory_presentation_properties` to register canonical surface
 //! properties and resolve them into `understory_presentation` primitives before
 //! asking this crate for final geometry.
 //!
-//! The first implemented contour family covers CSS-style box contours with
-//! elliptical radii and shaped corners. It supports round, square, bevel, and
-//! superellipse-based corner shapes, scales adjacent radii with the CSS
-//! smallest factor rule when they would overlap a side, and derives padding
-//! and content contours from concrete border and padding widths.
+//! The first implemented contour family covers CSS box contours with
+//! elliptical radii, shaped corners, and per-side border styles. It supports
+//! round, square, bevel, and superellipse-based corner shapes, scales adjacent
+//! radii with the CSS smallest factor rule when they would overlap a side, and
+//! derives padding and content contours from concrete border and padding
+//! widths.
 //!
 //! ## Specification baseline
 //!
@@ -75,6 +76,8 @@
 //!
 //! - rectangles are normalized to non-negative width and height;
 //! - negative or non-finite border widths become zero;
+//! - border widths with [`BorderStyle::None`] or [`BorderStyle::Hidden`]
+//!   become zero;
 //! - negative or non-finite padding widths become zero;
 //! - negative or non-finite radii become zero;
 //! - border-edge radii are scaled so top, right, bottom, and left side pairs
@@ -109,6 +112,7 @@ mod path;
 mod radii;
 mod shape;
 mod side;
+mod style;
 mod util;
 
 pub use contour::{BoxContour, ContourSideSpan, ResolvedCorner};
@@ -117,3 +121,4 @@ pub use geometry::{BorderSideGeometry, BoxDecorationGeometry, inset_rect};
 pub use radii::{CornerRadii, Corners};
 pub use shape::{CornerShape, CornerShapes, Superellipse};
 pub use side::{BoxArea, Side};
+pub use style::BorderStyle;

--- a/understory_box_decoration/src/side.rs
+++ b/understory_box_decoration/src/side.rs
@@ -23,7 +23,7 @@ impl Side {
     pub const ALL: [Self; 4] = [Self::Top, Self::Right, Self::Bottom, Self::Left];
 }
 
-/// A CSS-style box area that can be clipped or painted.
+/// A CSS box area that can be clipped or painted.
 ///
 /// The geometry kernel resolves these areas only after it has concrete border
 /// and padding widths. Margin geometry is intentionally absent because margin

--- a/understory_box_decoration/src/style.rs
+++ b/understory_box_decoration/src/style.rs
@@ -1,0 +1,46 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Resolved CSS `border-style` value for one physical border side.
+///
+/// Stored in [`BoxDecorationGeometry`](crate::BoxDecorationGeometry) and
+/// [`BorderSideGeometry`](crate::BorderSideGeometry) so renderers can choose
+/// side-specific border lowering. This crate records the value and exposes the
+/// associated geometry; it does not implement dashed, dotted, double, groove,
+/// ridge, inset, or outset painting.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum BorderStyle {
+    /// No border is drawn for this side.
+    #[default]
+    None,
+    /// No border is drawn for this side.
+    ///
+    /// CSS uses `hidden` differently from `none` during table border conflict
+    /// resolution. This geometry crate preserves the distinction but treats it
+    /// as non-painting.
+    Hidden,
+    /// A dotted border.
+    Dotted,
+    /// A dashed border.
+    Dashed,
+    /// A single solid border.
+    Solid,
+    /// Two parallel solid border lines.
+    Double,
+    /// A carved groove border.
+    Groove,
+    /// A raised ridge border.
+    Ridge,
+    /// An inset border.
+    Inset,
+    /// An outset border.
+    Outset,
+}
+
+impl BorderStyle {
+    /// Returns true when this style should produce visible border pixels.
+    #[must_use]
+    pub const fn paints_border(self) -> bool {
+        !matches!(self, Self::None | Self::Hidden)
+    }
+}

--- a/understory_presentation/src/lib.rs
+++ b/understory_presentation/src/lib.rs
@@ -148,6 +148,6 @@ pub use primitive::{
 };
 pub use store::{PresentationNode, PresentationStore};
 pub use understory_box_decoration::{
-    BorderSideGeometry, BoxArea, BoxContour, BoxDecorationGeometry, ContourSideSpan, CornerRadii,
-    CornerShape, CornerShapes, Corners, Edges, ResolvedCorner, Side, Superellipse,
+    BorderSideGeometry, BorderStyle, BoxArea, BoxContour, BoxDecorationGeometry, ContourSideSpan,
+    CornerRadii, CornerShape, CornerShapes, Corners, Edges, ResolvedCorner, Side, Superellipse,
 };

--- a/understory_presentation/src/primitive/surface.rs
+++ b/understory_presentation/src/primitive/surface.rs
@@ -3,7 +3,7 @@
 
 use smallvec::SmallVec;
 
-use crate::{BoxDecorationGeometry, Brush, Color, CornerRadii, CornerShapes, Edges};
+use crate::{BorderStyle, BoxDecorationGeometry, Brush, Color, CornerRadii, CornerShapes, Edges};
 use peniko::kurbo::{Affine, Rect};
 
 /// Resolved box-decoration drawing intent.
@@ -64,9 +64,10 @@ impl SurfacePrimitive {
     /// values in sync with any layout padding used for the same box.
     #[must_use]
     pub fn decoration_geometry(&self, border_box: Rect) -> BoxDecorationGeometry {
-        BoxDecorationGeometry::from_border_box(
+        BoxDecorationGeometry::from_styled_border_box(
             border_box,
             self.border.visible_widths(),
+            self.border.styles(),
             self.padding_widths,
             self.corner_radii,
             self.corner_shapes,
@@ -145,9 +146,9 @@ impl Border {
 
     /// Return the widths of visible border sides.
     ///
-    /// A side with no brush is treated as width zero, matching
-    /// [`BorderSide::is_empty`]. The result is suitable for
-    /// [`BoxDecorationGeometry::from_border_box`].
+    /// A side with no brush, no painting style, or no positive width is treated
+    /// as width zero, matching [`BorderSide::is_empty`]. The result is suitable
+    /// for [`BoxDecorationGeometry::from_styled_border_box`].
     #[must_use]
     pub fn visible_widths(&self) -> Edges<f64> {
         Edges::new(
@@ -155,6 +156,17 @@ impl Border {
             self.right.visible_width(),
             self.bottom.visible_width(),
             self.left.visible_width(),
+        )
+    }
+
+    /// Return the style of each border side.
+    #[must_use]
+    pub const fn styles(&self) -> Edges<BorderStyle> {
+        Edges::new(
+            self.top.style,
+            self.right.style,
+            self.bottom.style,
+            self.left.style,
         )
     }
 
@@ -190,6 +202,9 @@ pub struct BorderSide {
 
     /// Border width in logical pixels.
     pub width: f64,
+
+    /// CSS border style for this side.
+    pub style: BorderStyle,
 }
 
 impl BorderSide {
@@ -200,6 +215,7 @@ impl BorderSide {
             brush: Some(brush.into()),
             brush_transform: None,
             width,
+            style: BorderStyle::Solid,
         }
     }
 
@@ -210,12 +226,23 @@ impl BorderSide {
         self
     }
 
+    /// Sets the border style for this side.
+    #[must_use]
+    pub const fn with_style(mut self, style: BorderStyle) -> Self {
+        self.style = style;
+        self
+    }
+
     /// Returns true when the side should not draw.
     ///
-    /// A side is visible only when it has a brush and a positive finite width.
+    /// A side is visible only when it has a painting style, a brush, and a
+    /// positive finite width.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.brush.is_none() || !self.width.is_finite() || self.width <= 0.0
+        !self.style.paints_border()
+            || self.brush.is_none()
+            || !self.width.is_finite()
+            || self.width <= 0.0
     }
 
     /// Return the side width when the side has a brush and positive finite
@@ -335,6 +362,7 @@ mod tests {
                     brush: None,
                     brush_transform: None,
                     width: 6.0,
+                    style: BorderStyle::Solid,
                 },
                 bottom: BorderSide::new(Color::BLACK, -4.0),
                 left: BorderSide::new(Color::BLACK, 4.0),
@@ -348,6 +376,7 @@ mod tests {
         let geometry = surface.decoration_geometry(Rect::new(0.0, 0.0, 100.0, 50.0));
 
         assert_eq!(geometry.border_widths, Edges::new(2.0, 0.0, 0.0, 4.0));
+        assert_eq!(geometry.border_styles, Edges::all(BorderStyle::Solid));
         assert_eq!(geometry.padding_widths, Edges::new(1.0, 2.0, 3.0, 4.0));
         assert_eq!(geometry.padding_box, Rect::new(4.0, 2.0, 100.0, 50.0));
         assert_eq!(geometry.content_box, Rect::new(8.0, 3.0, 98.0, 47.0));
@@ -381,5 +410,20 @@ mod tests {
         let side = BorderSide::new(Color::BLACK, 2.0).with_brush_transform(transform);
 
         assert_eq!(side.brush_transform, Some(transform));
+    }
+
+    #[test]
+    fn border_style_controls_side_visibility() {
+        let solid = BorderSide::new(Color::BLACK, 2.0);
+        let none = BorderSide::new(Color::BLACK, 2.0).with_style(BorderStyle::None);
+        let hidden = BorderSide::new(Color::BLACK, 2.0).with_style(BorderStyle::Hidden);
+        let dashed = BorderSide::new(Color::BLACK, 2.0).with_style(BorderStyle::Dashed);
+
+        assert!(!solid.is_empty());
+        assert!(none.is_empty());
+        assert!(hidden.is_empty());
+        assert!(!dashed.is_empty());
+        assert_eq!(none.visible_width(), 0.0);
+        assert_eq!(dashed.visible_width(), 2.0);
     }
 }

--- a/understory_presentation_properties/CHANGELOG.md
+++ b/understory_presentation_properties/CHANGELOG.md
@@ -17,8 +17,8 @@ Understory Presentation Properties has not had a published release yet.
 - Added the initial `understory_presentation_properties` crate with `no_std`
   dependency-property integration for resolved presentation surfaces.
 - Added `SurfaceProperties` for registering canonical surface background,
-  border brush, border width, padding width, corner radius, and corner shape
-  properties.
+  border brush, border style, border width, padding width, corner radius, and
+  corner shape properties.
 - Added `SurfacePropertyValues` and `SurfaceProperties::resolve_surface` for
   resolving property/style/theme values into `understory_presentation`
   `SurfacePrimitive` values.

--- a/understory_presentation_properties/README.md
+++ b/understory_presentation_properties/README.md
@@ -40,7 +40,8 @@ Surface decoration spans several concerns:
 - property systems need typed longhands with defaults and invalidation
   metadata;
 - style systems need independently-overridable values such as one border
-  edge, one padding side, one corner radius, or one corner shape;
+  side's brush/style/width, one padding side, one corner radius, or one
+  corner shape;
 - presentation needs a resolved [`understory_presentation::SurfacePrimitive`]
   that can be cached in a paint tree;
 - renderers need geometry helpers such as
@@ -78,7 +79,7 @@ If default features are disabled, callers must enable either `libm` or
 
 ```rust
 use invalidation::Channel;
-use understory_presentation::{Brush, Color, CornerShape, Edges};
+use understory_presentation::{BorderStyle, Brush, Color, CornerShape, Edges};
 use understory_presentation_properties::{
     CornerRadius, StyleMatch, SurfacePropertyChannels, SurfaceProperties,
 };
@@ -111,6 +112,7 @@ impl DependencyObject<u32> for Element {
 let element = Element { store: PropertyStore::new(1) };
 let style = StyleBuilder::new()
     .set(surface.background, Some(Brush::from(Color::WHITE)))
+    .set(surface.border_styles.top, BorderStyle::Solid)
     .set(surface.border_widths.top, 2.0)
     .set(surface.border_brushes.top, Some(Brush::from(Color::BLACK)))
     .set(surface.padding_widths.top, 6.0)
@@ -130,6 +132,7 @@ let primitive = surface.resolve_surface(
 );
 
 assert_eq!(primitive.backgrounds.len(), 1);
+assert_eq!(primitive.border.styles().top, BorderStyle::Solid);
 assert_eq!(primitive.border.visible_widths(), Edges::new(2.0, 0.0, 0.0, 0.0));
 assert_eq!(primitive.padding_widths.top, 6.0);
 assert_eq!(primitive.corner_radii.top_left.width, 6.0);
@@ -138,9 +141,9 @@ assert_eq!(primitive.corner_shapes.top_left, CornerShape::squircle());
 
 ## Roadmap
 
-The first slice covers resolved surface background, per-side border brushes
-and widths, physical padding widths, per-corner elliptical radii, and
-per-corner shapes. Future work should add length-percentage values,
+The first slice covers resolved surface background, per-side border brushes,
+styles, and widths, physical padding widths, per-corner elliptical radii,
+and per-corner shapes. Future work should add length-percentage values,
 `border-shape`, richer background layers, shadow properties, and
 shape-related properties once a dedicated shape value crate exists. Those
 additions should keep the same pattern: properties are longhand, resolution

--- a/understory_presentation_properties/src/lib.rs
+++ b/understory_presentation_properties/src/lib.rs
@@ -23,7 +23,8 @@
 //! - property systems need typed longhands with defaults and invalidation
 //!   metadata;
 //! - style systems need independently-overridable values such as one border
-//!   edge, one padding side, one corner radius, or one corner shape;
+//!   side's brush/style/width, one padding side, one corner radius, or one
+//!   corner shape;
 //! - presentation needs a resolved [`understory_presentation::SurfacePrimitive`]
 //!   that can be cached in a paint tree;
 //! - renderers need geometry helpers such as
@@ -61,7 +62,7 @@
 //!
 //! ```rust
 //! use invalidation::Channel;
-//! use understory_presentation::{Brush, Color, CornerShape, Edges};
+//! use understory_presentation::{BorderStyle, Brush, Color, CornerShape, Edges};
 //! use understory_presentation_properties::{
 //!     CornerRadius, StyleMatch, SurfacePropertyChannels, SurfaceProperties,
 //! };
@@ -94,6 +95,7 @@
 //! let element = Element { store: PropertyStore::new(1) };
 //! let style = StyleBuilder::new()
 //!     .set(surface.background, Some(Brush::from(Color::WHITE)))
+//!     .set(surface.border_styles.top, BorderStyle::Solid)
 //!     .set(surface.border_widths.top, 2.0)
 //!     .set(surface.border_brushes.top, Some(Brush::from(Color::BLACK)))
 //!     .set(surface.padding_widths.top, 6.0)
@@ -113,6 +115,7 @@
 //! );
 //!
 //! assert_eq!(primitive.backgrounds.len(), 1);
+//! assert_eq!(primitive.border.styles().top, BorderStyle::Solid);
 //! assert_eq!(primitive.border.visible_widths(), Edges::new(2.0, 0.0, 0.0, 0.0));
 //! assert_eq!(primitive.padding_widths.top, 6.0);
 //! assert_eq!(primitive.corner_radii.top_left.width, 6.0);
@@ -121,9 +124,9 @@
 //!
 //! ## Roadmap
 //!
-//! The first slice covers resolved surface background, per-side border brushes
-//! and widths, physical padding widths, per-corner elliptical radii, and
-//! per-corner shapes. Future work should add length-percentage values,
+//! The first slice covers resolved surface background, per-side border brushes,
+//! styles, and widths, physical padding widths, per-corner elliptical radii,
+//! and per-corner shapes. Future work should add length-percentage values,
 //! `border-shape`, richer background layers, shadow properties, and
 //! shape-related properties once a dedicated shape value crate exists. Those
 //! additions should keep the same pattern: properties are longhand, resolution

--- a/understory_presentation_properties/src/surface.rs
+++ b/understory_presentation_properties/src/surface.rs
@@ -4,8 +4,8 @@
 use invalidation::ChannelSet;
 use kurbo::Size;
 use understory_presentation::{
-    BackgroundLayer, Border, BorderSide, Brush, CornerRadii, CornerShape, CornerShapes, Corners,
-    Edges, SurfacePrimitive,
+    BackgroundLayer, Border, BorderSide, BorderStyle, Brush, CornerRadii, CornerShape,
+    CornerShapes, Corners, Edges, SurfacePrimitive,
 };
 use understory_property::{DependencyObject, Property, PropertyMetadataBuilder, PropertyRegistry};
 use understory_style::{MatchState, ResolveCx, ResolveParentLookup, StyleCascade};
@@ -59,10 +59,10 @@ impl<'a> From<(&'a StyleCascade, MatchState)> for StyleMatch<'a> {
 
 /// Invalidation channels used by the canonical surface properties.
 ///
-/// Brush-only properties affect paint. Shape properties such as border widths,
-/// padding widths, corner radii, and corner shapes affect both `geometry` and
-/// `paint`, because they can change clipping, hit regions, border paths, and
-/// the pixels that are drawn.
+/// Brush-only properties affect paint. Shape properties such as border styles,
+/// border widths, padding widths, corner radii, and corner shapes affect both
+/// `geometry` and `paint`, because they can change clipping, hit regions,
+/// border paths, and the pixels that are drawn.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct SurfacePropertyChannels {
     /// Channels affected when the surface shape or decoration geometry changes.
@@ -167,6 +167,8 @@ pub struct SurfaceProperties {
     pub background: Property<Option<Brush>>,
     /// Per-side border brush properties.
     pub border_brushes: Edges<Property<Option<Brush>>>,
+    /// Per-side border style properties.
+    pub border_styles: Edges<Property<BorderStyle>>,
     /// Per-side border width properties.
     pub border_widths: Edges<Property<f64>>,
     /// Physical padding width properties.
@@ -201,6 +203,12 @@ impl SurfaceProperties {
                 register_optional_brush(registry, "Surface.BorderRightBrush", paint),
                 register_optional_brush(registry, "Surface.BorderBottomBrush", paint),
                 register_optional_brush(registry, "Surface.BorderLeftBrush", paint),
+            ),
+            border_styles: Edges::new(
+                register_border_style(registry, "Surface.BorderTopStyle", geometry_and_paint),
+                register_border_style(registry, "Surface.BorderRightStyle", geometry_and_paint),
+                register_border_style(registry, "Surface.BorderBottomStyle", geometry_and_paint),
+                register_border_style(registry, "Surface.BorderLeftStyle", geometry_and_paint),
             ),
             border_widths: Edges::new(
                 register_length(registry, "Surface.BorderTopWidth", geometry_and_paint),
@@ -275,6 +283,12 @@ impl SurfaceProperties {
                 bottom: cx.get_value(object, self.border_brushes.bottom, style),
                 left: cx.get_value(object, self.border_brushes.left, style),
             },
+            border_styles: Edges::new(
+                cx.get_value(object, self.border_styles.top, style),
+                cx.get_value(object, self.border_styles.right, style),
+                cx.get_value(object, self.border_styles.bottom, style),
+                cx.get_value(object, self.border_styles.left, style),
+            ),
             border_widths: Edges::new(
                 finite_non_negative(cx.get_value(object, self.border_widths.top, style)),
                 finite_non_negative(cx.get_value(object, self.border_widths.right, style)),
@@ -336,6 +350,8 @@ pub struct SurfacePropertyValues {
     pub background: Option<Brush>,
     /// Resolved per-side border brushes.
     pub border_brushes: Edges<Option<Brush>>,
+    /// Resolved per-side border styles.
+    pub border_styles: Edges<BorderStyle>,
     /// Resolved per-side border widths in logical pixels.
     pub border_widths: Edges<f64>,
     /// Resolved physical padding widths in logical pixels.
@@ -356,21 +372,25 @@ impl SurfacePropertyValues {
                     brush: self.border_brushes.top,
                     brush_transform: None,
                     width: self.border_widths.top,
+                    style: self.border_styles.top,
                 },
                 right: BorderSide {
                     brush: self.border_brushes.right,
                     brush_transform: None,
                     width: self.border_widths.right,
+                    style: self.border_styles.right,
                 },
                 bottom: BorderSide {
                     brush: self.border_brushes.bottom,
                     brush_transform: None,
                     width: self.border_widths.bottom,
+                    style: self.border_styles.bottom,
                 },
                 left: BorderSide {
                     brush: self.border_brushes.left,
                     brush_transform: None,
                     width: self.border_widths.left,
+                    style: self.border_styles.left,
                 },
             },
             padding_widths: self.padding_widths,
@@ -410,6 +430,19 @@ fn register_length(
         PropertyMetadataBuilder::new(0.0_f64)
             .affects_channels(channels)
             .coerce(finite_non_negative)
+            .build(),
+    )
+}
+
+fn register_border_style(
+    registry: &mut PropertyRegistry,
+    name: &'static str,
+    channels: ChannelSet,
+) -> Property<BorderStyle> {
+    registry.register(
+        name,
+        PropertyMetadataBuilder::new(BorderStyle::None)
+            .affects_channels(channels)
             .build(),
     )
 }
@@ -519,6 +552,10 @@ mod tests {
         assert!(!brush_channels.contains(GEOMETRY));
         assert!(brush_channels.contains(PAINT));
 
+        let style_channels = registry.affects_channels(surface.border_styles.top.id());
+        assert!(style_channels.contains(GEOMETRY));
+        assert!(style_channels.contains(PAINT));
+
         let width_channels = registry.affects_channels(surface.border_widths.top.id());
         assert!(width_channels.contains(GEOMETRY));
         assert!(width_channels.contains(PAINT));
@@ -547,6 +584,7 @@ mod tests {
         let primitive = surface.resolve_surface(&cx, &element, None);
 
         assert!(primitive.is_empty());
+        assert_eq!(primitive.border.styles(), Edges::all(BorderStyle::None));
         assert_eq!(primitive.border.visible_widths(), Edges::ZERO);
         assert_eq!(primitive.padding_widths, Edges::ZERO);
         assert_eq!(primitive.corner_radii, CornerRadii::ZERO);
@@ -567,6 +605,8 @@ mod tests {
             .set(surface.border_widths.right, 4.0)
             .set(surface.border_widths.bottom, -8.0)
             .set(surface.border_widths.left, f64::NAN)
+            .set(surface.border_styles.top, BorderStyle::Solid)
+            .set(surface.border_styles.right, BorderStyle::Dashed)
             .set(surface.border_brushes.top, Some(Brush::from(Color::BLACK)))
             .set(
                 surface.border_brushes.right,
@@ -596,6 +636,15 @@ mod tests {
 
         assert_eq!(primitive.backgrounds.len(), 1);
         assert_eq!(primitive.backgrounds[0].brush, Brush::from(Color::WHITE));
+        assert_eq!(
+            primitive.border.styles(),
+            Edges::new(
+                BorderStyle::Solid,
+                BorderStyle::Dashed,
+                BorderStyle::None,
+                BorderStyle::None,
+            )
+        );
         assert_eq!(
             primitive.border.visible_widths(),
             Edges::new(2.0, 4.0, 0.0, 0.0)


### PR DESCRIPTION
Add `BorderStyle` to `understory_box_decoration` and store per-side `Edges<BorderStyle>` on `BoxDecorationGeometry` and `BorderSideGeometry`.

Thread the style through `understory_presentation::BorderSide` and `understory_presentation_properties::SurfaceProperties`, including `Surface.Border*Style` longhands. `None` and `Hidden` zero used border widths; renderer-specific lowering remains outside these renderer-neutral crates.