### PR TITLE
Add box decoration border paint plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The focus is on clean separation of concerns, pluggable performance trade‑offs
 
 - `understory_box_decoration`
   - Renderer-neutral box decoration geometry for physical edges, box-area contours, and shaped corners.
-  - Supports elliptical per-corner radii, CSS smallest-factor radius fitting, round/square/bevel/superellipse corner shapes, derived border/padding/content contours, central border-side regions, and on-demand Kurbo path writing.
+  - Supports elliptical per-corner radii, CSS smallest-factor radius fitting, round/square/bevel/superellipse corner shapes, derived border/padding/content contours, renderer-neutral border paint plans and fragments, and on-demand Kurbo path writing.
   - Does not own style cascade, CSS parsing, brushes, images, layout, hit policy, or renderer command emission.
 
 - `understory_box_tree`

--- a/understory_box_decoration/CHANGELOG.md
+++ b/understory_box_decoration/CHANGELOG.md
@@ -21,8 +21,9 @@ Understory Box Decoration has not had a published release yet.
   physical edge widths, fitted elliptical corner radii, shaped corner contours,
   per-side border styles, derived border/padding/content geometry, and
   on-demand Kurbo path writing.
-- Added `Side`, `BoxArea`, and `BorderSideGeometry` for physical box-area
-  selection and central border-side regions.
+- Added `Side`, `BoxArea`, `BorderPaintGeometry`, `BorderSidePaintGeometry`,
+  and border fill/stroke fragments for physical box-area selection and
+  renderer-neutral border paint lowering.
 - Added CSS specification baseline documentation for CSS Backgrounds and
   Borders Level 3 contours, plus initial CSS Borders and Box Decorations Level
   4 `corner-shape` / superellipse coverage and a roadmap for broader Level 4

--- a/understory_box_decoration/README.md
+++ b/understory_box_decoration/README.md
@@ -24,10 +24,10 @@ Full documentation at https://github.com/orium/cargo-rdme -->
 Renderer-neutral box decoration geometry primitives.
 
 `understory_box_decoration` owns resolved geometry for painted boxes:
-physical edge widths, box-area contours, corner shapes, side regions, and
-on-demand path emission. It deliberately leaves style cascade, CSS parsing,
-layout, brushes, images, border-style paint lowering, hit policy, and
-renderer command emission to higher-level crates.
+physical edge widths, box-area contours, corner shapes, renderer-neutral
+border paint plans and fragments, and on-demand path emission. It
+deliberately leaves style cascade, CSS parsing, layout, brushes, images,
+hit policy, and renderer command emission to higher-level crates.
 
 If those values come from dependency properties, use
 `understory_presentation_properties` to register canonical surface
@@ -35,11 +35,11 @@ properties and resolve them into `understory_presentation` primitives before
 asking this crate for final geometry.
 
 The first implemented contour family covers CSS box contours with
-elliptical radii, shaped corners, and per-side border styles. It supports
-round, square, bevel, and superellipse-based corner shapes, scales adjacent
-radii with the CSS smallest factor rule when they would overlap a side, and
-derives padding and content contours from concrete border and padding
-widths.
+elliptical radii, shaped corners, per-side border styles, and
+renderer-neutral border paint command planning. It supports round, square,
+bevel, and superellipse-based corner shapes, scales adjacent radii with the
+CSS smallest factor rule when they would overlap a side, and derives
+padding and content contours from concrete border and padding widths.
 
 ## Specification baseline
 
@@ -84,6 +84,11 @@ let mut border_path = BezPath::new();
 geometry.write_border_ring_path(&mut border_path);
 assert!(!clip_path.is_empty());
 assert!(!border_path.is_empty());
+
+let plan = geometry.border_paint().per_side_plan();
+let mut command_count = 0;
+plan.for_each(|_| command_count += 1);
+assert!(command_count > 0);
 ```
 
 ## Boundary and invariants
@@ -111,10 +116,10 @@ application wants standard-library support.
 
 Near-term work should add resolved length-percentage radii so CSS parsing
 layers can defer percentage resolution until the border box is known. After
-that, the natural coverage expansion is corner transition regions,
-`box-shadow` spread geometry, and richer background painting areas. Level 4
-`border-shape` should probably consume a separate CSS-shapes value crate
-rather than making this crate own every shape syntax.
+that, the natural coverage expansion is `box-shadow` spread geometry,
+richer background painting areas, and path-based `border-shape` reference
+geometry. Level 4 `border-shape` should probably consume a separate
+CSS-shapes value crate rather than making this crate own every shape syntax.
 
 [CSS Backgrounds and Borders Module Level 3]: https://www.w3.org/TR/css-backgrounds-3/#border-radius
 [CSS Borders and Box Decorations Module Level 4]: https://drafts.csswg.org/css-borders-4/

--- a/understory_box_decoration/src/geometry.rs
+++ b/understory_box_decoration/src/geometry.rs
@@ -3,9 +3,11 @@
 
 use kurbo::{BezPath, Point, Rect, Size};
 
+use crate::path::write_contour_side_band_path;
 use crate::util::{finite_non_negative, normalize_rect};
 use crate::{
-    BorderStyle, BoxArea, BoxContour, CornerRadii, CornerShape, CornerShapes, Edges, Side,
+    BorderStyle, BoxArea, BoxContour, CornerRadii, CornerShape, CornerShapes, Edges,
+    ResolvedCorner, Side,
 };
 
 /// Fully resolved geometry for a single box decoration.
@@ -27,9 +29,9 @@ pub struct BoxDecorationGeometry {
     pub border_widths: Edges<f64>,
     /// Border style for each side.
     ///
-    /// The style is stored for renderer lowering. This geometry crate treats
-    /// [`BorderStyle::None`] and [`BorderStyle::Hidden`] as non-painting but
-    /// does not implement the paint algorithms for the visible styles.
+    /// The style is stored for renderer-neutral paint planning. This geometry
+    /// crate treats [`BorderStyle::None`] and [`BorderStyle::Hidden`] as
+    /// non-painting.
     pub border_styles: Edges<BorderStyle>,
     /// Non-negative padding widths for each side.
     pub padding_widths: Edges<f64>,
@@ -75,8 +77,8 @@ impl BoxDecorationGeometry {
     ///
     /// This is the entry point for callers that have resolved CSS
     /// `border-style` values. The styles are stored with the geometry and
-    /// copied into [`BorderSideGeometry`]; renderer/backend code remains
-    /// responsible for lowering each style into drawing commands.
+    /// copied into [`crate::BorderSidePaintGeometry`]; renderer/backend code
+    /// remains responsible for lowering each style into drawing commands.
     pub fn from_styled_border_box(
         border_box: Rect,
         border_widths: Edges<f64>,
@@ -168,8 +170,8 @@ impl BoxDecorationGeometry {
     /// of allocating a new path for every box.
     ///
     /// This method does not apply [`BorderStyle`]. Use
-    /// [`BoxDecorationGeometry::border_side_region`] when a lowerer needs
-    /// side-specific style data.
+    /// [`BoxDecorationGeometry::border_paint`] when a lowerer needs resolved
+    /// border paint fragments.
     pub fn write_border_ring_path(self, out: &mut BezPath) {
         self.border_edge.write_path(out);
         self.padding_edge.write_path(out);
@@ -192,83 +194,105 @@ impl BoxDecorationGeometry {
         path
     }
 
-    /// Returns the central side region for one physical border side.
+    /// Returns an intermediate contour through the border ring.
     ///
-    /// The returned region spans between the matching straight side spans of
-    /// the border and padding contours. It intentionally does not include
-    /// corner transition regions or border-style paint lowering.
+    /// `0.0` is the outer border edge and `1.0` is the inner padding edge.
+    /// Values outside that interval are clamped; non-finite values are treated
+    /// as `0.0`.
+    ///
+    /// This is intended for renderers that lower border styles such as
+    /// `double`, `groove`, `ridge`, dashed, or dotted by painting bands or
+    /// strokes inside the already-resolved border ring. It preserves resolved
+    /// corner shapes while interpolating the box and corner radii between the
+    /// border and padding contours.
     #[must_use]
-    pub fn border_side_region(self, side: Side) -> BorderSideGeometry {
-        let outer = self.border_edge.side_span(side);
-        let inner = self.padding_edge.side_span(side);
-        let width = match side {
-            Side::Top => self.border_widths.top,
-            Side::Right => self.border_widths.right,
-            Side::Bottom => self.border_widths.bottom,
-            Side::Left => self.border_widths.left,
-        };
-        let style = match side {
-            Side::Top => self.border_styles.top,
-            Side::Right => self.border_styles.right,
-            Side::Bottom => self.border_styles.bottom,
-            Side::Left => self.border_styles.left,
-        };
-
-        BorderSideGeometry {
-            side,
-            style,
-            width,
-            outer_start: outer.start,
-            outer_end: outer.end,
-            inner_start: inner.start,
-            inner_end: inner.end,
-            bounds: bounds_for_points([outer.start, outer.end, inner.start, inner.end]),
-        }
-    }
-}
-
-/// Central geometry for one physical border side.
-///
-/// This describes the side band between the straight spans of the outer border
-/// contour and inner padding contour. It is suitable for simple side-aware
-/// lowerers and leaves corner transition regions for a richer future API.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct BorderSideGeometry {
-    /// Physical side represented by this region.
-    pub side: Side,
-    /// Resolved style for this border side.
-    pub style: BorderStyle,
-    /// Visible border width for this side.
-    pub width: f64,
-    /// First point on the outer contour side span.
-    pub outer_start: Point,
-    /// Last point on the outer contour side span.
-    pub outer_end: Point,
-    /// First point on the inner contour side span.
-    pub inner_start: Point,
-    /// Last point on the inner contour side span.
-    pub inner_end: Point,
-    /// Axis-aligned bounds of the four side-region points.
-    pub bounds: Rect,
-}
-
-impl BorderSideGeometry {
-    /// Returns true when this side has no positive border width.
-    #[must_use]
-    pub fn is_empty(self) -> bool {
-        !self.style.paints_border() || !self.width.is_finite() || self.width <= 0.0
+    pub(crate) fn border_contour_at(self, t: f64) -> BoxContour {
+        interpolate_contour(self.border_edge, self.padding_edge, unit_interval(t))
     }
 
-    /// Appends this side region as a closed quadrilateral.
+    /// Appends a compound even-odd path for a band inside the border ring.
     ///
-    /// The path is appended to `out`; callers that want only this region
-    /// should clear or create their [`BezPath`] before calling.
-    pub fn write_path(self, out: &mut BezPath) {
-        out.move_to(self.outer_start);
-        out.line_to(self.outer_end);
-        out.line_to(self.inner_end);
-        out.line_to(self.inner_start);
+    /// `outer_t` and `inner_t` use the same coordinate as
+    /// [`Self::border_contour_at`], where `0.0` is the outer border edge and
+    /// `1.0` is the inner padding edge. The values are clamped into `[0, 1]`,
+    /// and `inner_t` is clamped to be no smaller than `outer_t`.
+    ///
+    /// This writes two closed subpaths with matching winding. Renderers
+    /// **must** fill the result with an even-odd rule to paint only the band.
+    pub(crate) fn write_border_band_path(self, outer_t: f64, inner_t: f64, out: &mut BezPath) {
+        let outer_t = unit_interval(outer_t);
+        let inner_t = unit_interval(inner_t).max(outer_t);
+        self.border_contour_at(outer_t).write_path(out);
+        self.border_contour_at(inner_t).write_path(out);
+    }
+
+    /// Builds a compound even-odd path for a band inside the border ring.
+    ///
+    /// Prefer [`Self::write_border_band_path`] in hot paths, and remember that
+    /// the returned path must be filled with an even-odd rule to remain hollow.
+    #[must_use]
+    pub(crate) fn to_border_band_path(self, outer_t: f64, inner_t: f64) -> BezPath {
+        let mut path = BezPath::new();
+        self.write_border_band_path(outer_t, inner_t, &mut path);
+        path
+    }
+
+    /// Appends the ownership clip polygon for one physical border side.
+    ///
+    /// Stroked styles use this to constrain side-owned open contours. Filled
+    /// styles use [`Self::write_border_side_band_path`] so shaped corners are
+    /// partitioned on their real contours instead of an axis-aligned polygon.
+    pub(crate) fn write_border_side_clip_path(self, side: Side, out: &mut BezPath) {
+        let points = border_side_clip_points(self.border_box, self.padding_box, side);
+        out.move_to(points[0]);
+        out.line_to(points[1]);
+        out.line_to(points[2]);
+        out.line_to(points[3]);
         out.close_path();
+    }
+
+    /// Builds the ownership clip polygon for one physical border side.
+    #[must_use]
+    pub(crate) fn to_border_side_clip_path(self, side: Side) -> BezPath {
+        let mut path = BezPath::new();
+        self.write_border_side_clip_path(side, &mut path);
+        path
+    }
+
+    /// Appends a closed path for one physical side's share of a border band.
+    ///
+    /// The side path follows the outer contour between adjacent corner miter
+    /// boundaries, then returns along the inner contour in reverse. That makes
+    /// filled side fragments meet adjacent sides on shaped corner contours
+    /// instead of relying on rectangular clips.
+    pub(crate) fn write_border_side_band_path(
+        self,
+        side: Side,
+        outer_t: f64,
+        inner_t: f64,
+        out: &mut BezPath,
+    ) {
+        let outer_t = unit_interval(outer_t);
+        let inner_t = unit_interval(inner_t).max(outer_t);
+        write_contour_side_band_path(
+            self.border_contour_at(outer_t),
+            self.border_contour_at(inner_t),
+            side,
+            out,
+        );
+    }
+
+    /// Builds one physical side's share of a border band.
+    #[must_use]
+    pub(crate) fn to_border_side_band_path(
+        self,
+        side: Side,
+        outer_t: f64,
+        inner_t: f64,
+    ) -> BezPath {
+        let mut path = BezPath::new();
+        self.write_border_side_band_path(side, outer_t, inner_t, &mut path);
+        path
     }
 }
 
@@ -301,22 +325,6 @@ fn inset_axis(min: f64, max: f64, before: f64, after: f64) -> (f64, f64) {
     }
 }
 
-fn bounds_for_points(points: [Point; 4]) -> Rect {
-    let mut x0 = points[0].x;
-    let mut y0 = points[0].y;
-    let mut x1 = points[0].x;
-    let mut y1 = points[0].y;
-
-    for point in points.into_iter().skip(1) {
-        x0 = x0.min(point.x);
-        y0 = y0.min(point.y);
-        x1 = x1.max(point.x);
-        y1 = y1.max(point.y);
-    }
-
-    Rect::new(x0, y0, x1, y1)
-}
-
 fn inset_radii_for_shapes(
     radii: CornerRadii,
     edges: Edges<f64>,
@@ -339,6 +347,84 @@ fn inset_corner_radius(original: Size, convex: Size, shape: CornerShape) -> Size
         original
     } else {
         convex
+    }
+}
+
+fn interpolate_contour(outer: BoxContour, inner: BoxContour, t: f64) -> BoxContour {
+    BoxContour::new(
+        Rect::new(
+            lerp_f64(outer.rect.x0, inner.rect.x0, t),
+            lerp_f64(outer.rect.y0, inner.rect.y0, t),
+            lerp_f64(outer.rect.x1, inner.rect.x1, t),
+            lerp_f64(outer.rect.y1, inner.rect.y1, t),
+        ),
+        crate::Corners::new(
+            interpolate_corner(outer.corners.top_left, inner.corners.top_left, t),
+            interpolate_corner(outer.corners.top_right, inner.corners.top_right, t),
+            interpolate_corner(outer.corners.bottom_right, inner.corners.bottom_right, t),
+            interpolate_corner(outer.corners.bottom_left, inner.corners.bottom_left, t),
+        ),
+    )
+}
+
+fn interpolate_corner(outer: ResolvedCorner, inner: ResolvedCorner, t: f64) -> ResolvedCorner {
+    ResolvedCorner::new(
+        Size::new(
+            lerp_f64(outer.radii.width, inner.radii.width, t),
+            lerp_f64(outer.radii.height, inner.radii.height, t),
+        ),
+        outer.shape,
+    )
+}
+
+fn border_side_clip_points(border_box: Rect, padding_box: Rect, side: Side) -> [Point; 4] {
+    let outer_top_left = Point::new(border_box.x0, border_box.y0);
+    let outer_top_right = Point::new(border_box.x1, border_box.y0);
+    let outer_bottom_right = Point::new(border_box.x1, border_box.y1);
+    let outer_bottom_left = Point::new(border_box.x0, border_box.y1);
+
+    let inner_top_left = Point::new(padding_box.x0, padding_box.y0);
+    let inner_top_right = Point::new(padding_box.x1, padding_box.y0);
+    let inner_bottom_right = Point::new(padding_box.x1, padding_box.y1);
+    let inner_bottom_left = Point::new(padding_box.x0, padding_box.y1);
+
+    match side {
+        Side::Top => [
+            outer_top_left,
+            outer_top_right,
+            inner_top_right,
+            inner_top_left,
+        ],
+        Side::Right => [
+            outer_top_right,
+            outer_bottom_right,
+            inner_bottom_right,
+            inner_top_right,
+        ],
+        Side::Bottom => [
+            outer_bottom_right,
+            outer_bottom_left,
+            inner_bottom_left,
+            inner_bottom_right,
+        ],
+        Side::Left => [
+            outer_bottom_left,
+            outer_top_left,
+            inner_top_left,
+            inner_bottom_left,
+        ],
+    }
+}
+
+fn lerp_f64(start: f64, end: f64, t: f64) -> f64 {
+    start + (end - start) * t
+}
+
+fn unit_interval(value: f64) -> f64 {
+    if value.is_finite() {
+        value.clamp(0.0, 1.0)
+    } else {
+        0.0
     }
 }
 
@@ -365,8 +451,8 @@ const fn visible_border_width(width: f64, style: BorderStyle) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Superellipse;
-    use kurbo::{PathEl, Size};
+    use crate::{Side, Superellipse};
+    use kurbo::{PathEl, Point, Size};
 
     #[test]
     fn geometry_derives_border_padding_and_content_contours() {
@@ -415,6 +501,67 @@ mod tests {
             .filter(|el| matches!(el, PathEl::ClosePath))
             .count();
         assert_eq!(close_count, 2);
+    }
+
+    #[test]
+    fn border_contour_at_interpolates_between_border_and_padding_edges() {
+        let geometry = BoxDecorationGeometry::from_round_border_box(
+            Rect::new(0.0, 0.0, 100.0, 50.0),
+            Edges::new(6.0, 12.0, 18.0, 24.0),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+        );
+
+        let middle = geometry.border_contour_at(0.5);
+
+        assert_eq!(middle.rect, Rect::new(12.0, 3.0, 94.0, 41.0));
+        assert_eq!(middle.corners.top_left.radii, Size::new(10.0, 17.0));
+        assert_eq!(middle.corners.bottom_right.radii, Size::new(14.0, 11.0));
+        assert_eq!(middle.corners.top_left.shape, CornerShape::Round);
+        assert_eq!(geometry.border_contour_at(-1.0), geometry.border_edge);
+        assert_eq!(geometry.border_contour_at(f64::NAN), geometry.border_edge);
+        assert_eq!(geometry.border_contour_at(2.0), geometry.padding_edge);
+    }
+
+    #[test]
+    fn border_band_path_appends_shaped_outer_and_inner_subpaths() {
+        let geometry = BoxDecorationGeometry::from_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(12.0),
+            Edges::ZERO,
+            CornerRadii::all(Size::new(24.0, 16.0)),
+            CornerShapes::new(
+                CornerShape::Square,
+                CornerShape::Bevel,
+                CornerShape::squircle(),
+                CornerShape::scoop(),
+            ),
+        );
+
+        let path = geometry.to_border_band_path(0.0, 1.0 / 3.0);
+        let close_count = path
+            .iter()
+            .filter(|el| matches!(el, PathEl::ClosePath))
+            .count();
+
+        assert_eq!(close_count, 2);
+        assert_eq!(
+            geometry
+                .border_contour_at(1.0 / 3.0)
+                .corners
+                .bottom_right
+                .shape,
+            CornerShape::squircle()
+        );
+        assert_eq!(
+            geometry
+                .border_contour_at(1.0 / 3.0)
+                .corners
+                .bottom_left
+                .shape,
+            CornerShape::scoop()
+        );
+        assert!(path.is_finite());
     }
 
     #[test]
@@ -475,9 +622,9 @@ mod tests {
         assert_eq!(geometry.border_edge.radii(), CornerRadii::ZERO);
         assert_eq!(geometry.padding_edge.radii(), CornerRadii::ZERO);
         assert_eq!(geometry.content_edge.radii(), CornerRadii::ZERO);
-        assert!(path_is_finite(&geometry.border_edge.to_path()));
-        assert!(path_is_finite(&geometry.padding_edge.to_path()));
-        assert!(path_is_finite(&geometry.to_border_ring_path()));
+        assert!(geometry.border_edge.to_path().is_finite());
+        assert!(geometry.padding_edge.to_path().is_finite());
+        assert!(geometry.to_border_ring_path().is_finite());
     }
 
     #[test]
@@ -496,7 +643,7 @@ mod tests {
             geometry.contour(BoxArea::Content).rect,
             geometry.content_box
         );
-        assert!(path_is_finite(&content_clip));
+        assert!(content_clip.is_finite());
     }
 
     #[test]
@@ -529,7 +676,7 @@ mod tests {
             geometry.border_edge.corners.bottom_left.shape,
             CornerShape::scoop()
         );
-        assert!(path_is_finite(&path));
+        assert!(path.is_finite());
     }
 
     #[test]
@@ -544,11 +691,11 @@ mod tests {
 
         let path = geometry.border_edge.to_path();
         assert!(path.iter().any(|el| matches!(el, PathEl::CurveTo(..))));
-        assert!(path_is_finite(&path));
+        assert!(path.is_finite());
     }
 
     #[test]
-    fn side_regions_follow_central_contour_spans() {
+    fn side_paint_geometry_reports_resolved_style_and_width() {
         let geometry = BoxDecorationGeometry::from_round_border_box(
             Rect::new(0.0, 0.0, 100.0, 50.0),
             Edges::new(4.0, 6.0, 8.0, 10.0),
@@ -556,19 +703,16 @@ mod tests {
             CornerRadii::uniform(12.0),
         );
 
-        let top = geometry.border_side_region(Side::Top);
+        let top = geometry.border_paint().side(Side::Top);
 
-        assert_eq!(top.width, 4.0);
-        assert_eq!(top.style, BorderStyle::Solid);
+        assert_eq!(top.width(), 4.0);
+        assert_eq!(top.style(), BorderStyle::Solid);
         assert!(!top.is_empty());
-        assert_eq!(top.outer_start, Point::new(12.0, 0.0));
-        assert_eq!(top.outer_end, Point::new(88.0, 0.0));
-        assert_eq!(top.inner_start, Point::new(12.0, 4.0));
-        assert_eq!(top.inner_end, Point::new(88.0, 4.0));
-
-        let mut path = BezPath::new();
-        top.write_path(&mut path);
-        assert!(path_is_finite(&path));
+        assert_eq!(
+            geometry.border_edge.side_span(Side::Top).start,
+            Point::new(12.0, 0.0)
+        );
+        assert!(top.ring().path.is_finite());
     }
 
     #[test]
@@ -601,19 +745,15 @@ mod tests {
     }
 
     #[test]
-    fn side_regions_with_non_finite_widths_are_empty() {
-        let side = BorderSideGeometry {
-            side: Side::Top,
-            style: BorderStyle::Solid,
-            width: f64::NAN,
-            outer_start: Point::ZERO,
-            outer_end: Point::ZERO,
-            inner_start: Point::ZERO,
-            inner_end: Point::ZERO,
-            bounds: Rect::ZERO,
-        };
+    fn side_paint_geometry_with_non_finite_width_is_empty() {
+        let geometry = BoxDecorationGeometry::from_round_border_box(
+            Rect::new(0.0, 0.0, 100.0, 50.0),
+            Edges::new(f64::NAN, 4.0, 4.0, 4.0),
+            Edges::ZERO,
+            CornerRadii::ZERO,
+        );
 
-        assert!(side.is_empty());
+        assert!(geometry.border_paint().side(Side::Top).is_empty());
     }
 
     #[test]
@@ -637,33 +777,10 @@ mod tests {
         assert_eq!(geometry.border_widths, Edges::new(4.0, 4.0, 0.0, 0.0));
         assert_eq!(geometry.border_styles.right, BorderStyle::Dashed);
         assert_eq!(
-            geometry.border_side_region(Side::Right).style,
+            geometry.border_paint().side(Side::Right).style(),
             BorderStyle::Dashed
         );
-        assert!(geometry.border_side_region(Side::Bottom).is_empty());
-        assert!(geometry.border_side_region(Side::Left).is_empty());
-    }
-
-    fn path_is_finite(path: &BezPath) -> bool {
-        path.iter().all(|element| match element {
-            PathEl::MoveTo(point) | PathEl::LineTo(point) => {
-                point.x.is_finite() && point.y.is_finite()
-            }
-            PathEl::QuadTo(control, point) => {
-                control.x.is_finite()
-                    && control.y.is_finite()
-                    && point.x.is_finite()
-                    && point.y.is_finite()
-            }
-            PathEl::CurveTo(control_0, control_1, point) => {
-                control_0.x.is_finite()
-                    && control_0.y.is_finite()
-                    && control_1.x.is_finite()
-                    && control_1.y.is_finite()
-                    && point.x.is_finite()
-                    && point.y.is_finite()
-            }
-            PathEl::ClosePath => true,
-        })
+        assert!(geometry.border_paint().side(Side::Bottom).is_empty());
+        assert!(geometry.border_paint().side(Side::Left).is_empty());
     }
 }

--- a/understory_box_decoration/src/lib.rs
+++ b/understory_box_decoration/src/lib.rs
@@ -7,10 +7,10 @@
 //! Renderer-neutral box decoration geometry primitives.
 //!
 //! `understory_box_decoration` owns resolved geometry for painted boxes:
-//! physical edge widths, box-area contours, corner shapes, side regions, and
-//! on-demand path emission. It deliberately leaves style cascade, CSS parsing,
-//! layout, brushes, images, border-style paint lowering, hit policy, and
-//! renderer command emission to higher-level crates.
+//! physical edge widths, box-area contours, corner shapes, renderer-neutral
+//! border paint plans and fragments, and on-demand path emission. It
+//! deliberately leaves style cascade, CSS parsing, layout, brushes, images,
+//! hit policy, and renderer command emission to higher-level crates.
 //!
 //! If those values come from dependency properties, use
 //! `understory_presentation_properties` to register canonical surface
@@ -18,11 +18,11 @@
 //! asking this crate for final geometry.
 //!
 //! The first implemented contour family covers CSS box contours with
-//! elliptical radii, shaped corners, and per-side border styles. It supports
-//! round, square, bevel, and superellipse-based corner shapes, scales adjacent
-//! radii with the CSS smallest factor rule when they would overlap a side, and
-//! derives padding and content contours from concrete border and padding
-//! widths.
+//! elliptical radii, shaped corners, per-side border styles, and
+//! renderer-neutral border paint command planning. It supports round, square,
+//! bevel, and superellipse-based corner shapes, scales adjacent radii with the
+//! CSS smallest factor rule when they would overlap a side, and derives
+//! padding and content contours from concrete border and padding widths.
 //!
 //! ## Specification baseline
 //!
@@ -67,6 +67,11 @@
 //! geometry.write_border_ring_path(&mut border_path);
 //! assert!(!clip_path.is_empty());
 //! assert!(!border_path.is_empty());
+//!
+//! let plan = geometry.border_paint().per_side_plan();
+//! let mut command_count = 0;
+//! plan.for_each(|_| command_count += 1);
+//! assert!(command_count > 0);
 //! ```
 //!
 //! ## Boundary and invariants
@@ -94,10 +99,10 @@
 //!
 //! Near-term work should add resolved length-percentage radii so CSS parsing
 //! layers can defer percentage resolution until the border box is known. After
-//! that, the natural coverage expansion is corner transition regions,
-//! `box-shadow` spread geometry, and richer background painting areas. Level 4
-//! `border-shape` should probably consume a separate CSS-shapes value crate
-//! rather than making this crate own every shape syntax.
+//! that, the natural coverage expansion is `box-shadow` spread geometry,
+//! richer background painting areas, and path-based `border-shape` reference
+//! geometry. Level 4 `border-shape` should probably consume a separate
+//! CSS-shapes value crate rather than making this crate own every shape syntax.
 //!
 //! [CSS Backgrounds and Borders Module Level 3]: https://www.w3.org/TR/css-backgrounds-3/#border-radius
 //! [CSS Borders and Box Decorations Module Level 4]: https://drafts.csswg.org/css-borders-4/
@@ -108,6 +113,7 @@ mod contour;
 mod edges;
 mod geometry;
 mod math;
+mod paint;
 mod path;
 mod radii;
 mod shape;
@@ -117,7 +123,13 @@ mod util;
 
 pub use contour::{BoxContour, ContourSideSpan, ResolvedCorner};
 pub use edges::Edges;
-pub use geometry::{BorderSideGeometry, BoxDecorationGeometry, inset_rect};
+pub use geometry::{BoxDecorationGeometry, inset_rect};
+pub use paint::{
+    BorderBand, BorderClip, BorderClipStack, BorderDashPattern, BorderFillFragment, BorderFillRule,
+    BorderPaintCommand, BorderPaintFill, BorderPaintGeometry, BorderPaintMode, BorderPaintPlan,
+    BorderPaintRole, BorderPaintSource, BorderPaintStroke, BorderReliefShade,
+    BorderSidePaintGeometry, BorderStrokeCap, BorderStrokeFragment, BorderStrokeSpec,
+};
 pub use radii::{CornerRadii, Corners};
 pub use shape::{CornerShape, CornerShapes, Superellipse};
 pub use side::{BoxArea, Side};

--- a/understory_box_decoration/src/math.rs
+++ b/understory_box_decoration/src/math.rs
@@ -12,6 +12,11 @@ mod backend {
     pub(crate) fn powf(value: f64, exponent: f64) -> f64 {
         value.powf(exponent)
     }
+
+    #[inline]
+    pub(crate) fn floor(value: f64) -> f64 {
+        value.floor()
+    }
 }
 
 #[cfg(all(not(feature = "std"), feature = "libm"))]
@@ -20,6 +25,11 @@ mod backend {
     pub(crate) fn powf(value: f64, exponent: f64) -> f64 {
         libm::pow(value, exponent)
     }
+
+    #[inline]
+    pub(crate) fn floor(value: f64) -> f64 {
+        libm::floor(value)
+    }
 }
 
-pub(crate) use backend::powf;
+pub(crate) use backend::{floor, powf};

--- a/understory_box_decoration/src/paint.rs
+++ b/understory_box_decoration/src/paint.rs
@@ -1,0 +1,1737 @@
+// Copyright 2026 the Understory Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use kurbo::{BezPath, ParamCurveArclen};
+
+use crate::math::floor;
+use crate::path::write_contour_side_segment_path;
+use crate::{BorderStyle, BoxDecorationGeometry, Side};
+
+/// Fill rule required to interpret a border fragment path.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum BorderFillRule {
+    /// The nonzero winding rule.
+    #[default]
+    NonZero,
+    /// The even-odd winding rule.
+    EvenOdd,
+}
+
+/// A path used as a clip while painting a border fragment.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BorderClip {
+    /// Clip path.
+    pub path: BezPath,
+    /// Fill rule for the clip path.
+    pub fill_rule: BorderFillRule,
+}
+
+impl BorderClip {
+    /// Creates a clip path with an explicit fill rule.
+    #[must_use]
+    pub fn new(path: BezPath, fill_rule: BorderFillRule) -> Self {
+        Self { path, fill_rule }
+    }
+}
+
+/// Clip stack needed to paint a resolved border fragment.
+///
+/// Renderers should push `side` first and `ring` second when both are present.
+/// This order makes side ownership the broad partition and the ring the final
+/// border-area constraint.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BorderClipStack {
+    /// Optional side-ownership clip for a physical side.
+    pub side: Option<BorderClip>,
+    /// Optional border-ring clip.
+    pub ring: Option<BorderClip>,
+}
+
+impl BorderClipStack {
+    /// Returns an empty clip stack.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            side: None,
+            ring: None,
+        }
+    }
+
+    /// Returns a stack with one side-ownership clip.
+    #[must_use]
+    pub fn side(path: BezPath) -> Self {
+        Self {
+            side: Some(BorderClip::new(path, BorderFillRule::NonZero)),
+            ring: None,
+        }
+    }
+
+    /// Returns a stack with one border-ring clip.
+    #[must_use]
+    pub fn ring(path: BezPath) -> Self {
+        Self {
+            side: None,
+            ring: Some(BorderClip::new(path, BorderFillRule::EvenOdd)),
+        }
+    }
+
+    /// Returns a stack with a side-ownership clip and a border-ring clip.
+    #[must_use]
+    pub fn side_and_ring(side: BezPath, ring: BezPath) -> Self {
+        Self {
+            side: Some(BorderClip::new(side, BorderFillRule::NonZero)),
+            ring: Some(BorderClip::new(ring, BorderFillRule::EvenOdd)),
+        }
+    }
+}
+
+/// A fillable border fragment.
+///
+/// The fragment may be a full border ring, a band inside that ring, or a
+/// side-owned view of either. Renderers own brush selection and draw ordering;
+/// this type only describes resolved geometry and clipping.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BorderFillFragment {
+    /// Fill path.
+    pub path: BezPath,
+    /// Fill rule for `path`.
+    pub fill_rule: BorderFillRule,
+    /// Clips to push before filling `path`.
+    pub clips: BorderClipStack,
+}
+
+impl BorderFillFragment {
+    /// Creates a fill fragment.
+    #[must_use]
+    pub fn new(path: BezPath, fill_rule: BorderFillRule, clips: BorderClipStack) -> Self {
+        Self {
+            path,
+            fill_rule,
+            clips,
+        }
+    }
+}
+
+/// A strokeable border fragment.
+///
+/// This path is open for side fragments. Renderers own brush selection and
+/// draw ordering; [`BorderPaintStroke`] carries the resolved stroke parameters.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BorderStrokeFragment {
+    /// Stroke path.
+    pub path: BezPath,
+    /// Clips to push before stroking `path`.
+    pub clips: BorderClipStack,
+}
+
+impl BorderStrokeFragment {
+    /// Creates a stroke fragment.
+    #[must_use]
+    pub fn new(path: BezPath, clips: BorderClipStack) -> Self {
+        Self { path, clips }
+    }
+}
+
+/// Line cap to use when stroking a border fragment.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum BorderStrokeCap {
+    /// Stroke endpoints stop exactly at the path endpoint.
+    #[default]
+    Butt,
+    /// Stroke endpoints are rounded.
+    Round,
+    /// Stroke endpoints extend by half the stroke width.
+    Square,
+}
+
+/// Resolved two-entry dash pattern for a border stroke.
+///
+/// The first length is the painted segment and the second length is the gap.
+/// Dotted borders use a tiny painted segment with a round cap so backends that
+/// discard zero-length dashes still render visible dots.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BorderDashPattern {
+    /// Dash phase offset.
+    pub offset: f64,
+    /// Painted and unpainted segment lengths.
+    pub lengths: [f64; 2],
+}
+
+impl BorderDashPattern {
+    /// Creates a resolved dash pattern.
+    #[must_use]
+    pub const fn new(offset: f64, lengths: [f64; 2]) -> Self {
+        Self { offset, lengths }
+    }
+}
+
+/// Resolved stroke parameters for a border stroke command.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct BorderStrokeSpec {
+    /// Stroke width in local coordinate units.
+    pub width: f64,
+    /// Stroke endpoint cap.
+    pub cap: BorderStrokeCap,
+    /// Optional dash pattern.
+    pub dash: Option<BorderDashPattern>,
+}
+
+impl BorderStrokeSpec {
+    /// Creates solid stroke parameters with the default butt cap.
+    #[must_use]
+    pub const fn solid(width: f64) -> Self {
+        Self {
+            width,
+            cap: BorderStrokeCap::Butt,
+            dash: None,
+        }
+    }
+
+    /// Creates stroke parameters with an explicit cap and dash pattern.
+    #[must_use]
+    pub const fn with_dash(width: f64, cap: BorderStrokeCap, dash: BorderDashPattern) -> Self {
+        Self {
+            width,
+            cap,
+            dash: Some(dash),
+        }
+    }
+}
+
+/// A normalized band inside the border ring.
+///
+/// `outer` and `inner` are in border-ring interpolation space: `0.0` is the
+/// outer border edge and `1.0` is the inner padding edge. Fragment builders
+/// clamp values into this interval and clamp `inner` to be no smaller than
+/// `outer`; non-finite values are treated as `0.0`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BorderBand {
+    /// Outer contour interpolation value.
+    pub outer: f64,
+    /// Inner contour interpolation value.
+    pub inner: f64,
+}
+
+impl BorderBand {
+    /// The full border ring.
+    pub const FULL: Self = Self::new(0.0, 1.0);
+
+    /// Creates a band from outer and inner interpolation values.
+    #[must_use]
+    pub const fn new(outer: f64, inner: f64) -> Self {
+        Self { outer, inner }
+    }
+}
+
+/// Paint sharing mode for a border paint plan.
+///
+/// This is supplied by the renderer or presentation layer because
+/// `understory_box_decoration` does not own brushes. A caller should use
+/// [`BorderPaintMode::Shared`] only when the visible sides can share one paint
+/// source. Otherwise, use [`BorderPaintMode::PerSide`] so each physical side
+/// gets side-owned fragments.
+///
+/// The mode is an optimization hint, not a command-shape guarantee: a shared
+/// plan falls back to per-side lowering whenever the sides do not share one
+/// whole-contour lowering (mixed styles, relief styles, or stroked styles
+/// with mixed widths), and those commands carry
+/// [`BorderPaintSource::Side`] sources. Renderers must therefore map both
+/// source variants regardless of the requested mode.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum BorderPaintMode {
+    /// Visible sides share one paint source where geometry permits it.
+    Shared,
+    /// Visible sides are painted independently.
+    PerSide,
+}
+
+/// Source slot for a border paint command.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum BorderPaintSource {
+    /// Use the caller's shared border paint.
+    Shared,
+    /// Use the paint for one physical side.
+    Side(Side),
+}
+
+/// Semantic role for a fill command.
+///
+/// Renderers use this to choose a brush while leaving geometry and draw order
+/// in the plan. Plans paint each border region exactly once, so a role selects
+/// the brush for its fragment; roles are never composited on top of each
+/// other.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum BorderPaintRole {
+    /// Paint with the command source's border brush unchanged.
+    Base,
+    /// Paint with a brush derived from the command source's border brush.
+    ///
+    /// Relief regions replace [`BorderPaintRole::Base`] for `inset`, `outset`,
+    /// `groove`, and `ridge`; they are not translucent overlays above a base
+    /// coat. Renderers should lighten or darken the source's border brush in
+    /// the manner of CSS relief border colors.
+    Relief(BorderReliefShade),
+}
+
+/// Relative shade used by relief-style border fills.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum BorderReliefShade {
+    /// Lighter relief shade.
+    Highlight,
+    /// Darker relief shade.
+    Shadow,
+}
+
+/// One fill command in a resolved border paint plan.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BorderPaintFill {
+    /// Paint source to use for this command.
+    pub source: BorderPaintSource,
+    /// CSS-style border style that produced this command.
+    pub style: BorderStyle,
+    /// Semantic paint role.
+    pub role: BorderPaintRole,
+    /// Fill geometry and clip stack.
+    pub fragment: BorderFillFragment,
+}
+
+impl BorderPaintFill {
+    /// Creates a fill command.
+    #[must_use]
+    pub fn new(
+        source: BorderPaintSource,
+        style: BorderStyle,
+        role: BorderPaintRole,
+        fragment: BorderFillFragment,
+    ) -> Self {
+        Self {
+            source,
+            style,
+            role,
+            fragment,
+        }
+    }
+}
+
+/// One stroke command in a resolved border paint plan.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BorderPaintStroke {
+    /// Paint source to use for this command.
+    pub source: BorderPaintSource,
+    /// CSS-style border style that produced this command.
+    pub style: BorderStyle,
+    /// Stroke parameters for this command.
+    pub stroke: BorderStrokeSpec,
+    /// Stroke geometry and clip stack.
+    pub fragment: BorderStrokeFragment,
+}
+
+impl BorderPaintStroke {
+    /// Creates a stroke command.
+    #[must_use]
+    pub fn new(
+        source: BorderPaintSource,
+        style: BorderStyle,
+        stroke: BorderStrokeSpec,
+        fragment: BorderStrokeFragment,
+    ) -> Self {
+        Self {
+            source,
+            style,
+            stroke,
+            fragment,
+        }
+    }
+}
+
+/// One command in a resolved border paint plan.
+#[derive(Clone, Debug, PartialEq)]
+pub enum BorderPaintCommand {
+    /// Fill a border fragment.
+    Fill(BorderPaintFill),
+    /// Stroke a border fragment.
+    Stroke(BorderPaintStroke),
+}
+
+/// Resolved border paint plan.
+///
+/// A plan converts resolved border geometry and per-side styles into a small
+/// sequence of renderer-neutral fill and stroke commands. It deliberately does
+/// not carry brushes; renderers map [`BorderPaintSource`] and
+/// [`BorderPaintRole`] to their own paint commands.
+///
+/// The plan itself is a cheap copyable description; the paths, arc lengths,
+/// and dash fitting are computed on every [`BorderPaintPlan::for_each`] call.
+/// Retained renderers should emit once and store the commands, re-running the
+/// plan only when the resolved geometry or styles change.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BorderPaintPlan {
+    geometry: BoxDecorationGeometry,
+    mode: BorderPaintMode,
+}
+
+impl BorderPaintPlan {
+    /// Creates a border paint plan from resolved geometry and a sharing mode.
+    #[must_use]
+    pub const fn new(geometry: BoxDecorationGeometry, mode: BorderPaintMode) -> Self {
+        Self { geometry, mode }
+    }
+
+    /// Returns the underlying resolved box decoration geometry.
+    #[must_use]
+    pub const fn geometry(self) -> BoxDecorationGeometry {
+        self.geometry
+    }
+
+    /// Returns the paint sharing mode.
+    #[must_use]
+    pub const fn mode(self) -> BorderPaintMode {
+        self.mode
+    }
+
+    /// Calls `paint` for each command in draw order.
+    pub fn for_each(self, mut paint: impl FnMut(BorderPaintCommand)) {
+        match self.mode {
+            BorderPaintMode::Shared => self.for_each_shared(&mut paint),
+            BorderPaintMode::PerSide => self.for_each_per_side(&mut paint),
+        }
+    }
+
+    fn for_each_shared(self, paint: &mut impl FnMut(BorderPaintCommand)) {
+        let Some(style) = uniform_visible_style(self.geometry) else {
+            self.for_each_per_side(paint);
+            return;
+        };
+
+        let source = BorderPaintSource::Shared;
+        let paint_geometry = self.geometry.border_paint();
+        match style {
+            BorderStyle::None | BorderStyle::Hidden => {}
+            BorderStyle::Solid => {
+                // A ring fill is exact for every corner shape and per-side
+                // width mix, unlike a centerline stroke, whose constant width
+                // only matches the band between the border and padding
+                // contours for circular corners.
+                paint(BorderPaintCommand::Fill(BorderPaintFill::new(
+                    source,
+                    style,
+                    BorderPaintRole::Base,
+                    paint_geometry.ring(),
+                )));
+            }
+            BorderStyle::Dotted | BorderStyle::Dashed => {
+                let Some(width) = shared_visible_width(self.geometry) else {
+                    self.for_each_per_side(paint);
+                    return;
+                };
+                let fragment = paint_geometry.stroke_contour(0.5);
+                paint(BorderPaintCommand::Stroke(BorderPaintStroke::new(
+                    source,
+                    style,
+                    stroke_spec_for_closed_contour(style, width, &fragment),
+                    fragment,
+                )));
+            }
+            BorderStyle::Double => {
+                paint(BorderPaintCommand::Fill(BorderPaintFill::new(
+                    source,
+                    style,
+                    BorderPaintRole::Base,
+                    paint_geometry.band(BorderBand::new(0.0, 1.0 / 3.0)),
+                )));
+                paint(BorderPaintCommand::Fill(BorderPaintFill::new(
+                    source,
+                    style,
+                    BorderPaintRole::Base,
+                    paint_geometry.band(BorderBand::new(2.0 / 3.0, 1.0)),
+                )));
+            }
+            BorderStyle::Groove | BorderStyle::Ridge | BorderStyle::Inset | BorderStyle::Outset => {
+                self.for_each_per_side(paint);
+            }
+        }
+    }
+
+    fn for_each_per_side(self, paint: &mut impl FnMut(BorderPaintCommand)) {
+        let paint_geometry = self.geometry.border_paint();
+        for side in ordered_visible_sides(self.geometry) {
+            let side_geometry = paint_geometry.side(side);
+            if side_geometry.is_empty() {
+                continue;
+            }
+            emit_side_commands(side_geometry, paint);
+        }
+    }
+}
+
+/// Resolved paint geometry for a box border.
+///
+/// This is the canonical border-lowering entry point. It groups the ring,
+/// band, side, and stroke-fragment operations so renderers do not need to
+/// reconstruct side ownership from raw box geometry.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BorderPaintGeometry {
+    geometry: BoxDecorationGeometry,
+}
+
+impl BorderPaintGeometry {
+    /// Creates border paint geometry from resolved box decoration geometry.
+    #[must_use]
+    pub const fn new(geometry: BoxDecorationGeometry) -> Self {
+        Self { geometry }
+    }
+
+    /// Returns the underlying resolved box decoration geometry.
+    #[must_use]
+    pub const fn geometry(self) -> BoxDecorationGeometry {
+        self.geometry
+    }
+
+    /// Returns a border paint plan for the requested paint sharing mode.
+    #[must_use]
+    pub const fn plan(self, mode: BorderPaintMode) -> BorderPaintPlan {
+        BorderPaintPlan::new(self.geometry, mode)
+    }
+
+    /// Returns a paint plan for a shared visible border paint.
+    #[must_use]
+    pub const fn shared_plan(self) -> BorderPaintPlan {
+        self.plan(BorderPaintMode::Shared)
+    }
+
+    /// Returns a paint plan for independent per-side border paint.
+    #[must_use]
+    pub const fn per_side_plan(self) -> BorderPaintPlan {
+        self.plan(BorderPaintMode::PerSide)
+    }
+
+    /// Returns the full border ring as an even-odd fill fragment.
+    #[must_use]
+    pub fn ring(self) -> BorderFillFragment {
+        BorderFillFragment::new(
+            self.geometry.to_border_ring_path(),
+            BorderFillRule::EvenOdd,
+            BorderClipStack::empty(),
+        )
+    }
+
+    /// Returns a band inside the border ring as an even-odd fill fragment.
+    #[must_use]
+    pub fn band(self, band: BorderBand) -> BorderFillFragment {
+        BorderFillFragment::new(
+            self.geometry.to_border_band_path(band.outer, band.inner),
+            BorderFillRule::EvenOdd,
+            BorderClipStack::empty(),
+        )
+    }
+
+    /// Returns a whole-contour centerline stroke fragment through the border
+    /// ring.
+    ///
+    /// Shared-paint `dashed` and `dotted` borders use this so dash phase
+    /// progresses continuously around the resolved shape instead of
+    /// restarting at every physical side. The fragment is clipped to the
+    /// border ring so renderer stroke width cannot leak outside the resolved
+    /// border area. Solid borders should fill [`BorderPaintGeometry::ring`]
+    /// instead: a constant-width centerline stroke only matches the border
+    /// band exactly for circular corners.
+    #[must_use]
+    pub fn stroke_contour(self, position: f64) -> BorderStrokeFragment {
+        let mut path = BezPath::new();
+        self.geometry
+            .border_contour_at(position)
+            .write_path(&mut path);
+        BorderStrokeFragment::new(
+            path,
+            BorderClipStack::ring(self.geometry.to_border_ring_path()),
+        )
+    }
+
+    /// Returns geometry for one physical border side.
+    #[must_use]
+    pub const fn side(self, side: Side) -> BorderSidePaintGeometry {
+        BorderSidePaintGeometry::new(self.geometry, side)
+    }
+}
+
+/// Resolved paint geometry for one physical border side.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BorderSidePaintGeometry {
+    geometry: BoxDecorationGeometry,
+    side: Side,
+}
+
+impl BorderSidePaintGeometry {
+    /// Creates side paint geometry from resolved box decoration geometry.
+    #[must_use]
+    pub const fn new(geometry: BoxDecorationGeometry, side: Side) -> Self {
+        Self { geometry, side }
+    }
+
+    /// Returns the physical side.
+    #[must_use]
+    pub const fn side(self) -> Side {
+        self.side
+    }
+
+    /// Returns the resolved style for this side.
+    #[must_use]
+    pub const fn style(self) -> BorderStyle {
+        match self.side {
+            Side::Top => self.geometry.border_styles.top,
+            Side::Right => self.geometry.border_styles.right,
+            Side::Bottom => self.geometry.border_styles.bottom,
+            Side::Left => self.geometry.border_styles.left,
+        }
+    }
+
+    /// Returns the visible border width for this side.
+    #[must_use]
+    pub const fn width(self) -> f64 {
+        match self.side {
+            Side::Top => self.geometry.border_widths.top,
+            Side::Right => self.geometry.border_widths.right,
+            Side::Bottom => self.geometry.border_widths.bottom,
+            Side::Left => self.geometry.border_widths.left,
+        }
+    }
+
+    /// Returns true when this side has no visible border pixels.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        !self.style().paints_border() || !self.width().is_finite() || self.width() <= 0.0
+    }
+
+    /// Returns this side's owned share of the full border ring.
+    ///
+    /// Filled styles use a real side-bounded path so adjacent sides meet at
+    /// shaped corner miter boundaries. Shared-paint borders can use
+    /// [`BorderPaintGeometry::ring`] when they need one whole-ring fill.
+    #[must_use]
+    pub fn ring(self) -> BorderFillFragment {
+        BorderFillFragment::new(
+            self.geometry.to_border_side_band_path(self.side, 0.0, 1.0),
+            BorderFillRule::NonZero,
+            BorderClipStack::empty(),
+        )
+    }
+
+    /// Returns this side's owned share of a band inside the border ring.
+    #[must_use]
+    pub fn band(self, band: BorderBand) -> BorderFillFragment {
+        BorderFillFragment::new(
+            self.geometry
+                .to_border_side_band_path(self.side, band.outer, band.inner),
+            BorderFillRule::NonZero,
+            BorderClipStack::empty(),
+        )
+    }
+
+    /// Returns an open contour stroke fragment for this side.
+    ///
+    /// The path spans the central side plus the side-owned miter-bounded parts
+    /// of the two adjacent corners. It is clipped to the border ring so
+    /// renderer stroke width cannot leak outside the resolved border area;
+    /// side ownership is carried by the path itself.
+    #[must_use]
+    pub fn stroke_contour(self, position: f64) -> BorderStrokeFragment {
+        self.stroke_contour_with_clips(
+            position,
+            BorderClipStack::ring(self.geometry.to_border_ring_path()),
+        )
+    }
+
+    fn owned_stroke_contour(self, position: f64) -> BorderStrokeFragment {
+        self.stroke_contour_with_clips(
+            position,
+            BorderClipStack::side_and_ring(
+                self.geometry.to_border_side_clip_path(self.side),
+                self.geometry.to_border_ring_path(),
+            ),
+        )
+    }
+
+    fn stroke_contour_with_clips(
+        self,
+        position: f64,
+        clips: BorderClipStack,
+    ) -> BorderStrokeFragment {
+        let contour = self.geometry.border_contour_at(position);
+        let mut path = BezPath::new();
+        write_contour_side_segment_path(
+            contour,
+            self.geometry.border_box,
+            self.geometry.padding_box,
+            self.side,
+            &mut path,
+        );
+        BorderStrokeFragment::new(path, clips)
+    }
+}
+
+fn emit_side_commands(
+    geometry: BorderSidePaintGeometry,
+    paint: &mut impl FnMut(BorderPaintCommand),
+) {
+    let side = geometry.side();
+    let source = BorderPaintSource::Side(side);
+    let style = geometry.style();
+    match style {
+        BorderStyle::None | BorderStyle::Hidden => {}
+        BorderStyle::Solid => {
+            paint(BorderPaintCommand::Fill(BorderPaintFill::new(
+                source,
+                style,
+                BorderPaintRole::Base,
+                geometry.ring(),
+            )));
+        }
+        BorderStyle::Dotted | BorderStyle::Dashed => {
+            let fragment = geometry.owned_stroke_contour(0.5);
+            paint(BorderPaintCommand::Stroke(BorderPaintStroke::new(
+                source,
+                style,
+                stroke_spec_for_open_contour(style, geometry.width(), &fragment),
+                fragment,
+            )));
+        }
+        BorderStyle::Double => {
+            paint(BorderPaintCommand::Fill(BorderPaintFill::new(
+                source,
+                style,
+                BorderPaintRole::Base,
+                geometry.band(BorderBand::new(0.0, 1.0 / 3.0)),
+            )));
+            paint(BorderPaintCommand::Fill(BorderPaintFill::new(
+                source,
+                style,
+                BorderPaintRole::Base,
+                geometry.band(BorderBand::new(2.0 / 3.0, 1.0)),
+            )));
+        }
+        BorderStyle::Inset | BorderStyle::Outset => {
+            paint(BorderPaintCommand::Fill(BorderPaintFill::new(
+                source,
+                style,
+                BorderPaintRole::Relief(inset_outset_shade(side, style)),
+                geometry.ring(),
+            )));
+        }
+        BorderStyle::Groove | BorderStyle::Ridge => {
+            let (outer, inner) = groove_ridge_shades(side, style);
+            paint(BorderPaintCommand::Fill(BorderPaintFill::new(
+                source,
+                style,
+                BorderPaintRole::Relief(outer),
+                geometry.band(BorderBand::new(0.0, 0.5)),
+            )));
+            paint(BorderPaintCommand::Fill(BorderPaintFill::new(
+                source,
+                style,
+                BorderPaintRole::Relief(inner),
+                geometry.band(BorderBand::new(0.5, 1.0)),
+            )));
+        }
+    }
+}
+
+fn ordered_visible_sides(geometry: BoxDecorationGeometry) -> [Side; 4] {
+    let mut sides = Side::ALL;
+    let mut i = 1;
+    while i < sides.len() {
+        let side = sides[i];
+        let mut j = i;
+        while j > 0 && side_sort_key(geometry, side) < side_sort_key(geometry, sides[j - 1]) {
+            sides[j] = sides[j - 1];
+            j -= 1;
+        }
+        sides[j] = side;
+        i += 1;
+    }
+    sides
+}
+
+fn side_sort_key(geometry: BoxDecorationGeometry, side: Side) -> (u8, u8) {
+    let style = style_for_side(geometry, side);
+    (style_priority(style), side_priority(side))
+}
+
+fn style_priority(style: BorderStyle) -> u8 {
+    match style {
+        BorderStyle::None | BorderStyle::Hidden => 0,
+        BorderStyle::Dotted | BorderStyle::Dashed | BorderStyle::Double => 1,
+        BorderStyle::Inset | BorderStyle::Groove | BorderStyle::Outset | BorderStyle::Ridge => 2,
+        BorderStyle::Solid => 3,
+    }
+}
+
+fn stroke_spec_for_style(style: BorderStyle, width: f64) -> BorderStrokeSpec {
+    const DOT_DASH_LENGTH: f64 = 1.0e-2;
+
+    let width = if width.is_finite() && width > 0.0 {
+        width
+    } else {
+        0.0
+    };
+
+    match style {
+        BorderStyle::Dotted => {
+            // CSS-style dotted borders are zero-length round-capped dashes, but
+            // Kurbo drops zero-length dash segments. Emit the smallest useful
+            // painted segment and keep the visual period at roughly 2w.
+            let dot = width.min(DOT_DASH_LENGTH);
+            BorderStrokeSpec::with_dash(
+                width,
+                BorderStrokeCap::Round,
+                BorderDashPattern::new(0.0, [dot, (width * 2.0 - dot).max(width)]),
+            )
+        }
+        BorderStyle::Dashed => {
+            let (dash, gap) = if width >= 3.0 {
+                (width * 2.0, width)
+            } else {
+                (width * 3.0, width * 2.0)
+            };
+            BorderStrokeSpec::with_dash(
+                width,
+                BorderStrokeCap::Butt,
+                BorderDashPattern::new(0.0, [dash, gap]),
+            )
+        }
+        _ => BorderStrokeSpec::solid(width),
+    }
+}
+
+fn stroke_spec_for_closed_contour(
+    style: BorderStyle,
+    width: f64,
+    fragment: &BorderStrokeFragment,
+) -> BorderStrokeSpec {
+    let mut stroke = stroke_spec_for_style(style, width);
+    let Some(dash) = stroke.dash else {
+        return stroke;
+    };
+    let Some(balanced) = balanced_closed_dash_pattern(dash.lengths, &fragment.path) else {
+        return stroke;
+    };
+    stroke.dash = Some(balanced);
+    stroke
+}
+
+fn stroke_spec_for_open_contour(
+    style: BorderStyle,
+    width: f64,
+    fragment: &BorderStrokeFragment,
+) -> BorderStrokeSpec {
+    let mut stroke = stroke_spec_for_style(style, width);
+    let Some(dash) = stroke.dash else {
+        return stroke;
+    };
+    let Some(balanced) = balanced_open_dash_pattern(dash.lengths, &fragment.path) else {
+        return stroke;
+    };
+    stroke.dash = Some(balanced);
+    stroke
+}
+
+/// Balances a dash pattern so full painted segments anchor both endpoints of
+/// an open contour.
+///
+/// The gap is stretched or squeezed to the nearest length where
+/// `length = (n + 1) * painted + n * gap` holds for a whole number of gaps
+/// `n`, so side strokes start and end with a dash at their corner miter
+/// boundaries instead of getting cut mid-dash.
+fn balanced_open_dash_pattern(lengths: [f64; 2], path: &BezPath) -> Option<BorderDashPattern> {
+    let painted = lengths[0];
+    let base_gap = lengths[1];
+    if !painted.is_finite() || painted < 0.0 || !base_gap.is_finite() || base_gap <= 0.0 {
+        return None;
+    }
+
+    let length = path_length(path);
+    let base_period = painted + base_gap;
+    if !length.is_finite() || length <= painted || base_period <= 0.0 {
+        return None;
+    }
+
+    let gaps = floor((length - painted) / base_period + 0.5).max(1.0);
+    let gap = (length - painted * (gaps + 1.0)) / gaps;
+    if !gap.is_finite() || gap <= 0.0 {
+        return None;
+    }
+    Some(BorderDashPattern::new(0.0, [painted, gap]))
+}
+
+fn balanced_closed_dash_pattern(lengths: [f64; 2], path: &BezPath) -> Option<BorderDashPattern> {
+    let painted = lengths[0];
+    let base_gap = lengths[1];
+    if !painted.is_finite() || painted < 0.0 || !base_gap.is_finite() || base_gap <= 0.0 {
+        return None;
+    }
+
+    let contour_length = path_length(path);
+    let base_period = painted + base_gap;
+    if !contour_length.is_finite() || contour_length <= 0.0 || base_period <= 0.0 {
+        return None;
+    }
+
+    let count = nearest_period_count(contour_length, base_period, painted);
+    let adjusted_period = contour_length / count;
+    if !adjusted_period.is_finite() || adjusted_period <= painted {
+        return None;
+    }
+
+    let gap = adjusted_period - painted;
+    Some(BorderDashPattern::new(painted + gap * 0.5, [painted, gap]))
+}
+
+fn nearest_period_count(total: f64, base_period: f64, painted: f64) -> f64 {
+    let estimate = total / base_period;
+    let lower = floor(estimate).max(1.0);
+    let upper = lower + 1.0;
+
+    let lower_error = (total / lower - base_period).abs();
+    let upper_error = (total / upper - base_period).abs();
+    let mut count = if upper_error < lower_error {
+        upper
+    } else {
+        lower
+    };
+
+    while count > 1.0 && total / count <= painted {
+        count -= 1.0;
+    }
+    count
+}
+
+fn path_length(path: &BezPath) -> f64 {
+    const ACCURACY: f64 = 0.1;
+
+    path.segments()
+        .map(|segment| segment.arclen(ACCURACY))
+        .sum()
+}
+
+fn side_priority(side: Side) -> u8 {
+    match side {
+        Side::Top => 0,
+        Side::Bottom => 1,
+        Side::Right => 2,
+        Side::Left => 3,
+    }
+}
+
+fn uniform_visible_style(geometry: BoxDecorationGeometry) -> Option<BorderStyle> {
+    let first = geometry.border_paint().side(Side::Top);
+    if first.is_empty() {
+        return None;
+    }
+    let style = first.style();
+    for side in [Side::Right, Side::Bottom, Side::Left] {
+        let side = geometry.border_paint().side(side);
+        if side.is_empty() || side.style() != style {
+            return None;
+        }
+    }
+    Some(style)
+}
+
+fn shared_visible_width(geometry: BoxDecorationGeometry) -> Option<f64> {
+    let first = geometry.border_paint().side(Side::Top);
+    if first.is_empty() {
+        return None;
+    }
+    let width = first.width();
+    for side in [Side::Right, Side::Bottom, Side::Left] {
+        let side = geometry.border_paint().side(side);
+        if side.is_empty() || !same_f64(side.width(), width) {
+            return None;
+        }
+    }
+    Some(width)
+}
+
+fn style_for_side(geometry: BoxDecorationGeometry, side: Side) -> BorderStyle {
+    match side {
+        Side::Top => geometry.border_styles.top,
+        Side::Right => geometry.border_styles.right,
+        Side::Bottom => geometry.border_styles.bottom,
+        Side::Left => geometry.border_styles.left,
+    }
+}
+
+fn inset_outset_shade(side: Side, style: BorderStyle) -> BorderReliefShade {
+    let before_edge = matches!(side, Side::Top | Side::Left);
+    let highlight = match style {
+        BorderStyle::Outset => before_edge,
+        BorderStyle::Inset => !before_edge,
+        _ => false,
+    };
+    relief_shade(highlight)
+}
+
+fn groove_ridge_shades(side: Side, style: BorderStyle) -> (BorderReliefShade, BorderReliefShade) {
+    let before_edge = matches!(side, Side::Top | Side::Left);
+    let outer_highlight = match style {
+        BorderStyle::Ridge => before_edge,
+        BorderStyle::Groove => !before_edge,
+        _ => false,
+    };
+    (
+        relief_shade(outer_highlight),
+        relief_shade(!outer_highlight),
+    )
+}
+
+fn relief_shade(highlight: bool) -> BorderReliefShade {
+    if highlight {
+        BorderReliefShade::Highlight
+    } else {
+        BorderReliefShade::Shadow
+    }
+}
+
+fn same_f64(a: f64, b: f64) -> bool {
+    a.to_bits() == b.to_bits()
+}
+
+impl BoxDecorationGeometry {
+    /// Returns the canonical border paint geometry view for this box.
+    #[must_use]
+    pub const fn border_paint(self) -> BorderPaintGeometry {
+        BorderPaintGeometry::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CornerRadii, CornerShape, CornerShapes, Edges, Superellipse};
+    use kurbo::{PathEl, Point, Rect, Size};
+
+    #[test]
+    fn border_paint_ring_and_band_are_even_odd_fragments() {
+        let geometry = rounded_geometry().border_paint();
+
+        let ring = geometry.ring();
+        let band = geometry.band(BorderBand::new(0.0, 1.0 / 3.0));
+
+        assert_eq!(ring.fill_rule, BorderFillRule::EvenOdd);
+        assert_eq!(band.fill_rule, BorderFillRule::EvenOdd);
+        assert_eq!(ring.clips, BorderClipStack::empty());
+        assert_eq!(band.clips, BorderClipStack::empty());
+        assert_eq!(close_count(&ring.path), 2);
+        assert_eq!(close_count(&band.path), 2);
+        assert!(ring.path.is_finite());
+        assert!(band.path.is_finite());
+    }
+
+    #[test]
+    fn side_fill_fragments_are_closed_side_owned_paths() {
+        let side = rounded_geometry().border_paint().side(Side::Right);
+
+        let ring = side.ring();
+        let band = side.band(BorderBand::new(2.0 / 3.0, 1.0));
+
+        assert_eq!(ring.fill_rule, BorderFillRule::NonZero);
+        assert_eq!(band.fill_rule, BorderFillRule::NonZero);
+        assert_eq!(close_count(&ring.path), 1);
+        assert_eq!(close_count(&band.path), 1);
+        assert_eq!(ring.clips, BorderClipStack::empty());
+        assert_eq!(band.clips, BorderClipStack::empty());
+        assert!(ring.path.is_finite());
+        assert!(band.path.is_finite());
+    }
+
+    #[test]
+    fn reference_sheet_side_fill_uses_corner_miter_boundary() {
+        let bottom = reference_sheet_geometry(Edges::all(BorderStyle::Solid))
+            .border_paint()
+            .side(Side::Bottom)
+            .ring();
+
+        let outer_corner = Point::new(0.0, 66.0);
+        let inner_corner = Point::new(8.0, 46.0);
+        let outer_join = previous_point_before_line_to(&bottom.path, inner_corner)
+            .expect("bottom side should join to the inner bottom-left corner");
+
+        assert!(
+            outer_join.x < inner_corner.x,
+            "outer join should lie before the inner corner on the bottom-left miter: {outer_join:?}"
+        );
+        assert!(
+            signed_line_distance(outer_corner, inner_corner, outer_join).abs() <= 1e-6,
+            "outer join should lie on the bottom-left miter line: {outer_join:?}"
+        );
+    }
+
+    #[test]
+    fn reference_sheet_side_stroke_uses_corner_miter_boundary() {
+        let bottom = reference_sheet_geometry(Edges::all(BorderStyle::Dashed))
+            .border_paint()
+            .side(Side::Bottom)
+            .stroke_contour(0.5);
+
+        let outer_corner = Point::new(0.0, 66.0);
+        let inner_corner = Point::new(8.0, 46.0);
+        let join = last_path_point(&bottom.path).expect("bottom stroke should have an endpoint");
+
+        assert!(
+            join.x < inner_corner.x,
+            "stroke join should lie before the inner corner on the bottom-left miter: {join:?}"
+        );
+        assert!(
+            signed_line_distance(outer_corner, inner_corner, join).abs() <= 1e-6,
+            "stroke join should lie on the bottom-left miter line: {join:?}"
+        );
+    }
+
+    #[test]
+    fn side_stroke_fragment_is_open_and_clipped_to_ring() {
+        let stroke = rounded_geometry()
+            .border_paint()
+            .side(Side::Top)
+            .stroke_contour(0.5);
+
+        assert_eq!(close_count(&stroke.path), 0);
+        assert!(
+            stroke
+                .path
+                .iter()
+                .any(|element| matches!(element, PathEl::CurveTo(..)))
+        );
+        assert!(stroke.clips.side.is_none());
+        assert_eq!(
+            stroke.clips.ring.as_ref().map(|clip| clip.fill_rule),
+            Some(BorderFillRule::EvenOdd)
+        );
+        assert_eq!(
+            stroke
+                .clips
+                .ring
+                .as_ref()
+                .map(|clip| close_count(&clip.path)),
+            Some(2)
+        );
+        assert!(stroke.path.is_finite());
+    }
+
+    #[test]
+    fn shared_double_plan_emits_two_whole_band_fills() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::new(6.0, 12.0, 18.0, 24.0),
+            Edges::all(BorderStyle::Double),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut fill_count = 0;
+        geometry
+            .border_paint()
+            .shared_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(fill) => {
+                    fill_count += 1;
+                    assert_eq!(fill.source, BorderPaintSource::Shared);
+                    assert_eq!(fill.style, BorderStyle::Double);
+                    assert_eq!(fill.role, BorderPaintRole::Base);
+                    assert_eq!(fill.fragment.fill_rule, BorderFillRule::EvenOdd);
+                    assert_eq!(close_count(&fill.fragment.path), 2);
+                    assert_eq!(fill.fragment.clips, BorderClipStack::empty());
+                }
+                BorderPaintCommand::Stroke(_) => panic!("double plan should not emit strokes"),
+            });
+
+        assert_eq!(fill_count, 2);
+    }
+
+    #[test]
+    fn shared_solid_plan_emits_one_ring_fill() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(8.0),
+            Edges::all(BorderStyle::Solid),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+            CornerShapes::all(CornerShape::Bevel),
+        );
+
+        let mut fill_count = 0;
+        geometry
+            .border_paint()
+            .shared_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(fill) => {
+                    fill_count += 1;
+                    assert_eq!(fill.source, BorderPaintSource::Shared);
+                    assert_eq!(fill.style, BorderStyle::Solid);
+                    assert_eq!(fill.role, BorderPaintRole::Base);
+                    assert_eq!(fill.fragment.fill_rule, BorderFillRule::EvenOdd);
+                    assert_eq!(close_count(&fill.fragment.path), 2);
+                    assert_eq!(fill.fragment.clips, BorderClipStack::empty());
+                    assert!(fill.fragment.path.is_finite());
+                }
+                BorderPaintCommand::Stroke(_) => panic!("shared solid plan should not stroke"),
+            });
+
+        assert_eq!(fill_count, 1);
+    }
+
+    #[test]
+    fn shared_solid_plan_keeps_one_ring_fill_for_mixed_widths() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::new(6.0, 12.0, 18.0, 24.0),
+            Edges::all(BorderStyle::Solid),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut fill_count = 0;
+        geometry
+            .border_paint()
+            .shared_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(fill) => {
+                    fill_count += 1;
+                    assert_eq!(fill.source, BorderPaintSource::Shared);
+                    assert_eq!(fill.role, BorderPaintRole::Base);
+                    assert_eq!(close_count(&fill.fragment.path), 2);
+                }
+                BorderPaintCommand::Stroke(_) => panic!("shared solid plan should not stroke"),
+            });
+
+        assert_eq!(fill_count, 1);
+    }
+
+    #[test]
+    fn non_visible_borders_emit_no_paint_commands() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::new(8.0, 0.0, f64::NAN, 12.0),
+            Edges::new(
+                BorderStyle::Hidden,
+                BorderStyle::Solid,
+                BorderStyle::Dashed,
+                BorderStyle::None,
+            ),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut shared_count = 0;
+        geometry
+            .border_paint()
+            .shared_plan()
+            .for_each(|_| shared_count += 1);
+
+        let mut per_side_count = 0;
+        geometry
+            .border_paint()
+            .per_side_plan()
+            .for_each(|_| per_side_count += 1);
+
+        assert!(!geometry.has_visible_border());
+        assert_eq!(shared_count, 0);
+        assert_eq!(per_side_count, 0);
+    }
+
+    #[test]
+    fn shared_rounded_dashed_plan_balances_one_closed_contour_stroke() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(8.0),
+            Edges::all(BorderStyle::Dashed),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut stroke_count = 0;
+        geometry
+            .border_paint()
+            .shared_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(_) => panic!("dashed plan should not emit fills"),
+                BorderPaintCommand::Stroke(stroke) => {
+                    stroke_count += 1;
+                    assert_eq!(stroke.source, BorderPaintSource::Shared);
+                    assert_eq!(stroke.style, BorderStyle::Dashed);
+                    assert_eq!(stroke.stroke.width, 8.0);
+                    assert_eq!(stroke.stroke.cap, BorderStrokeCap::Butt);
+                    assert_balanced_closed_dash(&stroke.fragment.path, stroke.stroke.dash, 16.0);
+                    assert_eq!(close_count(&stroke.fragment.path), 1);
+                    assert!(stroke.fragment.clips.side.is_none());
+                    assert_eq!(
+                        stroke
+                            .fragment
+                            .clips
+                            .ring
+                            .as_ref()
+                            .map(|clip| clip.fill_rule),
+                        Some(BorderFillRule::EvenOdd)
+                    );
+                    assert_eq!(
+                        stroke
+                            .fragment
+                            .clips
+                            .ring
+                            .as_ref()
+                            .map(|clip| close_count(&clip.path)),
+                        Some(2)
+                    );
+                    assert!(stroke.fragment.path.is_finite());
+                }
+            });
+
+        assert_eq!(stroke_count, 1);
+    }
+
+    #[test]
+    fn shared_rounded_dotted_plan_balances_drawable_round_dashes() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(8.0),
+            Edges::all(BorderStyle::Dotted),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut stroke_count = 0;
+        geometry
+            .border_paint()
+            .shared_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(_) => panic!("dotted plan should not emit fills"),
+                BorderPaintCommand::Stroke(stroke) => {
+                    stroke_count += 1;
+                    assert_eq!(stroke.source, BorderPaintSource::Shared);
+                    assert_eq!(stroke.style, BorderStyle::Dotted);
+                    assert_eq!(stroke.stroke.width, 8.0);
+                    assert_eq!(stroke.stroke.cap, BorderStrokeCap::Round);
+                    assert_balanced_closed_dash(&stroke.fragment.path, stroke.stroke.dash, 0.01);
+                    assert_eq!(close_count(&stroke.fragment.path), 1);
+                    assert!(stroke.fragment.clips.side.is_none());
+                    assert_eq!(
+                        stroke
+                            .fragment
+                            .clips
+                            .ring
+                            .as_ref()
+                            .map(|clip| clip.fill_rule),
+                        Some(BorderFillRule::EvenOdd)
+                    );
+                    assert_eq!(
+                        stroke
+                            .fragment
+                            .clips
+                            .ring
+                            .as_ref()
+                            .map(|clip| close_count(&clip.path)),
+                        Some(2)
+                    );
+                }
+            });
+
+        assert_eq!(stroke_count, 1);
+    }
+
+    #[test]
+    fn thin_dashed_plan_uses_longer_dash_ratio() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(2.0),
+            Edges::all(BorderStyle::Dashed),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut stroke_count = 0;
+        geometry
+            .border_paint()
+            .shared_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(_) => panic!("dashed plan should not emit fills"),
+                BorderPaintCommand::Stroke(stroke) => {
+                    stroke_count += 1;
+                    assert_eq!(stroke.style, BorderStyle::Dashed);
+                    assert_eq!(stroke.stroke.width, 2.0);
+                    assert_eq!(stroke.stroke.cap, BorderStrokeCap::Butt);
+                    assert_balanced_closed_dash(&stroke.fragment.path, stroke.stroke.dash, 6.0);
+                }
+            });
+
+        assert_eq!(stroke_count, 1);
+    }
+
+    #[test]
+    fn per_side_dashed_plan_emits_owned_strokes() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(8.0),
+            Edges::all(BorderStyle::Dashed),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut stroke_count = 0;
+        geometry
+            .border_paint()
+            .per_side_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(_) => panic!("dashed plan should not emit fills"),
+                BorderPaintCommand::Stroke(stroke) => {
+                    stroke_count += 1;
+                    assert!(matches!(stroke.source, BorderPaintSource::Side(_)));
+                    assert_eq!(stroke.style, BorderStyle::Dashed);
+                    assert_eq!(stroke.stroke.width, 8.0);
+                    assert_eq!(stroke.stroke.cap, BorderStrokeCap::Butt);
+                    assert_balanced_open_dash(&stroke.fragment.path, stroke.stroke.dash, 16.0);
+                    assert_eq!(close_count(&stroke.fragment.path), 0);
+                    assert_eq!(
+                        stroke
+                            .fragment
+                            .clips
+                            .side
+                            .as_ref()
+                            .map(|clip| clip.fill_rule),
+                        Some(BorderFillRule::NonZero)
+                    );
+                    assert_eq!(
+                        stroke
+                            .fragment
+                            .clips
+                            .side
+                            .as_ref()
+                            .map(|clip| close_count(&clip.path)),
+                        Some(1)
+                    );
+                    assert_eq!(
+                        stroke
+                            .fragment
+                            .clips
+                            .ring
+                            .as_ref()
+                            .map(|clip| clip.fill_rule),
+                        Some(BorderFillRule::EvenOdd)
+                    );
+                    assert_eq!(
+                        stroke
+                            .fragment
+                            .clips
+                            .ring
+                            .as_ref()
+                            .map(|clip| close_count(&clip.path)),
+                        Some(2)
+                    );
+                    assert!(stroke.fragment.path.is_finite());
+                }
+            });
+
+        assert_eq!(stroke_count, 4);
+    }
+
+    #[test]
+    fn per_side_dotted_plan_anchors_dots_at_corner_boundaries() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(8.0),
+            Edges::all(BorderStyle::Dotted),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut stroke_count = 0;
+        geometry
+            .border_paint()
+            .per_side_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(_) => panic!("dotted plan should not emit fills"),
+                BorderPaintCommand::Stroke(stroke) => {
+                    stroke_count += 1;
+                    assert_eq!(stroke.style, BorderStyle::Dotted);
+                    assert_eq!(stroke.stroke.cap, BorderStrokeCap::Round);
+                    assert_balanced_open_dash(&stroke.fragment.path, stroke.stroke.dash, 0.01);
+                }
+            });
+
+        assert_eq!(stroke_count, 4);
+    }
+
+    #[test]
+    fn per_side_double_plan_emits_side_owned_band_fills_without_clips() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 154.0, 68.0),
+            Edges::new(7.0, 11.0, 8.0, 5.0),
+            Edges::all(BorderStyle::Double),
+            Edges::ZERO,
+            CornerRadii::new(
+                Size::new(24.0, 18.0),
+                Size::new(28.0, 18.0),
+                Size::new(20.0, 26.0),
+                Size::new(18.0, 14.0),
+            ),
+            CornerShapes::new(
+                CornerShape::Superellipse(Superellipse::new(2.0)),
+                CornerShape::Bevel,
+                CornerShape::scoop(),
+                CornerShape::Round,
+            ),
+        );
+
+        let mut fill_count = 0;
+        geometry
+            .border_paint()
+            .per_side_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(fill) => {
+                    fill_count += 1;
+                    assert!(matches!(fill.source, BorderPaintSource::Side(_)));
+                    assert_eq!(fill.style, BorderStyle::Double);
+                    assert_eq!(fill.role, BorderPaintRole::Base);
+                    assert_eq!(fill.fragment.fill_rule, BorderFillRule::NonZero);
+                    assert_eq!(close_count(&fill.fragment.path), 1);
+                    assert_eq!(fill.fragment.clips, BorderClipStack::empty());
+                    assert!(fill.fragment.path.iter().count() > 4);
+                    assert!(fill.fragment.path.is_finite());
+                }
+                BorderPaintCommand::Stroke(_) => {
+                    panic!("per-side double plan should not emit strokes")
+                }
+            });
+
+        assert_eq!(fill_count, 8);
+    }
+
+    #[test]
+    fn inset_plan_emits_one_relief_fill_per_side() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(8.0),
+            Edges::all(BorderStyle::Inset),
+            Edges::ZERO,
+            CornerRadii::uniform(12.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut fill_count = 0;
+        geometry
+            .border_paint()
+            .shared_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(fill) => {
+                    fill_count += 1;
+                    assert_eq!(fill.style, BorderStyle::Inset);
+                    let BorderPaintRole::Relief(shade) = fill.role else {
+                        panic!("inset plan should only emit relief fills: {:?}", fill.role);
+                    };
+                    let BorderPaintSource::Side(side) = fill.source else {
+                        panic!("relief styles should paint per side: {:?}", fill.source);
+                    };
+                    // Inset looks pressed: before edges are dark, after edges
+                    // are light.
+                    let expected = match side {
+                        Side::Top | Side::Left => BorderReliefShade::Shadow,
+                        Side::Right | Side::Bottom => BorderReliefShade::Highlight,
+                    };
+                    assert_eq!(shade, expected, "wrong inset shade for {side:?}");
+                    assert_eq!(close_count(&fill.fragment.path), 1);
+                }
+                BorderPaintCommand::Stroke(_) => panic!("inset plan should not stroke"),
+            });
+
+        assert_eq!(fill_count, 4);
+    }
+
+    #[test]
+    fn groove_plan_emits_relief_band_pairs_per_side() {
+        let geometry = BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::all(8.0),
+            Edges::all(BorderStyle::Groove),
+            Edges::ZERO,
+            CornerRadii::uniform(12.0),
+            CornerShapes::ROUND,
+        );
+
+        let mut top_shades = [None, None];
+        let mut top_index = 0;
+        let mut fill_count = 0;
+        geometry
+            .border_paint()
+            .per_side_plan()
+            .for_each(|command| match command {
+                BorderPaintCommand::Fill(fill) => {
+                    fill_count += 1;
+                    assert_eq!(fill.style, BorderStyle::Groove);
+                    let BorderPaintRole::Relief(shade) = fill.role else {
+                        panic!("groove plan should only emit relief fills: {:?}", fill.role);
+                    };
+                    if fill.source == BorderPaintSource::Side(Side::Top) {
+                        top_shades[top_index] = Some(shade);
+                        top_index += 1;
+                    }
+                }
+                BorderPaintCommand::Stroke(_) => panic!("groove plan should not stroke"),
+            });
+
+        assert_eq!(fill_count, 8);
+        // Groove carves inward: the outer half of a before-edge side is dark
+        // and the inner half is light.
+        assert_eq!(
+            top_shades,
+            [
+                Some(BorderReliefShade::Shadow),
+                Some(BorderReliefShade::Highlight)
+            ]
+        );
+    }
+
+    #[test]
+    fn side_stroke_fragments_preserve_shaped_corner_segments() {
+        let geometry = BoxDecorationGeometry::from_border_box(
+            Rect::new(0.0, 0.0, 140.0, 88.0),
+            Edges::all(12.0),
+            Edges::ZERO,
+            CornerRadii::all(Size::new(26.0, 18.0)),
+            CornerShapes::new(
+                CornerShape::Square,
+                CornerShape::Superellipse(Superellipse::new(2.0)),
+                CornerShape::Bevel,
+                CornerShape::scoop(),
+            ),
+        );
+
+        for side in [Side::Top, Side::Right, Side::Bottom, Side::Left] {
+            let stroke = geometry.border_paint().side(side).stroke_contour(0.5);
+            assert_eq!(close_count(&stroke.path), 0);
+            assert!(stroke.path.iter().count() >= 3);
+            assert!(stroke.path.is_finite());
+        }
+    }
+
+    fn rounded_geometry() -> BoxDecorationGeometry {
+        BoxDecorationGeometry::from_round_border_box(
+            Rect::new(0.0, 0.0, 120.0, 80.0),
+            Edges::new(6.0, 12.0, 18.0, 24.0),
+            Edges::ZERO,
+            CornerRadii::uniform(20.0),
+        )
+    }
+
+    fn reference_sheet_geometry(border_styles: Edges<BorderStyle>) -> BoxDecorationGeometry {
+        BoxDecorationGeometry::from_styled_border_box(
+            Rect::new(0.0, 0.0, 184.0, 66.0),
+            Edges::new(4.0, 12.0, 20.0, 8.0),
+            border_styles,
+            Edges::ZERO,
+            CornerRadii::new(
+                Size::new(10.0, 30.0),
+                Size::new(40.0, 10.0),
+                Size::new(30.0, 50.0),
+                Size::new(60.0, 20.0),
+            ),
+            CornerShapes::ROUND,
+        )
+    }
+
+    fn previous_point_before_line_to(path: &BezPath, target: Point) -> Option<Point> {
+        let mut current = None;
+        for element in path.iter() {
+            match element {
+                PathEl::MoveTo(point) => current = Some(point),
+                PathEl::LineTo(point) => {
+                    if same_point(point, target) {
+                        return current;
+                    }
+                    current = Some(point);
+                }
+                PathEl::QuadTo(_, point) | PathEl::CurveTo(_, _, point) => current = Some(point),
+                PathEl::ClosePath => {}
+            }
+        }
+        None
+    }
+
+    fn last_path_point(path: &BezPath) -> Option<Point> {
+        let mut current = None;
+        for element in path.iter() {
+            match element {
+                PathEl::MoveTo(point)
+                | PathEl::LineTo(point)
+                | PathEl::QuadTo(_, point)
+                | PathEl::CurveTo(_, _, point) => current = Some(point),
+                PathEl::ClosePath => {}
+            }
+        }
+        current
+    }
+
+    fn same_point(a: Point, b: Point) -> bool {
+        (a.x - b.x).abs() <= 1e-6 && (a.y - b.y).abs() <= 1e-6
+    }
+
+    fn signed_line_distance(start: Point, end: Point, point: Point) -> f64 {
+        let line_x = end.x - start.x;
+        let line_y = end.y - start.y;
+        let point_x = point.x - start.x;
+        let point_y = point.y - start.y;
+        line_x * point_y - line_y * point_x
+    }
+
+    fn assert_balanced_open_dash(path: &BezPath, dash: Option<BorderDashPattern>, painted: f64) {
+        let dash = dash.expect("stroke should carry a dash pattern");
+        let gap = dash.lengths[1];
+        let length = path_length(path);
+        let gaps = (length - painted) / (painted + gap);
+
+        assert_eq!(dash.lengths[0], painted);
+        assert_eq!(dash.offset, 0.0, "open dashes should start on a dash");
+        assert!(
+            gap > 0.0,
+            "balanced dash gap should stay positive: {dash:?}"
+        );
+        assert!(
+            (gaps - floor(gaps + 0.5)).abs() <= 1e-9,
+            "open contour should end on a full dash: length={length}, gaps={gaps}, dash={dash:?}"
+        );
+    }
+
+    fn assert_balanced_closed_dash(path: &BezPath, dash: Option<BorderDashPattern>, painted: f64) {
+        let dash = dash.expect("stroke should carry a dash pattern");
+        let period = dash.lengths[0] + dash.lengths[1];
+        let contour_length = path_length(path);
+        let periods = contour_length / period;
+        let lower = floor(periods).max(1.0);
+        let upper = lower + 1.0;
+        let fit_error = (periods - lower).abs().min((periods - upper).abs());
+
+        assert_eq!(dash.lengths[0], painted);
+        assert!(
+            dash.lengths[1] > 0.0,
+            "balanced dash gap should stay positive: {dash:?}"
+        );
+        assert!(
+            dash.offset > painted && dash.offset < period,
+            "balanced dash should start inside a gap: {dash:?}"
+        );
+        assert!(
+            fit_error <= 1e-9,
+            "balanced dash period should divide the closed contour length: length={contour_length}, periods={periods}, dash={dash:?}"
+        );
+    }
+
+    fn close_count(path: &BezPath) -> usize {
+        path.iter()
+            .filter(|element| matches!(element, PathEl::ClosePath))
+            .count()
+    }
+}

--- a/understory_box_decoration/src/path.rs
+++ b/understory_box_decoration/src/path.rs
@@ -1,10 +1,10 @@
 // Copyright 2026 the Understory Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use kurbo::{BezPath, Point, Rect, Size};
+use kurbo::{BezPath, CubicBez, ParamCurve, Point, Rect, Size};
 
 use crate::math::powf;
-use crate::{BoxContour, CornerRadii, CornerShape, ResolvedCorner, Superellipse};
+use crate::{BoxContour, CornerRadii, CornerShape, Corners, ResolvedCorner, Side, Superellipse};
 
 const ARC_KAPPA: f64 = 0.552_284_749_830_793_6;
 const SUPERELLIPSE_SEGMENTS: usize = 12;
@@ -66,6 +66,442 @@ pub(crate) fn write_contour_path(contour: BoxContour, path: &mut BezPath) {
     path.close_path();
 }
 
+pub(crate) fn write_contour_side_segment_path(
+    contour: BoxContour,
+    outer_rect: Rect,
+    inner_rect: Rect,
+    side: Side,
+    path: &mut BezPath,
+) {
+    let splits = contour_corner_miter_splits(contour, outer_rect, inner_rect);
+    path.move_to(side_segment_start_with_splits(contour, side, splits));
+    append_contour_side_segment_with_splits(contour, side, splits, path);
+}
+
+pub(crate) fn write_contour_side_band_path(
+    outer: BoxContour,
+    inner: BoxContour,
+    side: Side,
+    path: &mut BezPath,
+) {
+    let (outer_splits, inner_splits) = side_band_corner_splits(outer, inner);
+
+    path.move_to(side_segment_start_with_splits(outer, side, outer_splits));
+    append_contour_side_segment_with_splits(outer, side, outer_splits, path);
+    path.line_to(side_segment_end_with_splits(inner, side, inner_splits));
+    append_contour_side_segment_reversed(inner, side, inner_splits, path);
+    path.close_path();
+}
+
+fn append_contour_side_segment_with_splits(
+    contour: BoxContour,
+    side: Side,
+    splits: Corners<f64>,
+    path: &mut BezPath,
+) {
+    let rect = contour.rect;
+    let corners = contour.corners;
+
+    match side {
+        Side::Top => {
+            append_corner_range(
+                path,
+                CornerPlacement::TopLeft,
+                rect,
+                corners.top_left,
+                splits.top_left,
+                1.0,
+            );
+            path.line_to(corner_start(
+                CornerPlacement::TopRight,
+                rect,
+                corners.top_right.radii,
+            ));
+            append_corner_range(
+                path,
+                CornerPlacement::TopRight,
+                rect,
+                corners.top_right,
+                0.0,
+                splits.top_right,
+            );
+        }
+        Side::Right => {
+            append_corner_range(
+                path,
+                CornerPlacement::TopRight,
+                rect,
+                corners.top_right,
+                splits.top_right,
+                1.0,
+            );
+            path.line_to(corner_start(
+                CornerPlacement::BottomRight,
+                rect,
+                corners.bottom_right.radii,
+            ));
+            append_corner_range(
+                path,
+                CornerPlacement::BottomRight,
+                rect,
+                corners.bottom_right,
+                0.0,
+                splits.bottom_right,
+            );
+        }
+        Side::Bottom => {
+            append_corner_range(
+                path,
+                CornerPlacement::BottomRight,
+                rect,
+                corners.bottom_right,
+                splits.bottom_right,
+                1.0,
+            );
+            path.line_to(corner_start(
+                CornerPlacement::BottomLeft,
+                rect,
+                corners.bottom_left.radii,
+            ));
+            append_corner_range(
+                path,
+                CornerPlacement::BottomLeft,
+                rect,
+                corners.bottom_left,
+                0.0,
+                splits.bottom_left,
+            );
+        }
+        Side::Left => {
+            append_corner_range(
+                path,
+                CornerPlacement::BottomLeft,
+                rect,
+                corners.bottom_left,
+                splits.bottom_left,
+                1.0,
+            );
+            path.line_to(corner_start(
+                CornerPlacement::TopLeft,
+                rect,
+                corners.top_left.radii,
+            ));
+            append_corner_range(
+                path,
+                CornerPlacement::TopLeft,
+                rect,
+                corners.top_left,
+                0.0,
+                splits.top_left,
+            );
+        }
+    }
+}
+
+fn append_contour_side_segment_reversed(
+    contour: BoxContour,
+    side: Side,
+    splits: Corners<f64>,
+    path: &mut BezPath,
+) {
+    let rect = contour.rect;
+    let corners = contour.corners;
+
+    match side {
+        Side::Top => {
+            append_corner_range(
+                path,
+                CornerPlacement::TopRight,
+                rect,
+                corners.top_right,
+                splits.top_right,
+                0.0,
+            );
+            path.line_to(corner_end(
+                CornerPlacement::TopLeft,
+                rect,
+                corners.top_left.radii,
+            ));
+            append_corner_range(
+                path,
+                CornerPlacement::TopLeft,
+                rect,
+                corners.top_left,
+                1.0,
+                splits.top_left,
+            );
+        }
+        Side::Right => {
+            append_corner_range(
+                path,
+                CornerPlacement::BottomRight,
+                rect,
+                corners.bottom_right,
+                splits.bottom_right,
+                0.0,
+            );
+            path.line_to(corner_end(
+                CornerPlacement::TopRight,
+                rect,
+                corners.top_right.radii,
+            ));
+            append_corner_range(
+                path,
+                CornerPlacement::TopRight,
+                rect,
+                corners.top_right,
+                1.0,
+                splits.top_right,
+            );
+        }
+        Side::Bottom => {
+            append_corner_range(
+                path,
+                CornerPlacement::BottomLeft,
+                rect,
+                corners.bottom_left,
+                splits.bottom_left,
+                0.0,
+            );
+            path.line_to(corner_end(
+                CornerPlacement::BottomRight,
+                rect,
+                corners.bottom_right.radii,
+            ));
+            append_corner_range(
+                path,
+                CornerPlacement::BottomRight,
+                rect,
+                corners.bottom_right,
+                1.0,
+                splits.bottom_right,
+            );
+        }
+        Side::Left => {
+            append_corner_range(
+                path,
+                CornerPlacement::TopLeft,
+                rect,
+                corners.top_left,
+                splits.top_left,
+                0.0,
+            );
+            path.line_to(corner_end(
+                CornerPlacement::BottomLeft,
+                rect,
+                corners.bottom_left.radii,
+            ));
+            append_corner_range(
+                path,
+                CornerPlacement::BottomLeft,
+                rect,
+                corners.bottom_left,
+                1.0,
+                splits.bottom_left,
+            );
+        }
+    }
+}
+
+fn side_segment_start_with_splits(contour: BoxContour, side: Side, splits: Corners<f64>) -> Point {
+    let rect = contour.rect;
+    let corners = contour.corners;
+    match side {
+        Side::Top => corner_point(
+            CornerPlacement::TopLeft,
+            rect,
+            corners.top_left,
+            splits.top_left,
+        ),
+        Side::Right => corner_point(
+            CornerPlacement::TopRight,
+            rect,
+            corners.top_right,
+            splits.top_right,
+        ),
+        Side::Bottom => corner_point(
+            CornerPlacement::BottomRight,
+            rect,
+            corners.bottom_right,
+            splits.bottom_right,
+        ),
+        Side::Left => corner_point(
+            CornerPlacement::BottomLeft,
+            rect,
+            corners.bottom_left,
+            splits.bottom_left,
+        ),
+    }
+}
+
+fn side_segment_end_with_splits(contour: BoxContour, side: Side, splits: Corners<f64>) -> Point {
+    let rect = contour.rect;
+    let corners = contour.corners;
+    match side {
+        Side::Top => corner_point(
+            CornerPlacement::TopRight,
+            rect,
+            corners.top_right,
+            splits.top_right,
+        ),
+        Side::Right => corner_point(
+            CornerPlacement::BottomRight,
+            rect,
+            corners.bottom_right,
+            splits.bottom_right,
+        ),
+        Side::Bottom => corner_point(
+            CornerPlacement::BottomLeft,
+            rect,
+            corners.bottom_left,
+            splits.bottom_left,
+        ),
+        Side::Left => corner_point(
+            CornerPlacement::TopLeft,
+            rect,
+            corners.top_left,
+            splits.top_left,
+        ),
+    }
+}
+
+fn side_band_corner_splits(outer: BoxContour, inner: BoxContour) -> (Corners<f64>, Corners<f64>) {
+    (
+        contour_corner_miter_splits(outer, outer.rect, inner.rect),
+        contour_corner_miter_splits(inner, outer.rect, inner.rect),
+    )
+}
+
+fn contour_corner_miter_splits(
+    contour: BoxContour,
+    outer_rect: Rect,
+    inner_rect: Rect,
+) -> Corners<f64> {
+    let top_left = corner_miter_line(CornerPlacement::TopLeft, outer_rect, inner_rect);
+    let top_right = corner_miter_line(CornerPlacement::TopRight, outer_rect, inner_rect);
+    let bottom_right = corner_miter_line(CornerPlacement::BottomRight, outer_rect, inner_rect);
+    let bottom_left = corner_miter_line(CornerPlacement::BottomLeft, outer_rect, inner_rect);
+
+    Corners::new(
+        corner_miter_progress(CornerPlacement::TopLeft, contour, top_left),
+        corner_miter_progress(CornerPlacement::TopRight, contour, top_right),
+        corner_miter_progress(CornerPlacement::BottomRight, contour, bottom_right),
+        corner_miter_progress(CornerPlacement::BottomLeft, contour, bottom_left),
+    )
+}
+
+fn corner_miter_line(placement: CornerPlacement, outer: Rect, inner: Rect) -> (Point, Point) {
+    (rect_corner(placement, outer), rect_corner(placement, inner))
+}
+
+fn corner_miter_progress(
+    placement: CornerPlacement,
+    contour: BoxContour,
+    line: (Point, Point),
+) -> f64 {
+    const SAMPLES: usize = 64;
+    const BISECT_STEPS: usize = 48;
+
+    let (line_start, line_end) = line;
+    let line_epsilon = line_start.distance(line_end).max(1.0) * 1e-9;
+    if line_start.distance(line_end) <= f64::EPSILON {
+        return 0.5;
+    }
+
+    let corner = corner_for_placement(contour, placement);
+    let mut best_progress = 0.0;
+    let mut best_distance = signed_line_distance(
+        line_start,
+        line_end,
+        corner_point(placement, contour.rect, corner, 0.0),
+    )
+    .abs();
+    let mut previous_progress = 0.0;
+    let mut previous_distance = signed_line_distance(
+        line_start,
+        line_end,
+        corner_point(placement, contour.rect, corner, previous_progress),
+    );
+
+    if previous_distance.abs() <= line_epsilon {
+        return previous_progress;
+    }
+
+    for i in 1..=SAMPLES {
+        let progress = i as f64 / SAMPLES as f64;
+        let point = corner_point(placement, contour.rect, corner, progress);
+        let distance = signed_line_distance(line_start, line_end, point);
+
+        if distance.abs() < best_distance {
+            best_distance = distance.abs();
+            best_progress = progress;
+        }
+
+        if distance.abs() <= line_epsilon {
+            return progress;
+        }
+
+        if previous_distance.is_sign_positive() != distance.is_sign_positive() {
+            let mut low = previous_progress;
+            let mut high = progress;
+            let mut low_distance = previous_distance;
+
+            for _ in 0..BISECT_STEPS {
+                let middle = (low + high) * 0.5;
+                let middle_distance = signed_line_distance(
+                    line_start,
+                    line_end,
+                    corner_point(placement, contour.rect, corner, middle),
+                );
+
+                if middle_distance.abs() <= line_epsilon {
+                    return middle;
+                }
+
+                if low_distance.is_sign_positive() == middle_distance.is_sign_positive() {
+                    low = middle;
+                    low_distance = middle_distance;
+                } else {
+                    high = middle;
+                }
+            }
+
+            return (low + high) * 0.5;
+        }
+
+        previous_progress = progress;
+        previous_distance = distance;
+    }
+
+    best_progress
+}
+
+fn corner_for_placement(contour: BoxContour, placement: CornerPlacement) -> ResolvedCorner {
+    match placement {
+        CornerPlacement::TopRight => contour.corners.top_right,
+        CornerPlacement::BottomRight => contour.corners.bottom_right,
+        CornerPlacement::BottomLeft => contour.corners.bottom_left,
+        CornerPlacement::TopLeft => contour.corners.top_left,
+    }
+}
+
+fn rect_corner(placement: CornerPlacement, rect: Rect) -> Point {
+    match placement {
+        CornerPlacement::TopRight => Point::new(rect.x1, rect.y0),
+        CornerPlacement::BottomRight => Point::new(rect.x1, rect.y1),
+        CornerPlacement::BottomLeft => Point::new(rect.x0, rect.y1),
+        CornerPlacement::TopLeft => Point::new(rect.x0, rect.y0),
+    }
+}
+
+fn signed_line_distance(start: Point, end: Point, point: Point) -> f64 {
+    let line_x = end.x - start.x;
+    let line_y = end.y - start.y;
+    let point_x = point.x - start.x;
+    let point_y = point.y - start.y;
+    line_x * point_y - line_y * point_x
+}
+
 #[derive(Clone, Copy, Debug)]
 enum CornerPlacement {
     TopRight,
@@ -97,6 +533,129 @@ fn append_corner(
     }
 }
 
+fn append_corner_range(
+    path: &mut BezPath,
+    placement: CornerPlacement,
+    rect: Rect,
+    corner: ResolvedCorner,
+    start: f64,
+    end: f64,
+) {
+    let start = positive_unit(start);
+    let end = positive_unit(end);
+    if distance(start, end) <= f64::EPSILON {
+        return;
+    }
+
+    if corner.radii.width <= 0.0 || corner.radii.height <= 0.0 {
+        path.line_to(corner_point(placement, rect, corner, end));
+        return;
+    }
+
+    match corner.shape {
+        CornerShape::Round => {
+            let cubic = round_corner_cubic(placement, rect, corner.radii);
+            append_cubic_range(path, cubic, start, end);
+        }
+        CornerShape::Superellipse(superellipse)
+            if distance(superellipse.parameter(), 1.0) <= 1e-9 =>
+        {
+            let cubic = round_corner_cubic(placement, rect, corner.radii);
+            append_cubic_range(path, cubic, start, end);
+        }
+        _ => append_sampled_corner_range(path, placement, rect, corner, start, end),
+    }
+}
+
+fn append_cubic_range(path: &mut BezPath, cubic: CubicBez, start: f64, end: f64) {
+    if start < end {
+        let segment = cubic.subsegment(start..end);
+        path.curve_to(segment.p1, segment.p2, segment.p3);
+    } else {
+        let segment = cubic.subsegment(end..start);
+        path.curve_to(segment.p2, segment.p1, segment.p0);
+    }
+}
+
+fn append_sampled_corner_range(
+    path: &mut BezPath,
+    placement: CornerPlacement,
+    rect: Rect,
+    corner: ResolvedCorner,
+    start: f64,
+    end: f64,
+) {
+    for i in 1..=SUPERELLIPSE_SEGMENTS {
+        let progress = start + (end - start) * (i as f64 / SUPERELLIPSE_SEGMENTS as f64);
+        path.line_to(corner_point(placement, rect, corner, progress));
+    }
+}
+
+fn corner_point(
+    placement: CornerPlacement,
+    rect: Rect,
+    corner: ResolvedCorner,
+    progress: f64,
+) -> Point {
+    let progress = positive_unit(progress);
+    let radii = corner.radii;
+    if radii.width <= 0.0 || radii.height <= 0.0 {
+        return corner_end(placement, rect, radii);
+    }
+
+    match corner.shape {
+        CornerShape::Round => round_corner_cubic(placement, rect, radii).eval(progress),
+        CornerShape::Square => piecewise_corner_point(
+            corner_start(placement, rect, radii),
+            square_corner_point(placement, rect),
+            corner_end(placement, rect, radii),
+            progress,
+        ),
+        CornerShape::Bevel => lerp_point(
+            corner_start(placement, rect, radii),
+            corner_end(placement, rect, radii),
+            progress,
+        ),
+        CornerShape::Superellipse(superellipse) => {
+            let parameter = superellipse.parameter();
+            if distance(parameter, 1.0) <= 1e-9 {
+                round_corner_cubic(placement, rect, radii).eval(progress)
+            } else if distance(parameter, 0.0) <= 1e-9 {
+                lerp_point(
+                    corner_start(placement, rect, radii),
+                    corner_end(placement, rect, radii),
+                    progress,
+                )
+            } else if parameter >= SUPERELLIPSE_LIMIT || parameter == f64::INFINITY {
+                piecewise_corner_point(
+                    corner_start(placement, rect, radii),
+                    square_corner_point(placement, rect),
+                    corner_end(placement, rect, radii),
+                    progress,
+                )
+            } else if parameter <= -SUPERELLIPSE_LIMIT || parameter == f64::NEG_INFINITY {
+                piecewise_corner_point(
+                    corner_start(placement, rect, radii),
+                    notch_corner_point(placement, rect, radii),
+                    corner_end(placement, rect, radii),
+                    progress,
+                )
+            } else {
+                let exponent = powf(2.0, parameter);
+                if !exponent.is_finite() || exponent <= 0.0 {
+                    return lerp_point(
+                        corner_start(placement, rect, radii),
+                        corner_end(placement, rect, radii),
+                        progress,
+                    );
+                }
+                let (u, v) = superellipse_point(placement, progress, exponent);
+                point_in_corner(rect, placement, radii, u, v)
+            }
+        }
+    }
+}
+
 fn append_round_corner(
     path: &mut BezPath,
     placement: CornerPlacement,
@@ -104,34 +663,12 @@ fn append_round_corner(
     radii: Size,
     end: Point,
 ) {
-    let (control1, control2) = match placement {
-        CornerPlacement::TopRight => (
-            Point::new(rect.x1 - radii.width + ARC_KAPPA * radii.width, rect.y0),
-            Point::new(rect.x1, rect.y0 + radii.height - ARC_KAPPA * radii.height),
-        ),
-        CornerPlacement::BottomRight => (
-            Point::new(rect.x1, rect.y1 - radii.height + ARC_KAPPA * radii.height),
-            Point::new(rect.x1 - radii.width + ARC_KAPPA * radii.width, rect.y1),
-        ),
-        CornerPlacement::BottomLeft => (
-            Point::new(rect.x0 + radii.width - ARC_KAPPA * radii.width, rect.y1),
-            Point::new(rect.x0, rect.y1 - radii.height + ARC_KAPPA * radii.height),
-        ),
-        CornerPlacement::TopLeft => (
-            Point::new(rect.x0, rect.y0 + radii.height - ARC_KAPPA * radii.height),
-            Point::new(rect.x0 + radii.width - ARC_KAPPA * radii.width, rect.y0),
-        ),
-    };
-    path.curve_to(control1, control2, end);
+    let cubic = round_corner_cubic(placement, rect, radii);
+    path.curve_to(cubic.p1, cubic.p2, end);
 }
 
 fn append_square_corner(path: &mut BezPath, placement: CornerPlacement, rect: Rect, end: Point) {
-    path.line_to(match placement {
-        CornerPlacement::TopRight => Point::new(rect.x1, rect.y0),
-        CornerPlacement::BottomRight => Point::new(rect.x1, rect.y1),
-        CornerPlacement::BottomLeft => Point::new(rect.x0, rect.y1),
-        CornerPlacement::TopLeft => Point::new(rect.x0, rect.y0),
-    });
+    path.line_to(square_corner_point(placement, rect));
     path.line_to(end);
 }
 
@@ -142,12 +679,7 @@ fn append_notch_corner(
     radii: Size,
     end: Point,
 ) {
-    path.line_to(match placement {
-        CornerPlacement::TopRight => Point::new(rect.x1 - radii.width, rect.y0 + radii.height),
-        CornerPlacement::BottomRight => Point::new(rect.x1 - radii.width, rect.y1 - radii.height),
-        CornerPlacement::BottomLeft => Point::new(rect.x0 + radii.width, rect.y1 - radii.height),
-        CornerPlacement::TopLeft => Point::new(rect.x0 + radii.width, rect.y0 + radii.height),
-    });
+    path.line_to(notch_corner_point(placement, rect, radii));
     path.line_to(end);
 }
 
@@ -222,6 +754,81 @@ fn point_in_corner(rect: Rect, placement: CornerPlacement, radii: Size, u: f64, 
         CornerPlacement::TopLeft => (rect.x0, rect.y0),
     };
     Point::new(x0 + radii.width * u, y0 + radii.height * v)
+}
+
+fn round_corner_cubic(placement: CornerPlacement, rect: Rect, radii: Size) -> CubicBez {
+    let start = corner_start(placement, rect, radii);
+    let end = corner_end(placement, rect, radii);
+    let (control1, control2) = match placement {
+        CornerPlacement::TopRight => (
+            Point::new(rect.x1 - radii.width + ARC_KAPPA * radii.width, rect.y0),
+            Point::new(rect.x1, rect.y0 + radii.height - ARC_KAPPA * radii.height),
+        ),
+        CornerPlacement::BottomRight => (
+            Point::new(rect.x1, rect.y1 - radii.height + ARC_KAPPA * radii.height),
+            Point::new(rect.x1 - radii.width + ARC_KAPPA * radii.width, rect.y1),
+        ),
+        CornerPlacement::BottomLeft => (
+            Point::new(rect.x0 + radii.width - ARC_KAPPA * radii.width, rect.y1),
+            Point::new(rect.x0, rect.y1 - radii.height + ARC_KAPPA * radii.height),
+        ),
+        CornerPlacement::TopLeft => (
+            Point::new(rect.x0, rect.y0 + radii.height - ARC_KAPPA * radii.height),
+            Point::new(rect.x0 + radii.width - ARC_KAPPA * radii.width, rect.y0),
+        ),
+    };
+    CubicBez::new(start, control1, control2, end)
+}
+
+fn corner_start(placement: CornerPlacement, rect: Rect, radii: Size) -> Point {
+    match placement {
+        CornerPlacement::TopRight => Point::new(rect.x1 - radii.width, rect.y0),
+        CornerPlacement::BottomRight => Point::new(rect.x1, rect.y1 - radii.height),
+        CornerPlacement::BottomLeft => Point::new(rect.x0 + radii.width, rect.y1),
+        CornerPlacement::TopLeft => Point::new(rect.x0, rect.y0 + radii.height),
+    }
+}
+
+fn corner_end(placement: CornerPlacement, rect: Rect, radii: Size) -> Point {
+    match placement {
+        CornerPlacement::TopRight => Point::new(rect.x1, rect.y0 + radii.height),
+        CornerPlacement::BottomRight => Point::new(rect.x1 - radii.width, rect.y1),
+        CornerPlacement::BottomLeft => Point::new(rect.x0, rect.y1 - radii.height),
+        CornerPlacement::TopLeft => Point::new(rect.x0 + radii.width, rect.y0),
+    }
+}
+
+fn square_corner_point(placement: CornerPlacement, rect: Rect) -> Point {
+    match placement {
+        CornerPlacement::TopRight => Point::new(rect.x1, rect.y0),
+        CornerPlacement::BottomRight => Point::new(rect.x1, rect.y1),
+        CornerPlacement::BottomLeft => Point::new(rect.x0, rect.y1),
+        CornerPlacement::TopLeft => Point::new(rect.x0, rect.y0),
+    }
+}
+
+fn notch_corner_point(placement: CornerPlacement, rect: Rect, radii: Size) -> Point {
+    match placement {
+        CornerPlacement::TopRight => Point::new(rect.x1 - radii.width, rect.y0 + radii.height),
+        CornerPlacement::BottomRight => Point::new(rect.x1 - radii.width, rect.y1 - radii.height),
+        CornerPlacement::BottomLeft => Point::new(rect.x0 + radii.width, rect.y1 - radii.height),
+        CornerPlacement::TopLeft => Point::new(rect.x0 + radii.width, rect.y0 + radii.height),
+    }
+}
+
+fn piecewise_corner_point(start: Point, middle: Point, end: Point, progress: f64) -> Point {
+    if progress <= 0.5 {
+        lerp_point(start, middle, progress * 2.0)
+    } else {
+        lerp_point(middle, end, (progress - 0.5) * 2.0)
+    }
+}
+
+fn lerp_point(start: Point, end: Point, progress: f64) -> Point {
+    Point::new(
+        start.x + (end.x - start.x) * progress,
+        start.y + (end.y - start.y) * progress,
+    )
 }
 
 fn positive_unit(value: f64) -> f64 {

--- a/understory_box_decoration/src/style.rs
+++ b/understory_box_decoration/src/style.rs
@@ -4,10 +4,10 @@
 /// Resolved CSS `border-style` value for one physical border side.
 ///
 /// Stored in [`BoxDecorationGeometry`](crate::BoxDecorationGeometry) and
-/// [`BorderSideGeometry`](crate::BorderSideGeometry) so renderers can choose
-/// side-specific border lowering. This crate records the value and exposes the
-/// associated geometry; it does not implement dashed, dotted, double, groove,
-/// ridge, inset, or outset painting.
+/// exposed through [`BorderSidePaintGeometry`](crate::BorderSidePaintGeometry)
+/// so renderers can inspect side-specific border lowering. This crate records
+/// the value and uses it to produce renderer-neutral border paint commands;
+/// brush selection and backend draw calls remain renderer-owned.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum BorderStyle {
     /// No border is drawn for this side.

--- a/understory_presentation/src/lib.rs
+++ b/understory_presentation/src/lib.rs
@@ -148,6 +148,10 @@ pub use primitive::{
 };
 pub use store::{PresentationNode, PresentationStore};
 pub use understory_box_decoration::{
-    BorderSideGeometry, BorderStyle, BoxArea, BoxContour, BoxDecorationGeometry, ContourSideSpan,
-    CornerRadii, CornerShape, CornerShapes, Corners, Edges, ResolvedCorner, Side, Superellipse,
+    BorderBand, BorderClip, BorderClipStack, BorderDashPattern, BorderFillFragment, BorderFillRule,
+    BorderPaintCommand, BorderPaintFill, BorderPaintGeometry, BorderPaintMode, BorderPaintPlan,
+    BorderPaintRole, BorderPaintSource, BorderPaintStroke, BorderReliefShade,
+    BorderSidePaintGeometry, BorderStrokeCap, BorderStrokeFragment, BorderStrokeSpec, BorderStyle,
+    BoxArea, BoxContour, BoxDecorationGeometry, ContourSideSpan, CornerRadii, CornerShape,
+    CornerShapes, Corners, Edges, ResolvedCorner, Side, Superellipse,
 };


### PR DESCRIPTION
Replace the central `BorderSideGeometry` model with renderer-neutral border paint planning. `BoxDecorationGeometry::border_paint` now exposes whole-ring, band, side-owned fill, and stroke fragments that preserve shaped corner contours.

Add command planning for solid, dashed, dotted, double, groove, ridge, inset, and outset borders while keeping brushes and renderer command emission outside `understory_box_decoration`.

Balance dash patterns for closed shared contours and open side contours, add side-owned band paths with corner miter boundaries, and re-export the new paint plan types through `understory_presentation`.